### PR TITLE
feat: config loader with multi-source API key resolution

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ The detailed background behind this methodology — the framework evaluation,
 the design decisions, and the evidence for every feature — is discussed in a
 pair of articles:
 
-- [The Truth is Out There. But How Do You Find It?](https://the-infrastructure-mindset.ghost.io/the-truth-is-out-there/) — the what and the why (Part 1)
-- [The Truth is Out There. Now Go Find It.](https://the-infrastructure-mindset.ghost.io/the-truth-is-out-there-now-go-find-it/) — the how and how to get it (Part 2)
+- [The Truth is Out There. But How Do You Find It?][part1]
+  — the what and the why (Part 1)
+- [The Truth is Out There. Now Go Find It.][part2]
+  — the how and how to get it (Part 2)
+
+[part1]: https://the-infrastructure-mindset.ghost.io/the-truth-is-out-there/
+[part2]: https://the-infrastructure-mindset.ghost.io/the-truth-is-out-there-now-go-find-it/
 
 ## Three Input Types
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ diogenes = "diogenes.cli:main"
 dev = [
     "ruff",
     "mypy",
+    "types-jsonschema",
     "pytest",
     "pytest-cov",
     "pip-audit",

--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -53,7 +53,9 @@ class APIClient:
         try:
             cfg = config if config is not None else load_config()
         except ConfigError as e:
-            raise SubAgentError("config", str(e)) from e
+            agent_name = "config"
+            msg = str(e)
+            raise SubAgentError(agent_name, msg) from e
 
         self._client = anthropic.Anthropic(api_key=cfg.api_key, base_url=cfg.base_url)
         self._model = model or cfg.model or self.DEFAULT_MODEL

--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import json
-import os
 from pathlib import Path
 from typing import Any
 
 import anthropic
+
+from diogenes.config import ConfigError, DioConfig, load_config
 
 
 class SubAgentError(Exception):
@@ -33,24 +34,29 @@ class APIClient:
     def __init__(
         self,
         *,
+        config: DioConfig | None = None,
         model: str | None = None,
         max_tokens: int | None = None,
     ) -> None:
         """Initialize the API client.
 
         Args:
-            model: Anthropic model ID. Defaults to Claude Sonnet.
+            config: Pre-loaded configuration. If omitted, loads from all config sources
+                (environment variable, .dorc files, .env file).
+            model: Anthropic model ID. Overrides the value in config.
             max_tokens: Maximum response tokens. Defaults to 8192.
 
-        """
-        api_key = os.environ.get("ANTHROPIC_API_KEY")
-        if not api_key:
-            msg = "ANTHROPIC_API_KEY environment variable is required"
-            agent_name = "api_client"
-            raise SubAgentError(agent_name, msg)
+        Raises:
+            SubAgentError: If configuration cannot be loaded (e.g., no API key found).
 
-        self._client = anthropic.Anthropic(api_key=api_key)
-        self._model = model or self.DEFAULT_MODEL
+        """
+        try:
+            cfg = config if config is not None else load_config()
+        except ConfigError as e:
+            raise SubAgentError("config", str(e)) from e
+
+        self._client = anthropic.Anthropic(api_key=cfg.api_key, base_url=cfg.base_url)
+        self._model = model or cfg.model or self.DEFAULT_MODEL
         self._max_tokens = max_tokens or self.DEFAULT_MAX_TOKENS
 
     def call_sub_agent(

--- a/src/diogenes/config.py
+++ b/src/diogenes/config.py
@@ -1,0 +1,122 @@
+"""Diogenes configuration loading."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tomllib
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+DEFAULT_BASE_URL = "https://api.anthropic.com"
+DEFAULT_MODEL = "claude-sonnet-4-20250514"
+
+
+class ConfigError(Exception):
+    """Raised when Diogenes configuration cannot be resolved."""
+
+
+@dataclass
+class DioConfig:
+    """Resolved Diogenes runtime configuration."""
+
+    api_key: str
+    base_url: str = DEFAULT_BASE_URL
+    model: str = DEFAULT_MODEL
+
+
+def _parse_dotenv(path: Path) -> dict[str, str]:
+    """Parse a .env file and return key-value pairs.
+
+    Handles comments, empty lines, ``KEY=value``, ``KEY="value"``, and ``export KEY=value``.
+    """
+    result: dict[str, str] = {}
+    for raw in path.read_text().splitlines():
+        stripped = raw.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        line = stripped.removeprefix("export ").strip()
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        key = key.strip()
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+            value = value[1:-1]
+        result[key] = value
+    return result
+
+
+def _load_toml(path: Path) -> dict[str, Any]:
+    """Load a TOML file and return its contents, or an empty dict if not found."""
+    if not path.exists():
+        return {}
+    with path.open("rb") as fh:
+        return tomllib.load(fh)
+
+
+def _section(toml: dict[str, Any], key: str) -> dict[str, Any]:
+    """Extract a named section from a TOML dict, returning empty dict if absent or wrong type."""
+    value = toml.get(key, {})
+    return value if isinstance(value, dict) else {}
+
+
+def load_config() -> DioConfig:
+    """Load Diogenes configuration from all sources in priority order.
+
+    Priority (highest to lowest):
+
+    1. ``ANTHROPIC_API_KEY`` environment variable
+    2. ``api.key`` in ``./.dorc`` (project-level config, current directory)
+    3. ``api.key`` in ``~/.dorc`` (user-level config)
+    4. ``ANTHROPIC_API_KEY`` from ``.env`` file in the current directory (loaded with a warning)
+
+    Returns:
+        Resolved :class:`DioConfig` instance.
+
+    Raises:
+        ConfigError: If no API key can be resolved from any source.
+
+    """
+    user_toml = _load_toml(Path.home() / ".dorc")
+    project_toml = _load_toml(Path.cwd() / ".dorc")
+
+    # Merge: project-level overrides user-level, section by section
+    toml: dict[str, Any] = {**user_toml}
+    for k, v in project_toml.items():
+        if isinstance(v, dict) and isinstance(toml.get(k), dict):
+            toml[k] = {**toml[k], **v}
+        else:
+            toml[k] = v
+
+    api_sect = _section(toml, "api")
+    env_sect = _section(toml, "env")
+
+    base_url = str(api_sect.get("base_url", DEFAULT_BASE_URL))
+    model = str(api_sect.get("model", DEFAULT_MODEL))
+    load_dotenv = bool(env_sect.get("load_dotenv", True))
+
+    # Priority 1: environment variable
+    api_key: str = os.environ.get("ANTHROPIC_API_KEY", "")
+
+    # Priority 2 & 3: config file key (project or user .dorc)
+    if not api_key:
+        api_key = str(api_sect.get("key", ""))
+
+    # Priority 4: .env file, with an explicit warning so it is never silent
+    if not api_key and load_dotenv:
+        dotenv_name = str(env_sect.get("dotenv_path", ".env"))
+        dotenv_path = Path(dotenv_name)
+        if dotenv_path.exists():
+            sys.stderr.write(f"Warning: Loading API key from {dotenv_path.resolve()}\n")
+            api_key = _parse_dotenv(dotenv_path).get("ANTHROPIC_API_KEY", "")
+
+    if not api_key:
+        msg = (
+            "No API key found. "
+            "Set ANTHROPIC_API_KEY, add api.key to .dorc, or create a .env file."
+        )
+        raise ConfigError(msg)
+
+    return DioConfig(api_key=api_key, base_url=base_url, model=model)

--- a/src/diogenes/config.py
+++ b/src/diogenes/config.py
@@ -42,7 +42,8 @@ def _parse_dotenv(path: Path) -> dict[str, str]:
         key, _, value = line.partition("=")
         key = key.strip()
         value = value.strip()
-        if len(value) >= 2 and value[0] == value[-1] and value[0] in ('"', "'"):
+        _min_quoted_len = 2
+        if len(value) >= _min_quoted_len and value[0] == value[-1] and value[0] in ('"', "'"):
             value = value[1:-1]
         result[key] = value
     return result

--- a/uv.lock
+++ b/uv.lock
@@ -298,6 +298,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-jsonschema" },
 ]
 
 [package.metadata]
@@ -316,6 +317,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "types-jsonschema" },
 ]
 
 [[package]]
@@ -1247,6 +1249,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/19/75/241269d1da26b624c0d5e110e8149093c759b7a286138f4efd61a60e75fe/tomli_w-1.2.0.tar.gz", hash = "sha256:2dd14fac5a47c27be9cd4c976af5a12d87fb1f0b4512f81d69cce3b35ae25021", size = 7184, upload-time = "2025-01-15T12:07:24.262Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c7/18/c86eb8e0202e32dd3df50d43d7ff9854f8e0603945ff398974c1d91ac1ef/tomli_w-1.2.0-py3-none-any.whl", hash = "sha256:188306098d013b691fcadc011abd66727d3c414c571bb01b1a174ba8c983cf90", size = 6675, upload-time = "2025-01-15T12:07:22.074Z" },
+]
+
+[[package]]
+name = "types-jsonschema"
+version = "4.26.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "referencing" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9f/4c/2ef5483ef81e7b6e1b901eb2994fd280cb19860134a20ff99e72748f3ccb/types_jsonschema-4.26.0.20260408.tar.gz", hash = "sha256:82b75a976ed1507c473b8dee2d4841bd65926758c6d672bb93d08bf5e16f1b3f", size = 16553, upload-time = "2026-04-08T04:36:00.543Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/3c/724ad6ecaea06e8c6c8a8c9949a0979e6a2149b8aec4fe160135c64dd5ac/types_jsonschema-4.26.0.20260408-py3-none-any.whl", hash = "sha256:1ab0058c2612b0b81fc4e3c88ec3f9ad9b0af3fd31a176030d78b6d6cefb6e7b", size = 16081, upload-time = "2026-04-08T04:35:59.678Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `src/diogenes/config.py` with `DioConfig` dataclass and `load_config()` function
- API key resolved in priority order: env var → project `.dorc` → user `~/.dorc` → `.env` file (with stderr warning)
- Supports `base_url` for future local LLM routing and `model` override via config
- Refactors `APIClient.__init__` to use `load_config()` internally — callers never responsible for key injection

## Test plan

- [ ] Verify `dio run` resolves API key from `.env` file in project root
- [ ] Verify `.dorc` TOML config is parsed correctly for `api.key`, `api.base_url`, `api.model`
- [ ] Verify `ConfigError` raised when no API key found in any source
- [ ] End-to-end: `dio run` with text input through input-clarifier sub-agent

Closes #61 (partial — config loader component)

🤖 Generated with [Claude Code](https://claude.com/claude-code)