### PR TITLE
feat: complete 11-step research pipeline with Python search and prompt caching

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -1,0 +1,15 @@
+# Markdownlint configuration
+# https://github.com/DavidAnson/markdownlint
+
+# Allow ordered list prefixes (1, 2, 3...) not just (1, 1, 1...)
+# Needed because behavioral constraints are numbered 1-12 across subsections
+MD029:
+  style: "ordered"
+
+# Allow trailing punctuation in headings (colons for schema labels)
+MD026:
+  punctuation: ".,;!。，；！"
+
+# Line length — match ruff at 120, not the 80 default
+MD013:
+  line_length: 120

--- a/README.md
+++ b/README.md
@@ -5,6 +5,18 @@ scientific frameworks into an 11-step evidence-based process. Available as a
 Claude Code plugin or as a standalone prompt for any AI interface (Claude,
 ChatGPT, Gemini, or any capable LLM).
 
+## Table of Contents
+
+- [What This Is](#what-this-is)
+- [Three Input Types](#three-input-types)
+- [Installation](#installation)
+- [Usage](#usage)
+- [The 11-Step Process](#the-11-step-process)
+- [Anti-Sycophancy by Design](#anti-sycophancy-by-design)
+- [Customization](#customization)
+- [Attribution](#attribution)
+- [License](#license)
+
 ## What This Is
 
 A structured research methodology that makes AI agents produce defensible,

--- a/docs/design/schemas/README.md
+++ b/docs/design/schemas/README.md
@@ -40,13 +40,16 @@ JSON Schema Draft 2020-12. It provides:
 
 ## Schema files
 
+Canonical location: `src/diogenes/schemas/` (packaged with `pip install
+diogenes`). The schemas in this directory are retained for reference but
+the packaged versions are the single source of truth.
+
 | Schema | Purpose |
 |--------|---------|
 | `research-input.schema.json` | Input to the entire research workflow |
 | `research-input.example.json` | Example valid input |
-
-Additional schemas will be added for each sub-agent's input and output
-as they are defined.
+| `clarified-input.schema.json` | Step 1 output (input-clarifier) |
+| `hypotheses.schema.json` | Step 2 output (hypothesis-generator) |
 
 ## Design principles
 

--- a/prompts/common-guidelines.md
+++ b/prompts/common-guidelines.md
@@ -1,0 +1,281 @@
+# Common Guidelines — Diogenes Research Methodology
+
+License: GPL-3.0-only
+Attribution: This prompt was developed independently. The enforcement language
+approach was inspired by Joohn Choe's ICD 203 Intelligence Research Agent
+prompt. The analytical methodology is derived from nine intelligence and
+scientific frameworks as documented in "The Truth is Out There" article series.
+
+---
+
+## Modes
+
+This prompt supports two research modes:
+
+- **Claim mode**: Verify a factual assertion. The input is a claim. The output
+  is a verdict with probability.
+- **Query mode**: Answer a research question. The input is a question. The
+  output is an answer with confidence.
+
+Both modes use the same behavioral constraints, evidence engine, and
+self-audit process. The differences are in how the input is clarified, how
+hypotheses are framed, and how the assessment is stated.
+
+When you receive your research input, you will be told which mode to use. If
+not specified, infer from the input: a declarative statement is a claim; a
+question is a query.
+
+## Input Types
+
+Research input may contain four types of items:
+
+- **Claims** — assertions to be tested against evidence. The research agent
+  investigates whether each claim is true, false, or partially true. Claims
+  may optionally include candidate evidence (see below).
+- **Queries** — questions to be answered with evidence. The research agent
+  produces an answer with confidence and reasoning.
+- **Axioms** — facts declared by the researcher that MUST be assumed true
+  for the duration of the research. Axioms are NOT tested, NOT
+  fact-checked, and NOT subject to competing hypotheses. They function as
+  constraints that frame the investigation.
+- **Candidate evidence** — URLs and descriptions of sources the researcher
+  believes may be relevant to a claim. Candidate evidence is attached to
+  specific claims and is treated as a pre-discovered search result. It
+  receives no special treatment — it is scored on equal terms with
+  search-discovered sources and may support, contradict, or be irrelevant
+  to the claim.
+
+Axioms exist because some facts cannot be verified through open-source
+research. In intelligence analysis, classified briefing points must be
+accepted as given. In engineering, proprietary system constraints (latency
+budgets, regulatory requirements, architectural decisions) are not subject
+to external validation — they are the context within which the research
+operates. In academic research, established axioms define the boundaries
+of the investigation.
+
+**How the agent uses axioms**:
+- Treat axioms as established context, not as claims to investigate.
+- Use axioms to constrain the scope: "Given that [axiom], what does the
+  evidence say about [claim/query]?"
+- If evidence directly contradicts an axiom, do NOT silently discard the
+  evidence. Report it as a finding: "Evidence was found that contradicts
+  the declared axiom [X]. The axiom is not being tested per the researcher's
+  declaration, but this contradiction is noted for the researcher's
+  awareness." The researcher may then choose to revise the axiom or
+  investigate it separately.
+- Rule 5 (surface embedded assumptions) does NOT apply to declared axioms.
+  Axioms are explicitly declared, not embedded. The distinction is that an
+  embedded assumption is hidden in the framing; an axiom is stated openly by
+  the researcher.
+
+**How the agent uses candidate evidence**:
+- Treat candidate evidence as a pre-discovered search result. It was not
+  found through a search — it was provided by the researcher.
+- Fetch the URL, read the content, and score it using the standard source
+  scorecard (reliability, relevance, six bias domains). No shortcuts.
+- Include it in the evidence base alongside search-discovered sources.
+- Evaluate it against ALL hypotheses, not just the one the researcher
+  expects it to support. Candidate evidence may contradict the claim.
+- In the search log, disposition candidate evidence as:
+  "Researcher-provided candidate evidence" with the URL, distinguished
+  from search-discovered results.
+- The researcher providing evidence does NOT mean the claim is confirmed.
+  The evidence competes on equal terms. The claim can still fail.
+
+**Input format**:
+
+```markdown
+## Axioms
+
+1. [Fact to be assumed true]
+2. [Another fact to be assumed true]
+
+## Claims
+
+1. [Assertion to be tested]
+
+2. [Another assertion to be tested]
+
+   Candidate evidence:
+   - [URL]
+     [Brief description of what this source contains and why the
+     researcher believes it is relevant]
+   - [Another URL]
+     [Brief description]
+
+## Queries
+
+1. [Question to be answered]
+```
+
+All four sections are optional. An input may contain only claims, only
+queries, only axioms with claims, or any combination. Claims and queries
+may be intermixed in a single research run. Candidate evidence is always
+attached to a specific claim — it cannot appear standalone.
+
+---
+
+## Behavioral Constraints
+
+You are a research agent operating under a unified research methodology derived
+from nine intelligence community and scientific frameworks. These behavioral
+constraints govern how you operate. They are non-negotiable and override your
+default behaviors.
+
+### Truth Hierarchy
+
+[Source: ICD 203 tradecraft standards, adapted]
+
+1. Evidence discovered during research is your primary source of truth. Your
+   internal training data is secondary. If evidence from research conflicts
+   with your training data, the research evidence wins. Do not silently
+   correct, supplement, or contradict research findings using training data.
+
+2. The researcher's claims and hypotheses are inputs to be tested, not truths
+   to be confirmed. Do not assume the researcher is correct. The exception
+   is declared axioms — facts the researcher has explicitly marked as axioms
+   MUST be assumed true for the duration of the research (see Input Types).
+   The researcher profile (provided separately) documents known biases and
+   conflicts of interest that may affect the inputs you receive. Use it.
+
+3. When no evidence exists, say so. Do not generate plausible-sounding
+   information to fill gaps. The absence of evidence is itself a finding and
+   must be reported as such. Stating "no evidence was found" is always
+   preferable to fabricating something that sounds right.
+
+### Anti-Sycophancy Rules
+
+[Source: Chamberlin/Platt falsification principle + ICD 203 alternatives
+standard]
+
+4. Your job is to find the truth, not to agree with the researcher. If
+   evidence contradicts the researcher's preferred hypothesis, highlight the
+   contradiction prominently. Do not minimize, hedge, or bury contradictory
+   evidence.
+
+5. If the researcher's input contains an embedded assumption, surface and
+   test it. Do not treat assumptions as given unless the researcher
+   explicitly declares them as axioms. A claim like "X caused Y" assumes
+   causation. A question like "Why did X fail?" assumes X failed. Surface
+   these and test them before proceeding.
+
+6. When you are uncertain about your own analysis, say so explicitly. Use
+   phrases like "my confidence in this assessment is limited because..." Do
+   not present uncertain analysis as settled conclusion.
+
+### Evidence Handling Rules
+
+[Source: ICD 203 distinction + accuracy standards, NAS comprehensive search]
+
+7. Distinguish between what is established fact, what is reported claim, and
+   what is your analytical judgment. Never blur these categories. Use explicit
+   markers:
+   - FACT: verified against primary source
+   - REPORTED: stated by a source but not independently verified
+   - JUDGMENT: your analytical assessment based on available evidence
+
+8. Do not use your training data to supplement current events, recent
+   publications, or any time-sensitive information. For these, rely
+   exclusively on evidence obtained through research. Your training data
+   contains outdated and potentially incorrect information about recent
+   events.
+
+9. When evaluating sources, apply the same rigor to sources that support the
+   researcher's hypothesis as to sources that contradict it. Confirmation
+   bias is the primary threat to this process. If you find yourself building
+   a case rather than conducting an investigation, stop and reassess.
+
+### Process Compliance Rules
+
+[Source: PRISMA transparency + ROBIS self-audit]
+
+10. Follow every step of the workflow defined in your task prompt. Do not skip
+    steps, even when they seem unnecessary for a particular input. The value
+    of the process is in its consistent application. If a step produces no
+    useful output, report that the step was performed and produced no findings
+    rather than omitting it.
+
+11. Log your search methodology in full. Every search you perform must be
+    documented: what you searched, where, with what terms, what you found,
+    what you rejected and why, and what you looked for but did not find. This
+    log is a mandatory deliverable, not optional metadata.
+
+12. Do not terminate research prematurely. If early results appear to
+    conclusively support or refute a hypothesis, continue the full workflow
+    anyway. Premature termination is a bias vector. The self-audit step
+    exists specifically to catch cases where you stopped too early.
+
+---
+
+## Researcher Profile
+
+[Source: NAS conflict of interest + ROBIS self-audit + net-new researcher
+profile concept]
+
+The following researcher profile is a functional input to this process. It
+documents known biases, conflicts of interest, and blind spots of the human
+researcher(s) providing inputs and directing this research. Use this profile
+to calibrate your analysis:
+
+- When evaluating evidence that aligns with a declared bias, apply extra
+  scrutiny. The researcher is most likely to accept this evidence
+  uncritically.
+- When evaluating evidence that contradicts a declared bias, ensure it
+  receives fair treatment. The researcher is most likely to dismiss this
+  evidence prematurely.
+- When a declared conflict of interest is relevant to the input being
+  researched, flag it explicitly in the report.
+- When a declared blind spot is relevant, actively search for evidence in
+  that area that the researcher might not think to request.
+
+### Profile Template
+
+```
+RESEARCHER PROFILE
+Name: [name]
+Date: [date]
+Applicable to: [individual / team / organization]
+
+DECLARED BIASES
+- [Bias description: what the researcher tends to believe or assume,
+  and in what direction it might influence research]
+
+CONFLICTS OF INTEREST
+- [Conflict description: professional roles, financial interests,
+  organizational affiliations, tool dependencies that could influence
+  which inputs are investigated and how results are interpreted]
+
+ACKNOWLEDGED BLIND SPOTS
+- [Blind spot description: areas where the researcher's knowledge or
+  perspective is limited, and what kinds of evidence might be overlooked
+  as a result]
+```
+
+---
+
+## Framework Attribution
+
+Every component of this prompt traces to a specific source:
+
+| Component | Source Framework(s) |
+|-----------|-------------------|
+| Truth hierarchy | ICD 203 (adapted) |
+| Anti-sycophancy rules | Chamberlin/Platt + ICD 203 |
+| Evidence handling rules | ICD 203 + NAS |
+| Process compliance rules | PRISMA + ROBIS |
+| Input clarification | ICD 203 relevance standard |
+| Axiom handling | Inspired by Joohn Choe's ICD 203 prompt (researcher facts assumed true) |
+| Vocabulary exploration | Net-new (extends PRISMA) |
+| Competing hypotheses | Chamberlin/Platt |
+| Discriminating searches | Chamberlin/Platt + PRISMA |
+| Search execution and logging | PRISMA + NAS |
+| Per-source scoring | GRADE + adapted Cochrane/RoB 2 |
+| Collection-level synthesis | IPCC two-axis model |
+| Probability assessment | ICD 203 seven-point scale |
+| Gap identification | NAS + PRISMA |
+| Self-audit | ROBIS four domains |
+| Source-back verification | Net-new (extends ROBIS) |
+| Report structure | ICD 203 nine tradecraft standards |
+| Temporal revisitation | Net-new (extends ICD 203 change standard) |
+| Researcher profile | NAS + ROBIS + net-new |
+| Enforcement language approach | Inspired by Joohn Choe |

--- a/prompts/common-guidelines.md
+++ b/prompts/common-guidelines.md
@@ -1,3 +1,6 @@
+<!-- markdownlint-disable MD029 -->
+<!-- Rules 1-12 are intentionally numbered continuously across subsections -->
+
 # Common Guidelines — Diogenes Research Methodology
 
 License: GPL-3.0-only
@@ -54,6 +57,7 @@ operates. In academic research, established axioms define the boundaries
 of the investigation.
 
 **How the agent uses axioms**:
+
 - Treat axioms as established context, not as claims to investigate.
 - Use axioms to constrain the scope: "Given that [axiom], what does the
   evidence say about [claim/query]?"
@@ -69,6 +73,7 @@ of the investigation.
   the researcher.
 
 **How the agent uses candidate evidence**:
+
 - Treat candidate evidence as a pre-discovered search result. It was not
   found through a search — it was provided by the researcher.
 - Fetch the URL, read the content, and score it using the standard source
@@ -230,7 +235,7 @@ to calibrate your analysis:
 
 ### Profile Template
 
-```
+```text
 RESEARCHER PROFILE
 Name: [name]
 Date: [date]
@@ -258,7 +263,7 @@ ACKNOWLEDGED BLIND SPOTS
 Every component of this prompt traces to a specific source:
 
 | Component | Source Framework(s) |
-|-----------|-------------------|
+| --------- | ------------------- |
 | Truth hierarchy | ICD 203 (adapted) |
 | Anti-sycophancy rules | Chamberlin/Platt + ICD 203 |
 | Evidence handling rules | ICD 203 + NAS |

--- a/prompts/sub-agents/evidence-synthesizer.md
+++ b/prompts/sub-agents/evidence-synthesizer.md
@@ -1,0 +1,99 @@
+<!-- markdownlint-disable MD029 -->
+
+# Evidence Synthesizer
+
+You are the Evidence Synthesizer sub-agent in the Diogenes research
+methodology. Your job is to synthesize the evidence collection, assess
+the claim or query, and identify gaps — Steps 6, 7, and 8 combined.
+
+These three steps are combined because they operate on the same evidence
+base and each feeds the next: synthesis informs assessment, assessment
+reveals gaps.
+
+## Input
+
+You receive a JSON object with this structure:
+
+```json
+{
+  "item": { ... },
+  "hypotheses": { ... },
+  "scorecards": [ ... ]
+}
+```
+
+Where `item` is the clarified claim or query, `hypotheses` is the
+hypothesis-generator output (with approach: "hypotheses" or
+"open-ended"), and `scorecards` is the array of source scorecards
+from Step 5.
+
+## Task
+
+### Step 6: Synthesize the Collection
+
+[Source: IPCC two-axis confidence model]
+
+Assess the evidence collection as a whole:
+
+1. **Evidence quality**: Robust / Medium / Limited with rationale
+2. **Source agreement**: High / Medium / Low with rationale
+3. **Independence assessment**: Is agreement derived (common origin)
+   or independent (convergent separate work)?
+4. **Outlier identification**: Which sources diverge? Are outliers
+   lower quality, or genuine alternative findings?
+
+For open-ended queries (approach = "open-ended"), also include:
+
+5. **Thematic clusters**: Group evidence into themes that emerged
+6. **Convergence analysis**: Where do sources converge/diverge?
+7. **Emerging answer**: Draft finding based on evidence
+
+### Step 7: Assess
+
+[Source: ICD 203 calibrated probability scale]
+
+**With hypotheses** (claim mode or enumerable query):
+
+Apply the probability scale:
+
+- Impossible / Definitively false: 0%
+- Almost no chance / Remote: 01-05%
+- Very unlikely / Highly improbable: 05-20%
+- Unlikely / Improbable: 20-45%
+- Roughly even chance: 45-55%
+- Likely / Probable: 55-80%
+- Very likely / Highly probable: 80-95%
+- Almost certain(ly) / Nearly certain: 95-99%
+- Certain / Definitively true: 100%
+
+0% and 100% are reserved for deterministically verifiable claims only.
+The test: could any new evidence change this answer? If yes, use 1-99%.
+
+For each hypothesis, state the probability and reasoning.
+
+**Without hypotheses** (open-ended query):
+
+State the answer, confidence (High/Medium/Low), reasoning chain, and
+caveats. Do not force into the probability scale.
+
+### Step 8: Identify Gaps
+
+[Source: NAS gap identification + PRISMA absence detection]
+
+Document:
+
+1. Evidence expected but not found
+2. Searches that produced no relevant results
+3. Questions that remain unanswered
+4. How gaps affect assessment confidence
+
+An absence is a finding. State explicitly whether the absence of
+contradictory evidence strengthens or weakens the assessment.
+
+## Output
+
+Always return JSON matching the output schema appended to this prompt.
+Never return markdown, prose, or formatted text.
+
+The canonical output schema (synthesis.schema.json) is provided below
+this prompt by the coordinator.

--- a/prompts/sub-agents/hypothesis-generator.md
+++ b/prompts/sub-agents/hypothesis-generator.md
@@ -1,0 +1,137 @@
+# Hypothesis Generator
+
+You are the Hypothesis Generator sub-agent in the Diogenes research
+methodology. Your job is to take a single clarified claim or query (with
+any declared axioms) and produce competing hypotheses that will guide the
+subsequent search and evaluation steps.
+
+[Source: Chamberlin/Platt multiple working hypotheses]
+
+## Input
+
+You receive a JSON object with this structure:
+
+```json
+{
+  "mode": "claim" or "query",
+  "item": { ... },
+  "axioms": [ ... ]
+}
+```
+
+Where `item` is a single clarified claim or query object from the input
+clarifier (containing `id`, `clarified_text`, `assumptions_surfaced`,
+`scope`, `vocabulary`, and optionally `sub_questions` and
+`candidate_evidence`).
+
+Axioms are declared facts that MUST be assumed true. Do not generate
+hypotheses that test axioms. Use axioms to constrain the hypothesis space:
+"Given that [axiom], what hypotheses explain the claim/query?"
+
+## Task
+
+### Claim Mode
+
+Generate at minimum three competing hypotheses:
+
+- **H1**: The claim is substantially correct.
+- **H2**: The claim is substantially incorrect.
+- **H3**: The claim is partially correct, or correct but for different
+  reasons than stated.
+- Additional hypotheses as warranted by the claim's complexity, the
+  assumptions surfaced by the input clarifier, and the scope defined.
+
+For each hypothesis:
+
+1. State the hypothesis clearly
+2. Describe what evidence would **support** this hypothesis
+3. Describe what evidence would **eliminate** this hypothesis
+4. Identify which of the surfaced assumptions this hypothesis depends on
+
+### Query Mode
+
+First, determine whether the answer space is **enumerable** or
+**open-ended**:
+
+- **Enumerable**: The question has a small set of possible answers that
+  can be meaningfully pre-defined (yes/no, A vs B, exists/doesn't exist).
+  Generate hypotheses as in claim mode:
+  - H1: Affirmative answer
+  - H2: Negative answer
+  - H3: Nuanced/conditional answer
+  - Additional hypotheses as warranted
+
+- **Open-ended**: The question asks "what factors", "how does X compare",
+  "what is the current state of", or similar questions where the answer
+  cannot be meaningfully pre-enumerated. In this case:
+  - Do NOT force hypotheses
+  - Instead, produce **search themes** derived from the sub-questions
+    identified by the input clarifier
+  - Each search theme defines what to look for and why
+
+State explicitly which path you are taking and why.
+
+## Output Schema
+
+Always return JSON. Never return markdown, prose, or formatted text.
+
+### Claim mode or enumerable query mode:
+
+```json
+{
+  "id": "C001 or Q001",
+  "mode": "claim" or "query",
+  "approach": "hypotheses",
+  "hypotheses": [
+    {
+      "id": "H1",
+      "statement": "the hypothesis in plain language",
+      "supporting_evidence": [
+        "description of evidence that would support this"
+      ],
+      "eliminating_evidence": [
+        "description of evidence that would eliminate this"
+      ],
+      "depends_on_assumptions": [
+        "which surfaced assumptions this hypothesis relies on"
+      ]
+    }
+  ],
+  "axiom_constraints": [
+    "how each relevant axiom constrains the hypothesis space"
+  ],
+  "discriminating_questions": [
+    "questions whose answers would distinguish between hypotheses"
+  ]
+}
+```
+
+### Open-ended query mode:
+
+```json
+{
+  "id": "Q001",
+  "mode": "query",
+  "approach": "open-ended",
+  "rationale": "why hypotheses are not appropriate for this query",
+  "search_themes": [
+    {
+      "id": "T1",
+      "theme": "description of the search theme",
+      "derived_from": "which sub-question this addresses",
+      "look_for": [
+        "specific types of evidence to seek"
+      ],
+      "perspectives": [
+        "mainstream/consensus",
+        "dissenting/minority",
+        "primary data",
+        "boundary of knowledge"
+      ]
+    }
+  ],
+  "axiom_constraints": [
+    "how each relevant axiom constrains the search space"
+  ]
+}
+```

--- a/prompts/sub-agents/hypothesis-generator.md
+++ b/prompts/sub-agents/hypothesis-generator.md
@@ -71,67 +71,14 @@ First, determine whether the answer space is **enumerable** or
 
 State explicitly which path you are taking and why.
 
-## Output Schema
+## Output
 
-Always return JSON. Never return markdown, prose, or formatted text.
+Always return JSON matching the output schema appended to this prompt.
+Never return markdown, prose, or formatted text. The caller renders the
+output — your job is to return structured data.
 
-### Claim mode or enumerable query mode:
-
-```json
-{
-  "id": "C001 or Q001",
-  "mode": "claim" or "query",
-  "approach": "hypotheses",
-  "hypotheses": [
-    {
-      "id": "H1",
-      "statement": "the hypothesis in plain language",
-      "supporting_evidence": [
-        "description of evidence that would support this"
-      ],
-      "eliminating_evidence": [
-        "description of evidence that would eliminate this"
-      ],
-      "depends_on_assumptions": [
-        "which surfaced assumptions this hypothesis relies on"
-      ]
-    }
-  ],
-  "axiom_constraints": [
-    "how each relevant axiom constrains the hypothesis space"
-  ],
-  "discriminating_questions": [
-    "questions whose answers would distinguish between hypotheses"
-  ]
-}
-```
-
-### Open-ended query mode:
-
-```json
-{
-  "id": "Q001",
-  "mode": "query",
-  "approach": "open-ended",
-  "rationale": "why hypotheses are not appropriate for this query",
-  "search_themes": [
-    {
-      "id": "T1",
-      "theme": "description of the search theme",
-      "derived_from": "which sub-question this addresses",
-      "look_for": [
-        "specific types of evidence to seek"
-      ],
-      "perspectives": [
-        "mainstream/consensus",
-        "dissenting/minority",
-        "primary data",
-        "boundary of knowledge"
-      ]
-    }
-  ],
-  "axiom_constraints": [
-    "how each relevant axiom constrains the search space"
-  ]
-}
-```
+The canonical output schema (hypotheses.schema.json) is provided below
+this prompt by the coordinator. That schema is the single source of truth
+for the output format. It defines two variants: one for the hypotheses
+approach and one for the open-ended approach. Use the variant that matches
+your chosen approach.

--- a/prompts/sub-agents/input-clarifier.md
+++ b/prompts/sub-agents/input-clarifier.md
@@ -127,6 +127,7 @@ Return a JSON object with this structure:
 ## Task
 
 For each claim:
+
 1. Restate for testability — remove ambiguity, expand acronyms
 2. Surface embedded assumptions (e.g., "X caused Y" assumes causation)
 3. Define scope: domain, timeframe, testability
@@ -135,6 +136,7 @@ For each claim:
 6. Assign sequential IDs: C001, C002, ...
 
 For each query:
+
 1. Restate precisely — clarify what counts as an answer
 2. Decompose into sub-questions if the query is compound
 3. Surface embedded assumptions
@@ -143,6 +145,7 @@ For each query:
 6. Assign sequential IDs: Q001, Q002, ...
 
 For axioms:
+
 1. Pass through unchanged with sequential IDs: A001, A002, ...
 2. Do NOT test or challenge axioms — they are declared constraints
 

--- a/prompts/sub-agents/input-clarifier.md
+++ b/prompts/sub-agents/input-clarifier.md
@@ -38,12 +38,6 @@ required fields per your input schema. If validation fails, return:
 Do NOT proceed with partial input. Do NOT ask clarifying questions.
 Return the error and let the caller decide what to do.
 
-## Output
-
-Always return JSON matching your output schema. Never return markdown,
-prose, or formatted text. The caller renders the output — your job is
-to return structured data.
-
 ## Input Schema
 
 The input should contain at least one of `claims` or `queries`:
@@ -64,65 +58,15 @@ from the text. A declarative statement is a claim. A question is a query.
 A statement prefixed with "Assume:" or "Given:" or explicitly marked as
 an axiom is an axiom.
 
-## Output Schema
+## Output
 
-Return a JSON object with this structure:
+Always return JSON matching the output schema appended to this prompt.
+Never return markdown, prose, or formatted text. The caller renders the
+output — your job is to return structured data.
 
-```json
-{
-  "claims": [
-    {
-      "id": "C001",
-      "original_text": "the claim as received",
-      "clarified_text": "the claim restated for testability",
-      "assumptions_surfaced": ["list of embedded assumptions found"],
-      "scope": {
-        "domain": "subject area",
-        "timeframe": "temporal scope",
-        "testability": "how this can be verified"
-      },
-      "vocabulary": {
-        "primary_terms": ["key terms to search"],
-        "domain_variants": ["alternative terms in other fields"],
-        "related_concepts": ["broader or narrower terms"]
-      },
-      "candidate_evidence": [
-        {"url": "https://...", "description": "..."}
-      ]
-    }
-  ],
-  "queries": [
-    {
-      "id": "Q001",
-      "original_text": "the question as received",
-      "clarified_text": "the question restated precisely",
-      "sub_questions": ["decomposed sub-questions if applicable"],
-      "assumptions_surfaced": ["embedded assumptions found"],
-      "scope": {
-        "domain": "subject area",
-        "timeframe": "temporal scope"
-      },
-      "vocabulary": {
-        "primary_terms": ["key terms to search"],
-        "domain_variants": ["alternative terms in other fields"],
-        "related_concepts": ["broader or narrower terms"]
-      }
-    }
-  ],
-  "axioms": [
-    {
-      "id": "A001",
-      "text": "the axiom as declared"
-    }
-  ],
-  "metadata": {
-    "claims_count": 0,
-    "queries_count": 0,
-    "axioms_count": 0,
-    "candidate_evidence_count": 0
-  }
-}
-```
+The canonical output schema (clarified-input.schema.json) is provided
+below this prompt by the coordinator. That schema is the single source
+of truth for the output format.
 
 ## Task
 

--- a/prompts/sub-agents/relevance-scorer.md
+++ b/prompts/sub-agents/relevance-scorer.md
@@ -1,0 +1,63 @@
+# Relevance Scorer
+
+You are the Relevance Scorer sub-agent in the Diogenes research
+methodology. Your job is to score a small batch of search results for
+relevance to a specific research item.
+
+## Input
+
+You receive a JSON object with this structure:
+
+```json
+{
+  "item_id": "C001",
+  "clarified_text": "the claim or query being researched",
+  "search_intent": "what this search was looking for",
+  "results": [
+    {
+      "url": "https://...",
+      "title": "...",
+      "snippet": "..."
+    }
+  ]
+}
+```
+
+## Task
+
+For each result in the batch, assign a relevance score and brief
+rationale:
+
+- **Score 8-10**: Highly relevant. Directly addresses the research
+  intent. From a reputable source. Should be included in the evidence
+  base.
+- **Score 5-7**: Moderately relevant. Partially addresses the intent,
+  or addresses it indirectly. May be useful as supporting context.
+- **Score 2-4**: Low relevance. Only tangentially related, or from a
+  questionable source.
+- **Score 0-1**: Not relevant. Off-topic, spam, duplicate, or
+  inaccessible.
+
+Scoring criteria:
+
+- **Relevance to intent**: Does the title and snippet indicate this
+  source addresses what the search was looking for?
+- **Source quality**: Is this a reputable source (academic, government,
+  established media, official documentation)?
+- **Specificity**: Does this appear to contain specific evidence or
+  data, or is it generic/superficial?
+
+Keep rationales to one sentence. This is a triage step, not a deep
+evaluation.
+
+Return ONLY the url, relevance_score, and rationale for each result.
+Do NOT echo back the title or snippet — the coordinator already has
+those from the raw search results.
+
+## Output
+
+Always return JSON matching the output schema appended to this prompt.
+Never return markdown, prose, or formatted text.
+
+The canonical output schema (relevance-scores.schema.json) is provided
+below this prompt by the coordinator.

--- a/prompts/sub-agents/report-assembler.md
+++ b/prompts/sub-agents/report-assembler.md
@@ -1,0 +1,77 @@
+# Report Assembler
+
+You are the Report Assembler sub-agent in the Diogenes research
+methodology. Your job is to produce the final structured research
+report for a single claim or query, pulling together all prior steps.
+
+[Source: ICD 203 tradecraft standards]
+
+## Input
+
+You receive a JSON object with the complete research chain:
+
+```json
+{
+  "item": { ... },
+  "hypotheses": { ... },
+  "search_results": { ... },
+  "scorecards": [ ... ],
+  "synthesis": { ... },
+  "self_audit": { ... }
+}
+```
+
+## Task
+
+Produce the final report. Every claim must be sourced. Every judgment
+must be distinguished from fact. Every reasoning chain must be explicit.
+
+### Claim mode report structure
+
+1. Claim as received and clarified
+2. Competing hypotheses and their status
+3. Assessment with probability rating and reasoning chain
+4. Evidence summary with scorecard highlights
+5. Collection synthesis
+6. Gaps
+7. Self-audit results (all domains)
+8. Revisit triggers
+9. Source reading list reference
+
+### Query mode report structure
+
+1. Question as received and clarified
+2. Sub-questions and which were answered
+3. Hypotheses and status (if generated), or thematic synthesis (if not)
+4. Answer with confidence and reasoning chain
+5. Evidence summary with scorecard highlights
+6. Collection synthesis
+7. Gaps
+8. Self-audit results (all domains)
+9. Revisit triggers
+10. Source reading list reference
+
+### Revisit triggers (mandatory)
+
+Identify specific, testable conditions that would warrant re-running
+this research:
+
+- Named studies that, if replicated or refuted, would change the
+  assessment
+- Specific events that would invalidate key assumptions
+- Time-based triggers (prediction windows)
+- Data sources that, if updated, would provide newer figures
+- Regulatory or policy changes
+- Named organizations whose positions, if changed, would alter the
+  evidence base
+
+Each trigger must be specific enough that a future agent could check
+whether it has occurred without needing the original research context.
+
+## Output
+
+Always return JSON matching the output schema appended to this prompt.
+Never return markdown, prose, or formatted text.
+
+The canonical output schema (report.schema.json) is provided below
+this prompt by the coordinator.

--- a/prompts/sub-agents/result-selector.md
+++ b/prompts/sub-agents/result-selector.md
@@ -1,0 +1,79 @@
+# Result Selector
+
+You are the Result Selector sub-agent in the Diogenes research
+methodology. Your job is to evaluate raw search results and select
+which sources belong in the evidence base for a single claim or query.
+
+[Source: PRISMA search transparency + NAS comprehensive search]
+
+## Input
+
+You receive a JSON object with this structure:
+
+```json
+{
+  "item": { ... },
+  "search_plan": { ... },
+  "search_executions": [ ... ]
+}
+```
+
+Where `item` is the clarified claim or query (from Step 1),
+`search_plan` is the planned searches (from Step 3), and
+`search_executions` is the log of searches already executed by the
+coordinator with raw results (titles, URLs, snippets).
+
+The searches have already been performed. Your job is NOT to search —
+it is to evaluate the results and select the best sources.
+
+## Task
+
+For each search execution in the log:
+
+1. Review the results (titles, URLs, snippets)
+2. Select results that are relevant to the search intent described
+   in the search plan
+3. Reject results that are not relevant, with a brief rationale
+4. Log your selection decisions
+
+### Selection criteria
+
+Select results based on:
+
+- **Relevance**: Does this result directly address the search intent?
+- **Source quality**: Is this from a reputable source (academic journal,
+  government agency, established news organization, official
+  documentation)?
+- **Recency**: For time-sensitive topics, prefer recent sources.
+- **Diversity**: Select results from multiple sources, not just
+  multiple results from one domain.
+
+Reject results that are:
+
+- Off-topic or only tangentially related
+- From unreliable sources (content farms, SEO spam, undated blogs)
+- Duplicates of already-selected results
+- Paywalled with no accessible abstract or summary
+
+### Candidate evidence
+
+If the item includes candidate evidence (researcher-provided URLs),
+include them in your output as:
+
+- Origin: "researcher-provided"
+- Subject to the same selection criteria as search-discovered results
+
+### Accountability
+
+Every result returned by the search must be dispositioned — either
+selected with a rationale or rejected with a rationale. The sum of
+selected + rejected must equal the total results found.
+
+## Output
+
+Always return JSON matching the output schema appended to this prompt.
+Never return markdown, prose, or formatted text.
+
+The canonical output schema (search-results.schema.json) is provided
+below this prompt by the coordinator. That schema is the single source
+of truth for the output format.

--- a/prompts/sub-agents/search-designer.md
+++ b/prompts/sub-agents/search-designer.md
@@ -1,0 +1,78 @@
+# Search Designer
+
+You are the Search Designer sub-agent in the Diogenes research
+methodology. Your job is to take a single item's hypotheses (or search
+themes for open-ended queries) along with its vocabulary mappings and
+produce a concrete, executable search plan.
+
+[Source: Chamberlin/Platt strong inference + PRISMA search transparency]
+
+## Input
+
+You receive a JSON object with this structure:
+
+```json
+{
+  "item": { ... },
+  "hypotheses": { ... }
+}
+```
+
+Where `item` is the clarified claim or query (with vocabulary mappings
+from Step 1) and `hypotheses` is the hypothesis-generator output for
+that item (from Step 2).
+
+## Task
+
+### With hypotheses (claim mode or enumerable query mode)
+
+For each hypothesis, design searches specifically intended to find
+evidence that would **disprove** it. This includes the researcher's
+preferred hypothesis. The goal is **falsification, not confirmation**.
+
+For each search:
+
+1. State which hypothesis this search targets and whether you are
+   looking for supporting or eliminating evidence
+2. Specify the search terms, using vocabulary variants from the
+   clarified item to ensure cross-domain coverage
+3. Specify the sources or databases to search
+4. Describe what a useful result would look like
+5. Describe what absence of results would mean
+
+Also use the discriminating questions from the hypothesis output to
+design searches that distinguish between hypotheses.
+
+### Without hypotheses (open-ended query mode)
+
+For each search theme, design searches intended to find comprehensive,
+representative evidence. The goal is coverage and diversity of
+perspective. Design searches that would surface:
+
+- The mainstream/consensus view
+- Dissenting or minority views
+- Primary data and original research
+- The boundaries of current knowledge
+
+For each search:
+
+1. State which search theme this addresses
+2. Specify the search terms, using vocabulary variants
+3. Specify the sources or databases to search
+4. Describe the perspective this search is intended to surface
+
+### Search term design
+
+Use the vocabulary mappings from the clarified item to generate search
+terms across domains. A single concept may have different names in
+different fields. Design searches that cover the full vocabulary space,
+not just the primary terms.
+
+## Output
+
+Always return JSON matching the output schema appended to this prompt.
+Never return markdown, prose, or formatted text.
+
+The canonical output schema (search-plan.schema.json) is provided below
+this prompt by the coordinator. That schema is the single source of
+truth for the output format.

--- a/prompts/sub-agents/search-executor.md
+++ b/prompts/sub-agents/search-executor.md
@@ -1,0 +1,84 @@
+# Search Executor
+
+You are the Search Executor sub-agent in the Diogenes research
+methodology. Your job is to execute a search plan for a single claim
+or query, log every search performed, and select results for the
+evidence base.
+
+[Source: PRISMA search transparency + NAS comprehensive search]
+
+## Input
+
+You receive a JSON object with this structure:
+
+```json
+{
+  "item": { ... },
+  "search_plan": { ... }
+}
+```
+
+Where `item` is the clarified claim or query (from Step 1) and
+`search_plan` is the search plan (from Step 3) containing the planned
+searches with terms, sources, and expected outcomes.
+
+You also have access to a web search tool. Use it to execute the
+searches in the plan.
+
+## Task
+
+Execute the search plan. For every search in the plan:
+
+1. Use the web search tool with the specified search terms
+2. Review the results returned
+3. Select results that are relevant to the search intent
+4. Reject results that are not relevant, with a brief rationale
+5. Log everything — what you searched, what you found, what you
+   selected, and what you rejected
+
+### Search execution rules
+
+- Execute every search in the plan. Do not skip searches.
+- Use the exact terms from the plan, plus reasonable variations if
+  the initial terms return insufficient results.
+- For each search, aim for at least 3-5 relevant results when available.
+- If a search returns no relevant results, log it as such. Absence
+  is a finding.
+- Do not stop searching because early results seem conclusive. Execute
+  the full plan.
+
+### Candidate evidence
+
+If the item includes candidate evidence (researcher-provided URLs),
+include them in the search log as:
+
+- Origin: "researcher-provided"
+- Not associated with any search query
+- Subject to the same selection criteria as search-discovered results
+
+### Result selection criteria
+
+Select results based on:
+
+- **Relevance**: Does this result directly address the search intent?
+- **Source quality**: Is this from a reputable source (academic journal,
+  government agency, established news organization, official documentation)?
+- **Recency**: For time-sensitive topics, prefer recent sources.
+- **Diversity**: Select results from multiple sources, not just the
+  first few from one domain.
+
+Reject results that are:
+
+- Off-topic or only tangentially related
+- From unreliable sources (content farms, SEO spam, undated blogs)
+- Duplicates of already-selected results
+- Paywalled with no accessible abstract or summary
+
+## Output
+
+Always return JSON matching the output schema appended to this prompt.
+Never return markdown, prose, or formatted text.
+
+The canonical output schema (search-results.schema.json) is provided
+below this prompt by the coordinator. That schema is the single source
+of truth for the output format.

--- a/prompts/sub-agents/self-auditor.md
+++ b/prompts/sub-agents/self-auditor.md
@@ -1,0 +1,70 @@
+# Self-Auditor
+
+You are the Self-Auditor sub-agent in the Diogenes research methodology.
+Your job is to audit the research process, verify source interpretations,
+and produce a prioritized reading list — Steps 9, 9b, and 9c combined.
+
+## Input
+
+You receive a JSON object with this structure:
+
+```json
+{
+  "item": { ... },
+  "hypotheses": { ... },
+  "search_results": { ... },
+  "scorecards": [ ... ],
+  "synthesis": { ... }
+}
+```
+
+The full chain of evidence from clarification through synthesis.
+
+## Task
+
+### Step 9: Self-Audit (ROBIS four domains)
+
+Audit the research process against four domains. Rate each Pass /
+Concern / Fail:
+
+1. **Eligibility criteria**: Were relevance criteria defined before
+   searching, or did they shift after seeing results?
+2. **Search comprehensiveness**: Was the search broad enough? Did it
+   stop when sufficient evidence was found for one hypothesis?
+3. **Evaluation consistency**: Was the same scoring rigor applied to
+   all sources regardless of whether they supported or contradicted
+   the hypothesis?
+4. **Synthesis fairness**: Was all evidence synthesized fairly, or
+   were some sources weighted disproportionately?
+
+If any domain rates Concern or Fail, document why and assess the
+impact on conclusions.
+
+### Step 9b: Source-Back Verification
+
+For each source cited in the assessment, verify the interpretation:
+
+1. Compare what the assessment claims about the source vs what the
+   source actually says (based on the scorecard and content extract)
+2. Check: names, roles, quotes, dates, numbers, characterizations
+3. Flag discrepancies as minor (phrasing nuance) or major (factual
+   error or misattribution)
+
+### Step 9c: Source Reading List
+
+Produce a prioritized reading list from the scored sources:
+
+- **Must read**: High reliability AND High relevance
+- **Should read**: High reliability OR High relevance (not both)
+- **Reference**: Everything else
+
+For each source include: URL, one-sentence summary of its contribution,
+priority ranking, origin (search-discovered or researcher-provided).
+
+## Output
+
+Always return JSON matching the output schema appended to this prompt.
+Never return markdown, prose, or formatted text.
+
+The canonical output schema (self-audit.schema.json) is provided below
+this prompt by the coordinator.

--- a/prompts/sub-agents/source-scorer.md
+++ b/prompts/sub-agents/source-scorer.md
@@ -79,5 +79,8 @@ Return ONLY the url and the scoring fields (reliability, relevance,
 bias_assessment, overall_quality). Do NOT echo back the title, snippet,
 or content_extract — the coordinator already has those.
 
+Keep ALL rationales to one sentence maximum. This is a triage scorecard,
+not a detailed analysis. Brevity is critical.
+
 The canonical output schema (source-scorecards.schema.json) is provided
 below this prompt by the coordinator.

--- a/prompts/sub-agents/source-scorer.md
+++ b/prompts/sub-agents/source-scorer.md
@@ -1,0 +1,79 @@
+# Source Scorer
+
+You are the Source Scorer sub-agent in the Diogenes research
+methodology. Your job is to produce a scorecard for a batch of sources
+that have been selected for the evidence base.
+
+[Source: GRADE reliability/relevance + adapted Cochrane/RoB 2 bias
+domains]
+
+## Input
+
+You receive a JSON object with this structure:
+
+```json
+{
+  "item_id": "C001",
+  "clarified_text": "the claim or query being researched",
+  "sources": [
+    {
+      "url": "https://...",
+      "title": "...",
+      "snippet": "...",
+      "content_extract": "first ~2000 chars of page content if available"
+    }
+  ]
+}
+```
+
+The `content_extract` may be empty if the page could not be fetched.
+Score based on whatever information is available (title, snippet, URL
+domain, and content extract if present).
+
+## Task
+
+For each source, produce a scorecard with three components:
+
+### Reliability (How trustworthy is this source?)
+
+Rate: High / Medium / Low
+
+Consider:
+
+- Source type (peer-reviewed journal, government report, news article,
+  blog post, social media)
+- Author credentials and institutional affiliation
+- Publication venue reputation
+- Whether claims are sourced and verifiable
+
+### Relevance (How directly does this address the research item?)
+
+Rate: High / Medium / Low
+
+Consider:
+
+- Does the source directly discuss the claim or query topic?
+- Is the evidence in the source applicable to the specific scope?
+- How central is this source to answering the research question?
+
+### Bias Assessment (six domains)
+
+Rate each: Low risk / Some concerns / High risk / N/A
+
+1. **Missing data**: Is important data absent or incomplete?
+2. **Measurement**: Could expectations or methodology influence results?
+3. **Selective reporting**: Were all findings reported, or only favorable ones?
+4. **Randomization**: Was selection bias avoided? (N/A if not an RCT)
+5. **Protocol deviation**: Was methodology followed? (N/A if not an RCT)
+6. **Conflict of interest/funding**: Who funded this? Who benefits?
+
+For the two conditional domains (randomization and protocol deviation),
+use "N/A" when the source is not based on a randomized controlled trial.
+
+## Output
+
+Always return JSON matching the output schema appended to this prompt.
+Never return markdown, prose, or formatted text.
+
+The canonical output schema (source-scorecards.schema.json) is provided
+below this prompt by the coordinator.

--- a/prompts/sub-agents/source-scorer.md
+++ b/prompts/sub-agents/source-scorer.md
@@ -75,5 +75,9 @@ use "N/A" when the source is not based on a randomized controlled trial.
 Always return JSON matching the output schema appended to this prompt.
 Never return markdown, prose, or formatted text.
 
+Return ONLY the url and the scoring fields (reliability, relevance,
+bias_assessment, overall_quality). Do NOT echo back the title, snippet,
+or content_extract — the coordinator already has those.
+
 The canonical output schema (source-scorecards.schema.json) is provided
 below this prompt by the coordinator.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dev = [
     "ruff",
     "mypy",
     "types-jsonschema",
+    "types-requests",
     "pytest",
     "pytest-cov",
     "pip-audit",
@@ -99,7 +100,9 @@ docstring-quotes = "double"
 ]
 "src/diogenes/commands/**/*.py" = [
     "T201",    # Command implementations use print for user-facing output.
+    "PLR0911", # Command execute() has early-return error handling per step.
     "PLR0915", # Command functions may exceed 50 statements.
+    "C901",    # Command execute() orchestrates multi-step pipeline.
 ]
 "src/diogenes/pipeline.py" = [
     "T201",    # Pipeline steps print progress for user-facing output.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,11 +101,13 @@ docstring-quotes = "double"
 "src/diogenes/commands/**/*.py" = [
     "T201",    # Command implementations use print for user-facing output.
     "PLR0911", # Command execute() has early-return error handling per step.
+    "PLR0912", # Command execute() has branches per pipeline step.
     "PLR0915", # Command functions may exceed 50 statements.
     "C901",    # Command execute() orchestrates multi-step pipeline.
 ]
 "src/diogenes/pipeline.py" = [
     "T201",    # Pipeline steps print progress for user-facing output.
+    "PLR0913", # Later steps receive all prior step outputs as arguments.
 ]
 "src/diogenes/api_client.py" = [
     "PLR0913", # call_sub_agent has keyword-only params for composability.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,9 @@ docstring-quotes = "double"
     "T201",    # Command implementations use print for user-facing output.
     "PLR0915", # Command functions may exceed 50 statements.
 ]
+"src/diogenes/pipeline.py" = [
+    "T201",    # Pipeline steps print progress for user-facing output.
+]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ package-dir = {"" = "src"}
 where = ["src"]
 
 [tool.setuptools.package-data]
-diogenes = ["py.typed"]
+diogenes = ["py.typed", "schemas/*.json"]
 
 [tool.ruff]
 line-length = 120
@@ -103,6 +103,9 @@ docstring-quotes = "double"
 ]
 "src/diogenes/pipeline.py" = [
     "T201",    # Pipeline steps print progress for user-facing output.
+]
+"src/diogenes/api_client.py" = [
+    "PLR0913", # call_sub_agent has keyword-only params for composability.
 ]
 
 [tool.ruff.format]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,6 +111,7 @@ docstring-quotes = "double"
 ]
 "src/diogenes/api_client.py" = [
     "PLR0913", # call_sub_agent has keyword-only params for composability.
+    "C901",    # _parse_json_response handles multiple extraction strategies.
 ]
 
 [tool.ruff.format]

--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import anthropic
+import jsonschema
 
 from diogenes.config import ConfigError, DioConfig, load_config
 
@@ -18,6 +19,37 @@ class SubAgentError(Exception):
         """Initialize with the failing agent name and error message."""
         self.agent_name = agent_name
         super().__init__(f"Sub-agent '{agent_name}' failed: {message}")
+
+
+def _parse_json_response(text_content: str, agent_name: str) -> dict[str, Any]:
+    """Parse JSON from a sub-agent response, handling markdown code fences."""
+    json_text = text_content.strip()
+    if json_text.startswith("```"):
+        lines = json_text.split("\n")
+        lines = [line for line in lines if not line.strip().startswith("```")]
+        json_text = "\n".join(lines)
+
+    try:
+        result: dict[str, Any] = json.loads(json_text)
+    except json.JSONDecodeError as e:
+        msg = f"Response is not valid JSON: {e}\nRaw response:\n{text_content[:500]}"
+        raise SubAgentError(agent_name, msg) from e
+
+    return result
+
+
+def _validate_against_schema(
+    result: dict[str, Any],
+    schema_dict: dict[str, Any],
+    agent_name: str,
+) -> None:
+    """Validate a parsed response against a JSON Schema."""
+    try:
+        jsonschema.validate(instance=result, schema=schema_dict)
+    except jsonschema.ValidationError as e:
+        path = ".".join(str(p) for p in e.absolute_path)
+        msg = f"Response failed schema validation at '{path}': {e.message}"
+        raise SubAgentError(agent_name, msg) from e
 
 
 class APIClient:
@@ -37,6 +69,7 @@ class APIClient:
     DEFAULT_MAX_TOKENS = 8192
     _PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts"
     _COMMON_GUIDELINES_PATH = _PROMPTS_DIR / "common-guidelines.md"
+    _SCHEMAS_DIR = Path(__file__).parent / "schemas"
 
     def __init__(
         self,
@@ -77,6 +110,43 @@ class APIClient:
         else:
             self._common_guidelines = ""
 
+    def _compose_system_prompt(
+        self,
+        agent_prompt: str,
+        *,
+        include_guidelines: bool,
+        output_schema: str | None,
+    ) -> tuple[str, dict[str, Any] | None]:
+        """Compose the system prompt from guidelines, agent prompt, and schema.
+
+        Returns:
+            Tuple of (system_prompt, schema_dict or None).
+
+        """
+        parts = []
+        if include_guidelines and self._common_guidelines:
+            parts.append(self._common_guidelines)
+        parts.append(agent_prompt)
+
+        schema_dict: dict[str, Any] | None = None
+        if output_schema:
+            schema_path = self._SCHEMAS_DIR / output_schema
+            if not schema_path.exists():
+                agent_name = "schema"
+                msg = f"Output schema not found: {schema_path}"
+                raise SubAgentError(agent_name, msg)
+            schema_text = schema_path.read_text()
+            schema_dict = json.loads(schema_text)
+            parts.append(
+                "## Output JSON Schema\n\n"
+                "Your output MUST conform to this JSON Schema. "
+                "This is the canonical specification — if anything in the prompt "
+                "above conflicts with this schema, the schema wins.\n\n"
+                f"```json\n{schema_text}\n```"
+            )
+
+        return "\n\n---\n\n".join(parts), schema_dict
+
     def call_sub_agent(
         self,
         *,
@@ -85,6 +155,7 @@ class APIClient:
         model: str | None = None,
         max_tokens: int | None = None,
         include_guidelines: bool = True,
+        output_schema: str | None = None,
     ) -> dict[str, Any]:
         """Call a sub-agent prompt and return parsed JSON.
 
@@ -96,13 +167,17 @@ class APIClient:
             include_guidelines: Prepend common behavioral guidelines to the
                 system prompt. Defaults to True. Set to False only for purely
                 mechanical steps that do not involve judgment or evidence handling.
+            output_schema: Schema filename (e.g., 'hypotheses.schema.json') to
+                append to the system prompt and validate the response against.
+                Loaded from the schemas package directory.
 
         Returns:
             Parsed JSON dict from the sub-agent response.
 
         Raises:
             SubAgentError: If the prompt file doesn't exist, the API
-                call fails, or the response is not valid JSON.
+                call fails, the response is not valid JSON, or the
+                response does not conform to the output schema.
 
         """
         prompt_file = Path(prompt_path)
@@ -111,11 +186,11 @@ class APIClient:
             raise SubAgentError(prompt_file.stem, msg)
 
         agent_prompt = prompt_file.read_text()
-
-        if include_guidelines and self._common_guidelines:
-            system_prompt = self._common_guidelines + "\n\n---\n\n" + agent_prompt
-        else:
-            system_prompt = agent_prompt
+        system_prompt, schema_dict = self._compose_system_prompt(
+            agent_prompt,
+            include_guidelines=include_guidelines,
+            output_schema=output_schema,
+        )
 
         # Convert dict input to JSON string
         user_message = json.dumps(user_input, indent=2) if isinstance(user_input, dict) else user_input
@@ -141,19 +216,9 @@ class APIClient:
             msg = "Empty response from API"
             raise SubAgentError(prompt_file.stem, msg)
 
-        # Parse JSON from response — handle markdown code blocks
-        json_text = text_content.strip()
-        if json_text.startswith("```"):
-            # Strip markdown code fence
-            lines = json_text.split("\n")
-            # Remove first line (```json or ```) and last line (```)
-            lines = [line for line in lines if not line.strip().startswith("```")]
-            json_text = "\n".join(lines)
+        result = _parse_json_response(text_content, prompt_file.stem)
 
-        try:
-            result: dict[str, Any] = json.loads(json_text)
-        except json.JSONDecodeError as e:
-            msg = f"Response is not valid JSON: {e}\nRaw response:\n{text_content[:500]}"
-            raise SubAgentError(prompt_file.stem, msg) from e
+        if schema_dict is not None:
+            _validate_against_schema(result, schema_dict, prompt_file.stem)
 
         return result

--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
@@ -10,6 +11,84 @@ import anthropic
 import jsonschema
 
 from diogenes.config import ConfigError, DioConfig, load_config
+
+
+@dataclass
+class CallUsage:
+    """Token and tool usage from a single API call."""
+
+    agent_name: str
+    model: str
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_creation_tokens: int = 0
+    cache_read_tokens: int = 0
+    web_search_requests: int = 0
+    web_fetch_requests: int = 0
+    service_tier: str = "standard"
+
+
+@dataclass
+class UsageAccumulator:
+    """Accumulates usage across all API calls in a session."""
+
+    calls: list[CallUsage] = field(default_factory=list)
+
+    def record(self, usage: CallUsage) -> None:
+        """Record a single call's usage."""
+        self.calls.append(usage)
+
+    @property
+    def total_input_tokens(self) -> int:
+        """Total input tokens across all calls."""
+        return sum(c.input_tokens for c in self.calls)
+
+    @property
+    def total_output_tokens(self) -> int:
+        """Total output tokens across all calls."""
+        return sum(c.output_tokens for c in self.calls)
+
+    @property
+    def total_tokens(self) -> int:
+        """Total tokens (input + output) across all calls."""
+        return self.total_input_tokens + self.total_output_tokens
+
+    @property
+    def total_web_searches(self) -> int:
+        """Total web search requests across all calls."""
+        return sum(c.web_search_requests for c in self.calls)
+
+    @property
+    def total_web_fetches(self) -> int:
+        """Total web fetch requests across all calls."""
+        return sum(c.web_fetch_requests for c in self.calls)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize to a dict for JSON output."""
+        return {
+            "totals": {
+                "input_tokens": self.total_input_tokens,
+                "output_tokens": self.total_output_tokens,
+                "total_tokens": self.total_tokens,
+                "web_search_requests": self.total_web_searches,
+                "web_fetch_requests": self.total_web_fetches,
+                "api_calls": len(self.calls),
+            },
+            "per_call": [
+                {
+                    "agent": c.agent_name,
+                    "model": c.model,
+                    "input_tokens": c.input_tokens,
+                    "output_tokens": c.output_tokens,
+                    "cache_creation_tokens": c.cache_creation_tokens,
+                    "cache_read_tokens": c.cache_read_tokens,
+                    "web_search_requests": c.web_search_requests,
+                    "web_fetch_requests": c.web_fetch_requests,
+                    "service_tier": c.service_tier,
+                }
+                for c in self.calls
+            ],
+        }
 
 
 class SubAgentError(Exception):
@@ -110,6 +189,8 @@ class APIClient:
         else:
             self._common_guidelines = ""
 
+        self.usage = UsageAccumulator()
+
     def _compose_system_prompt(
         self,
         agent_prompt: str,
@@ -209,7 +290,11 @@ class APIClient:
 
         if enable_web_search:
             api_kwargs["tools"] = [
-                {"type": "web_search_20260209", "name": "web_search"},
+                {
+                    "type": "web_search_20260209",
+                    "name": "web_search",
+                    "allowed_callers": ["direct"],
+                },
             ]
 
         try:
@@ -217,6 +302,20 @@ class APIClient:
         except anthropic.APIError as e:
             msg = f"API call failed: {e}"
             raise SubAgentError(prompt_file.stem, msg) from e
+
+        # Record usage
+        server_tool = response.usage.server_tool_use
+        self.usage.record(CallUsage(
+            agent_name=prompt_file.stem,
+            model=response.model,
+            input_tokens=response.usage.input_tokens,
+            output_tokens=response.usage.output_tokens,
+            cache_creation_tokens=response.usage.cache_creation_input_tokens or 0,
+            cache_read_tokens=response.usage.cache_read_input_tokens or 0,
+            web_search_requests=server_tool.web_search_requests if server_tool else 0,
+            web_fetch_requests=server_tool.web_fetch_requests if server_tool else 0,
+            service_tier=response.usage.service_tier or "standard",
+        ))
 
         # Extract text content from response
         text_content = ""

--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -253,17 +253,28 @@ class APIClient:
         *,
         include_guidelines: bool,
         output_schema: str | None,
-    ) -> tuple[str, dict[str, Any] | None]:
-        """Compose the system prompt from guidelines, agent prompt, and schema.
+    ) -> tuple[list[dict[str, Any]], dict[str, Any] | None]:
+        """Compose the system prompt as content blocks with cache control.
+
+        The common guidelines are marked as cacheable — they're identical across
+        all calls and represent ~5K tokens that would otherwise be charged at full
+        rate 90+ times per run. With prompt caching, repeated blocks cost 90% less.
 
         Returns:
-            Tuple of (system_prompt, schema_dict or None).
+            Tuple of (system_blocks, schema_dict or None).
 
         """
-        parts = []
+        blocks: list[dict[str, Any]] = []
+
         if include_guidelines and self._common_guidelines:
-            parts.append(self._common_guidelines)
-        parts.append(agent_prompt)
+            blocks.append({
+                "type": "text",
+                "text": self._common_guidelines,
+                "cache_control": {"type": "ephemeral"},
+            })
+
+        # Agent prompt + schema combined into one block
+        prompt_parts = [agent_prompt]
 
         schema_dict: dict[str, Any] | None = None
         if output_schema:
@@ -274,7 +285,7 @@ class APIClient:
                 raise SubAgentError(agent_name, msg)
             schema_text = schema_path.read_text()
             schema_dict = json.loads(schema_text)
-            parts.append(
+            prompt_parts.append(
                 "## Output JSON Schema\n\n"
                 "Your output MUST conform to this JSON Schema. "
                 "This is the canonical specification — if anything in the prompt "
@@ -282,7 +293,9 @@ class APIClient:
                 f"```json\n{schema_text}\n```"
             )
 
-        return "\n\n---\n\n".join(parts), schema_dict
+        blocks.append({"type": "text", "text": "\n\n---\n\n".join(prompt_parts)})
+
+        return blocks, schema_dict
 
     def call_sub_agent(
         self,
@@ -327,7 +340,7 @@ class APIClient:
             raise SubAgentError(prompt_file.stem, msg)
 
         agent_prompt = prompt_file.read_text()
-        system_prompt, schema_dict = self._compose_system_prompt(
+        system_blocks, schema_dict = self._compose_system_prompt(
             agent_prompt,
             include_guidelines=include_guidelines,
             output_schema=output_schema,
@@ -340,7 +353,7 @@ class APIClient:
         api_kwargs: dict[str, Any] = {
             "model": model or self._model,
             "max_tokens": max_tokens or self._max_tokens,
-            "system": system_prompt,
+            "system": system_blocks,
             "messages": [{"role": "user", "content": user_message}],
         }
 

--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -28,6 +28,30 @@ class CallUsage:
     service_tier: str = "standard"
 
 
+# Approximate per-token costs in USD (Anthropic API, standard tier)
+# These are estimates for cost tracking — actual billing may vary.
+_MODEL_COSTS: dict[str, tuple[float, float]] = {
+    # Values are (input_cost_per_1M_tokens, output_cost_per_1M_tokens)
+    "claude-sonnet-4-20250514": (3.00, 15.00),
+    "claude-haiku-4-5-20251001": (0.80, 4.00),
+    "claude-opus-4-20250514": (15.00, 75.00),
+}
+_WEB_SEARCH_COST_PER_REQUEST = 0.01  # $10/1K searches
+
+
+def _estimate_call_cost(call: CallUsage) -> float:
+    """Estimate the USD cost of a single API call."""
+    input_rate, output_rate = _MODEL_COSTS.get(
+        call.model, (3.00, 15.00),  # default to Sonnet rates
+    )
+    token_cost = (
+        call.input_tokens * input_rate / 1_000_000
+        + call.output_tokens * output_rate / 1_000_000
+    )
+    search_cost = call.web_search_requests * _WEB_SEARCH_COST_PER_REQUEST
+    return token_cost + search_cost
+
+
 @dataclass
 class UsageAccumulator:
     """Accumulates usage across all API calls in a session."""
@@ -63,6 +87,11 @@ class UsageAccumulator:
         """Total web fetch requests across all calls."""
         return sum(c.web_fetch_requests for c in self.calls)
 
+    @property
+    def total_estimated_cost(self) -> float:
+        """Total estimated USD cost across all calls."""
+        return sum(_estimate_call_cost(c) for c in self.calls)
+
     def to_dict(self) -> dict[str, Any]:
         """Serialize to a dict for JSON output."""
         return {
@@ -73,6 +102,7 @@ class UsageAccumulator:
                 "web_search_requests": self.total_web_searches,
                 "web_fetch_requests": self.total_web_fetches,
                 "api_calls": len(self.calls),
+                "estimated_cost_usd": round(self.total_estimated_cost, 4),
             },
             "per_call": [
                 {
@@ -85,6 +115,7 @@ class UsageAccumulator:
                     "web_search_requests": c.web_search_requests,
                     "web_fetch_requests": c.web_fetch_requests,
                     "service_tier": c.service_tier,
+                    "estimated_cost_usd": round(_estimate_call_cost(c), 4),
                 }
                 for c in self.calls
             ],

--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -42,12 +42,10 @@ _WEB_SEARCH_COST_PER_REQUEST = 0.01  # $10/1K searches
 def _estimate_call_cost(call: CallUsage) -> float:
     """Estimate the USD cost of a single API call."""
     input_rate, output_rate = _MODEL_COSTS.get(
-        call.model, (3.00, 15.00),  # default to Sonnet rates
+        call.model,
+        (3.00, 15.00),  # default to Sonnet rates
     )
-    token_cost = (
-        call.input_tokens * input_rate / 1_000_000
-        + call.output_tokens * output_rate / 1_000_000
-    )
+    token_cost = call.input_tokens * input_rate / 1_000_000 + call.output_tokens * output_rate / 1_000_000
     search_cost = call.web_search_requests * _WEB_SEARCH_COST_PER_REQUEST
     return token_cost + search_cost
 
@@ -163,7 +161,7 @@ def _parse_json_response(text_content: str, agent_name: str) -> dict[str, Any]:
             depth -= 1
             if depth == 0:
                 try:
-                    extracted: dict[str, Any] = json.loads(json_text[start:i + 1])
+                    extracted: dict[str, Any] = json.loads(json_text[start : i + 1])
                 except json.JSONDecodeError:
                     break
                 else:
@@ -267,11 +265,13 @@ class APIClient:
         blocks: list[dict[str, Any]] = []
 
         if include_guidelines and self._common_guidelines:
-            blocks.append({
-                "type": "text",
-                "text": self._common_guidelines,
-                "cache_control": {"type": "ephemeral"},
-            })
+            blocks.append(
+                {
+                    "type": "text",
+                    "text": self._common_guidelines,
+                    "cache_control": {"type": "ephemeral"},
+                }
+            )
 
         # Agent prompt + schema combined into one block
         prompt_parts = [agent_prompt]
@@ -374,17 +374,19 @@ class APIClient:
 
         # Record usage
         server_tool = response.usage.server_tool_use
-        self.usage.record(CallUsage(
-            agent_name=prompt_file.stem,
-            model=response.model,
-            input_tokens=response.usage.input_tokens,
-            output_tokens=response.usage.output_tokens,
-            cache_creation_tokens=response.usage.cache_creation_input_tokens or 0,
-            cache_read_tokens=response.usage.cache_read_input_tokens or 0,
-            web_search_requests=server_tool.web_search_requests if server_tool else 0,
-            web_fetch_requests=server_tool.web_fetch_requests if server_tool else 0,
-            service_tier=response.usage.service_tier or "standard",
-        ))
+        self.usage.record(
+            CallUsage(
+                agent_name=prompt_file.stem,
+                model=response.model,
+                input_tokens=response.usage.input_tokens,
+                output_tokens=response.usage.output_tokens,
+                cache_creation_tokens=response.usage.cache_creation_input_tokens or 0,
+                cache_read_tokens=response.usage.cache_read_input_tokens or 0,
+                web_search_requests=server_tool.web_search_requests if server_tool else 0,
+                web_fetch_requests=server_tool.web_fetch_requests if server_tool else 0,
+                service_tier=response.usage.service_tier or "standard",
+            )
+        )
 
         # Extract text content from response
         text_content = ""

--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -193,7 +193,7 @@ class APIClient:
 
         Args:
             config: Pre-loaded configuration. If omitted, loads from all config sources
-                (environment variable, .dorc files, .env file).
+                (environment variable, .diorc files, .env file).
             model: Anthropic model ID. Overrides the value in config.
             max_tokens: Maximum response tokens. Defaults to 8192.
             guidelines_path: Path to common guidelines file. Defaults to

--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -156,6 +156,7 @@ class APIClient:
         max_tokens: int | None = None,
         include_guidelines: bool = True,
         output_schema: str | None = None,
+        enable_web_search: bool = False,
     ) -> dict[str, Any]:
         """Call a sub-agent prompt and return parsed JSON.
 
@@ -170,6 +171,9 @@ class APIClient:
             output_schema: Schema filename (e.g., 'hypotheses.schema.json') to
                 append to the system prompt and validate the response against.
                 Loaded from the schemas package directory.
+            enable_web_search: Include the Anthropic web search server tool.
+                When True, the model can execute web searches during the call.
+                Anthropic handles search execution server-side.
 
         Returns:
             Parsed JSON dict from the sub-agent response.
@@ -195,13 +199,21 @@ class APIClient:
         # Convert dict input to JSON string
         user_message = json.dumps(user_input, indent=2) if isinstance(user_input, dict) else user_input
 
+        # Build API call kwargs
+        api_kwargs: dict[str, Any] = {
+            "model": model or self._model,
+            "max_tokens": max_tokens or self._max_tokens,
+            "system": system_prompt,
+            "messages": [{"role": "user", "content": user_message}],
+        }
+
+        if enable_web_search:
+            api_kwargs["tools"] = [
+                {"type": "web_search_20260209", "name": "web_search"},
+            ]
+
         try:
-            response = self._client.messages.create(
-                model=model or self._model,
-                max_tokens=max_tokens or self._max_tokens,
-                system=system_prompt,
-                messages=[{"role": "user", "content": user_message}],
-            )
+            response = self._client.messages.create(**api_kwargs)
         except anthropic.APIError as e:
             msg = f"API call failed: {e}"
             raise SubAgentError(prompt_file.stem, msg) from e

--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -26,10 +26,17 @@ class APIClient:
     Each sub-agent is a markdown prompt file. The client loads the prompt,
     sends it as the system message with the user input, and returns the
     parsed JSON response.
+
+    By default, the common guidelines (behavioral constraints, input types,
+    researcher profile) are prepended to every sub-agent prompt. This ensures
+    all sub-agents operate under the same non-negotiable rules regardless of
+    which step they implement.
     """
 
     DEFAULT_MODEL = "claude-sonnet-4-20250514"
     DEFAULT_MAX_TOKENS = 8192
+    _PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts"
+    _COMMON_GUIDELINES_PATH = _PROMPTS_DIR / "common-guidelines.md"
 
     def __init__(
         self,
@@ -37,6 +44,7 @@ class APIClient:
         config: DioConfig | None = None,
         model: str | None = None,
         max_tokens: int | None = None,
+        guidelines_path: str | Path | None = None,
     ) -> None:
         """Initialize the API client.
 
@@ -45,6 +53,8 @@ class APIClient:
                 (environment variable, .dorc files, .env file).
             model: Anthropic model ID. Overrides the value in config.
             max_tokens: Maximum response tokens. Defaults to 8192.
+            guidelines_path: Path to common guidelines file. Defaults to
+                prompts/common-guidelines.md in the repo root.
 
         Raises:
             SubAgentError: If configuration cannot be loaded (e.g., no API key found).
@@ -61,6 +71,12 @@ class APIClient:
         self._model = model or cfg.model or self.DEFAULT_MODEL
         self._max_tokens = max_tokens or self.DEFAULT_MAX_TOKENS
 
+        gp = Path(guidelines_path) if guidelines_path is not None else self._COMMON_GUIDELINES_PATH
+        if gp.exists():
+            self._common_guidelines = gp.read_text()
+        else:
+            self._common_guidelines = ""
+
     def call_sub_agent(
         self,
         *,
@@ -68,6 +84,7 @@ class APIClient:
         user_input: str | dict[str, Any],
         model: str | None = None,
         max_tokens: int | None = None,
+        include_guidelines: bool = True,
     ) -> dict[str, Any]:
         """Call a sub-agent prompt and return parsed JSON.
 
@@ -76,6 +93,9 @@ class APIClient:
             user_input: User input as JSON dict or raw text string.
             model: Override the default model for this call.
             max_tokens: Override the default max tokens for this call.
+            include_guidelines: Prepend common behavioral guidelines to the
+                system prompt. Defaults to True. Set to False only for purely
+                mechanical steps that do not involve judgment or evidence handling.
 
         Returns:
             Parsed JSON dict from the sub-agent response.
@@ -90,7 +110,12 @@ class APIClient:
             msg = f"Prompt file not found: {prompt_file}"
             raise SubAgentError(prompt_file.stem, msg)
 
-        system_prompt = prompt_file.read_text()
+        agent_prompt = prompt_file.read_text()
+
+        if include_guidelines and self._common_guidelines:
+            system_prompt = self._common_guidelines + "\n\n---\n\n" + agent_prompt
+        else:
+            system_prompt = agent_prompt
 
         # Convert dict input to JSON string
         user_message = json.dumps(user_input, indent=2) if isinstance(user_input, dict) else user_input

--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -132,20 +132,45 @@ class SubAgentError(Exception):
 
 
 def _parse_json_response(text_content: str, agent_name: str) -> dict[str, Any]:
-    """Parse JSON from a sub-agent response, handling markdown code fences."""
+    """Parse JSON from a sub-agent response, handling markdown code fences and trailing text."""
     json_text = text_content.strip()
     if json_text.startswith("```"):
         lines = json_text.split("\n")
         lines = [line for line in lines if not line.strip().startswith("```")]
         json_text = "\n".join(lines)
 
+    # Try parsing the full text first
     try:
         result: dict[str, Any] = json.loads(json_text)
-    except json.JSONDecodeError as e:
-        msg = f"Response is not valid JSON: {e}\nRaw response:\n{text_content[:500]}"
-        raise SubAgentError(agent_name, msg) from e
+    except json.JSONDecodeError:
+        pass
+    else:
+        return result
 
-    return result
+    # If that fails, try to extract JSON object from the text.
+    # Some models (especially Haiku) append explanatory text after valid JSON.
+    start = json_text.find("{")
+    if start == -1:
+        msg = f"No JSON object found in response.\nRaw response:\n{text_content[:500]}"
+        raise SubAgentError(agent_name, msg)
+
+    # Find the matching closing brace by tracking depth
+    depth = 0
+    for i in range(start, len(json_text)):
+        if json_text[i] == "{":
+            depth += 1
+        elif json_text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                try:
+                    extracted: dict[str, Any] = json.loads(json_text[start:i + 1])
+                except json.JSONDecodeError:
+                    break
+                else:
+                    return extracted
+
+    msg = f"Could not extract valid JSON from response.\nRaw response:\n{text_content[:500]}"
+    raise SubAgentError(agent_name, msg)
 
 
 def _validate_against_schema(

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from diogenes.api_client import APIClient, SubAgentError
+from diogenes.pipeline import step2_generate_hypotheses, write_step_output
 from diogenes.schema_validator import ValidationError, parse_input_file, validate_research_input
 
 # Resolve prompts directory relative to repo root
@@ -72,6 +73,64 @@ def _write_research_input(output_dir: Path, data: dict[str, Any]) -> Path:
     return path
 
 
+def _parse_and_clarify(
+    input_path: Path,
+    client: APIClient,
+) -> dict[str, Any] | None:
+    """Parse the input file and clarify if needed (Step 1).
+
+    Returns the research input dict, or None on error (after printing).
+    """
+    print(f"Reading input: {input_path}")
+    try:
+        raw_input = parse_input_file(input_path)
+    except FileNotFoundError as e:
+        print(f"ERROR: {e}")
+        return None
+
+    # Route — JSON or text?
+    if isinstance(raw_input, dict):
+        print("Input format: JSON — validating schema...")
+        try:
+            research_input = validate_research_input(raw_input)
+        except ValidationError as e:
+            print(f"ERROR: {e}")
+            return None
+        print(f"  Claims: {len(research_input.get('claims', []))}")
+        print(f"  Queries: {len(research_input.get('queries', []))}")
+        print(f"  Axioms: {len(research_input.get('axioms', []))}")
+        return research_input
+
+    # Text input — call input-clarifier sub-agent
+    print("Input format: text — calling input-clarifier sub-agent...")
+    clarifier_prompt = _PROMPTS_DIR / "input-clarifier.md"
+
+    try:
+        clarified = client.call_sub_agent(
+            prompt_path=clarifier_prompt,
+            user_input=raw_input,
+        )
+    except SubAgentError as e:
+        print(f"ERROR: {e}")
+        return None
+
+    if clarified.get("error"):
+        print(f"ERROR: Input clarifier failed: {clarified.get('message', 'unknown error')}")
+        return None
+
+    research_input = {
+        "claims": clarified.get("claims", []),
+        "queries": clarified.get("queries", []),
+        "axioms": clarified.get("axioms", []),
+    }
+
+    claims_count = len(research_input.get("claims", []))
+    queries_count = len(research_input.get("queries", []))
+    axioms_count = len(research_input.get("axioms", []))
+    print(f"  Clarified: {claims_count} claims, {queries_count} queries, {axioms_count} axioms")
+    return research_input
+
+
 def execute(input_file: str, output: str, runs: int) -> int:
     """Execute the 'dio run' command.
 
@@ -87,62 +146,17 @@ def execute(input_file: str, output: str, runs: int) -> int:
     output_dir = Path(output)
     input_path = Path(input_file)
 
-    # Step 1: Read and parse input file
-    print(f"Reading input: {input_path}")
+    # Initialize API client (reused for all sub-agent calls)
     try:
-        raw_input = parse_input_file(input_path)
-    except FileNotFoundError as e:
+        client = APIClient()
+    except SubAgentError as e:
         print(f"ERROR: {e}")
         return 1
 
-    # Step 2: Route — JSON or text?
-    if isinstance(raw_input, dict):
-        # JSON input — validate directly
-        print("Input format: JSON — validating schema...")
-        try:
-            research_input = validate_research_input(raw_input)
-        except ValidationError as e:
-            print(f"ERROR: {e}")
-            return 1
-        print(f"  Claims: {len(research_input.get('claims', []))}")
-        print(f"  Queries: {len(research_input.get('queries', []))}")
-        print(f"  Axioms: {len(research_input.get('axioms', []))}")
-    else:
-        # Text input — call input-clarifier sub-agent
-        print("Input format: text — calling input-clarifier sub-agent...")
-        clarifier_prompt = _PROMPTS_DIR / "input-clarifier.md"
-
-        try:
-            client = APIClient()
-        except SubAgentError as e:
-            print(f"ERROR: {e}")
-            return 1
-
-        try:
-            clarified = client.call_sub_agent(
-                prompt_path=clarifier_prompt,
-                user_input=raw_input,
-            )
-        except SubAgentError as e:
-            print(f"ERROR: {e}")
-            return 1
-
-        # Check for sub-agent error response
-        if clarified.get("error"):
-            print(f"ERROR: Input clarifier failed: {clarified.get('message', 'unknown error')}")
-            return 1
-
-        # Build the research input from clarified output
-        research_input = {
-            "claims": clarified.get("claims", []),
-            "queries": clarified.get("queries", []),
-            "axioms": clarified.get("axioms", []),
-        }
-
-        claims_count = len(research_input.get("claims", []))
-        queries_count = len(research_input.get("queries", []))
-        axioms_count = len(research_input.get("axioms", []))
-        print(f"  Clarified: {claims_count} claims, {queries_count} queries, {axioms_count} axioms")
+    # Step 1: Parse input and clarify via sub-agent if needed
+    research_input = _parse_and_clarify(input_path, client)
+    if research_input is None:
+        return 1
 
     # Step 3: Write research-input.json
     print(f"Output directory: {output_dir}")
@@ -163,10 +177,28 @@ def execute(input_file: str, output: str, runs: int) -> int:
         snapshot_dest.write_text(prompt_snapshot_src.read_text())
         print("  Saved: prompt-snapshot.md")
 
+    # --- Pipeline execution ---
+    for run_dir in run_dirs:
+        print()
+        print(f"=== {run_dir.name} ===")
+
+        # Step 2: Generate competing hypotheses
+        print("Step 2: Generating competing hypotheses...")
+        try:
+            hypotheses = step2_generate_hypotheses(research_input, client)
+        except SubAgentError as e:
+            print(f"ERROR: {e}")
+            return 1
+
+        hyp_path = write_step_output(run_dir, "hypotheses.json", hypotheses)
+        print(f"  Wrote: {hyp_path}")
+
+        # Steps 3-11: not yet implemented
+        print()
+        print(f"  Pipeline paused after step 2 for {run_dir.name}.")
+        print("  Steps 3-11 not yet implemented.")
+
     print()
-    print("Research input parsed and validated.")
-    print(f"Directory structure created at: {group_dir}")
-    print()
-    print("Next steps: execute sub-agent pipeline for each run (not yet implemented).")
+    print(f"Research complete. Output: {group_dir}")
 
     return 0

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -9,6 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from diogenes.api_client import APIClient, SubAgentError
+from diogenes.config import load_config
 from diogenes.pipeline import (
     step2_generate_hypotheses,
     step3_design_searches,
@@ -16,6 +17,7 @@ from diogenes.pipeline import (
     write_step_output,
 )
 from diogenes.schema_validator import ValidationError, parse_input_file, validate_research_input
+from diogenes.search_providers import BraveSearchProvider, GoogleSearchProvider
 
 # Resolve prompts directory relative to repo root
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent
@@ -137,6 +139,29 @@ def _parse_and_clarify(
     return research_input
 
 
+def _create_search_provider() -> BraveSearchProvider | GoogleSearchProvider | None:
+    """Create a search provider from config.
+
+    Returns the provider, or None on error (after printing).
+    """
+    cfg = load_config()
+
+    if cfg.search_provider == "brave":
+        if not cfg.brave_api_key:
+            print("ERROR: Brave Search requires BRAVE_API_KEY in .dorc or .env")
+            return None
+        return BraveSearchProvider(cfg.brave_api_key)
+
+    if cfg.search_provider == "google":
+        if not cfg.google_api_key or not cfg.google_search_engine_id:
+            print("ERROR: Google Search requires GOOGLE_API_KEY and GOOGLE_SEARCH_ENGINE_ID")
+            return None
+        return GoogleSearchProvider(cfg.google_api_key, cfg.google_search_engine_id)
+
+    print(f"ERROR: Unknown search provider: {cfg.search_provider}")
+    return None
+
+
 def execute(input_file: str, output: str, runs: int) -> int:
     """Execute the 'dio run' command.
 
@@ -157,6 +182,11 @@ def execute(input_file: str, output: str, runs: int) -> int:
         client = APIClient()
     except SubAgentError as e:
         print(f"ERROR: {e}")
+        return 1
+
+    # Initialize search provider
+    search_provider = _create_search_provider()
+    if search_provider is None:
         return 1
 
     # Step 1: Parse input and clarify via sub-agent if needed
@@ -213,7 +243,9 @@ def execute(input_file: str, output: str, runs: int) -> int:
         # Step 4: Execute searches and log
         print("Step 4: Executing searches...")
         try:
-            search_results = step4_execute_searches(research_input, search_plans, client)
+            search_results = step4_execute_searches(
+                research_input, search_plans, client, search_provider,
+            )
         except SubAgentError as e:
             print(f"ERROR: {e}")
             return 1

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -149,14 +149,14 @@ def _create_search_provider() -> SerperSearchProvider | BraveSearchProvider | Go
 
     if cfg.search_provider == "serper":
         if not cfg.serper_api_key:
-            print("ERROR: Serper.dev requires SERPER_API_KEY in .dorc or .env")
+            print("ERROR: Serper.dev requires SERPER_API_KEY in .diorc or .env")
             print("  Sign up free at https://serper.dev/ (2,500 searches/month)")
             return None
         return SerperSearchProvider(cfg.serper_api_key)
 
     if cfg.search_provider == "brave":
         if not cfg.brave_api_key:
-            print("ERROR: Brave Search requires BRAVE_API_KEY in .dorc or .env")
+            print("ERROR: Brave Search requires BRAVE_API_KEY in .diorc or .env")
             return None
         return BraveSearchProvider(cfg.brave_api_key)
 

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from diogenes.api_client import APIClient, SubAgentError
-from diogenes.pipeline import step2_generate_hypotheses, write_step_output
+from diogenes.pipeline import step2_generate_hypotheses, step3_design_searches, write_step_output
 from diogenes.schema_validator import ValidationError, parse_input_file, validate_research_input
 
 # Resolve prompts directory relative to repo root
@@ -194,10 +194,21 @@ def execute(input_file: str, output: str, runs: int) -> int:
         hyp_path = write_step_output(run_dir, "hypotheses.json", hypotheses)
         print(f"  Wrote: {hyp_path}")
 
-        # Steps 3-11: not yet implemented
+        # Step 3: Design discriminating searches
+        print("Step 3: Designing search plans...")
+        try:
+            search_plans = step3_design_searches(research_input, hypotheses, client)
+        except SubAgentError as e:
+            print(f"ERROR: {e}")
+            return 1
+
+        plan_path = write_step_output(run_dir, "search-plans.json", search_plans)
+        print(f"  Wrote: {plan_path}")
+
+        # Steps 4-11: not yet implemented
         print()
-        print(f"  Pipeline paused after step 2 for {run_dir.name}.")
-        print("  Steps 3-11 not yet implemented.")
+        print(f"  Pipeline paused after step 3 for {run_dir.name}.")
+        print("  Steps 4-11 not yet implemented.")
 
     print()
     print(f"Research complete. Output: {group_dir}")

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -256,7 +256,10 @@ def execute(input_file: str, output: str, runs: int) -> int:
         print("Step 4: Executing searches...")
         try:
             search_results = step4_execute_searches(
-                research_input, search_plans, client, search_provider,
+                research_input,
+                search_plans,
+                client,
+                search_provider,
             )
         except SubAgentError as e:
             print(f"ERROR: {e}")
@@ -280,7 +283,10 @@ def execute(input_file: str, output: str, runs: int) -> int:
         print("Steps 6-8: Synthesizing evidence and assessing...")
         try:
             synthesis = steps678_synthesize_and_assess(
-                research_input, hypotheses, scorecards, client,
+                research_input,
+                hypotheses,
+                scorecards,
+                client,
             )
         except SubAgentError as e:
             print(f"ERROR: {e}")
@@ -293,8 +299,12 @@ def execute(input_file: str, output: str, runs: int) -> int:
         print("Step 9: Self-audit and verification...")
         try:
             audit = step9_self_audit(
-                research_input, hypotheses, search_results, scorecards,
-                synthesis, client,
+                research_input,
+                hypotheses,
+                search_results,
+                scorecards,
+                synthesis,
+                client,
             )
         except SubAgentError as e:
             print(f"ERROR: {e}")
@@ -307,8 +317,13 @@ def execute(input_file: str, output: str, runs: int) -> int:
         print("Step 10: Assembling final reports...")
         try:
             reports = step10_report(
-                research_input, hypotheses, search_results, scorecards,
-                synthesis, audit, client,
+                research_input,
+                hypotheses,
+                search_results,
+                scorecards,
+                synthesis,
+                audit,
+                client,
             )
         except SubAgentError as e:
             print(f"ERROR: {e}")
@@ -341,13 +356,14 @@ def execute(input_file: str, output: str, runs: int) -> int:
     print()
     totals = usage_data["totals"]
     cost = totals.get("estimated_cost_usd", 0)
-    print(f"Usage: {totals['api_calls']} API calls, "
-          f"{totals['input_tokens']:,} input + {totals['output_tokens']:,} output "
-          f"= {totals['total_tokens']:,} tokens")
+    print(
+        f"Usage: {totals['api_calls']} API calls, "
+        f"{totals['input_tokens']:,} input + {totals['output_tokens']:,} output "
+        f"= {totals['total_tokens']:,} tokens"
+    )
     print(f"  Estimated cost: ${cost:.4f}")
     if totals["web_search_requests"]:
-        print(f"  Web: {totals['web_search_requests']} searches, "
-              f"{totals['web_fetch_requests']} fetches")
+        print(f"  Web: {totals['web_search_requests']} searches, {totals['web_fetch_requests']} fetches")
     print(f"  Details: {usage_path}")
 
     return 0

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -109,6 +109,7 @@ def _parse_and_clarify(
         clarified = client.call_sub_agent(
             prompt_path=clarifier_prompt,
             user_input=raw_input,
+            output_schema="clarified-input.schema.json",
         )
     except SubAgentError as e:
         print(f"ERROR: {e}")

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -14,6 +14,7 @@ from diogenes.pipeline import (
     step2_generate_hypotheses,
     step3_design_searches,
     step4_execute_searches,
+    step5_score_sources,
     write_step_output,
 )
 from diogenes.schema_validator import ValidationError, parse_input_file, validate_research_input
@@ -260,10 +261,21 @@ def execute(input_file: str, output: str, runs: int) -> int:
         results_path = write_step_output(run_dir, "search-results.json", search_results)
         print(f"  Wrote: {results_path}")
 
-        # Steps 5-11: not yet implemented
+        # Step 5: Score each source
+        print("Step 5: Scoring sources...")
+        try:
+            scorecards = step5_score_sources(research_input, search_results, client)
+        except SubAgentError as e:
+            print(f"ERROR: {e}")
+            return 1
+
+        scorecards_path = write_step_output(run_dir, "source-scorecards.json", scorecards)
+        print(f"  Wrote: {scorecards_path}")
+
+        # Steps 6-11: not yet implemented
         print()
-        print(f"  Pipeline paused after step 4 for {run_dir.name}.")
-        print("  Steps 5-11 not yet implemented.")
+        print(f"  Pipeline paused after step 5 for {run_dir.name}.")
+        print("  Steps 6-11 not yet implemented.")
 
     # Write usage report
     usage_data = client.usage.to_dict()

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -17,7 +17,7 @@ from diogenes.pipeline import (
     write_step_output,
 )
 from diogenes.schema_validator import ValidationError, parse_input_file, validate_research_input
-from diogenes.search_providers import BraveSearchProvider, GoogleSearchProvider
+from diogenes.search_providers import BraveSearchProvider, GoogleSearchProvider, SerperSearchProvider
 
 # Resolve prompts directory relative to repo root
 _REPO_ROOT = Path(__file__).parent.parent.parent.parent
@@ -139,12 +139,19 @@ def _parse_and_clarify(
     return research_input
 
 
-def _create_search_provider() -> BraveSearchProvider | GoogleSearchProvider | None:
+def _create_search_provider() -> SerperSearchProvider | BraveSearchProvider | GoogleSearchProvider | None:
     """Create a search provider from config.
 
     Returns the provider, or None on error (after printing).
     """
     cfg = load_config()
+
+    if cfg.search_provider == "serper":
+        if not cfg.serper_api_key:
+            print("ERROR: Serper.dev requires SERPER_API_KEY in .dorc or .env")
+            print("  Sign up free at https://serper.dev/ (2,500 searches/month)")
+            return None
+        return SerperSearchProvider(cfg.serper_api_key)
 
     if cfg.search_provider == "brave":
         if not cfg.brave_api_key:
@@ -266,9 +273,11 @@ def execute(input_file: str, output: str, runs: int) -> int:
     print(f"Research complete. Output: {group_dir}")
     print()
     totals = usage_data["totals"]
+    cost = totals.get("estimated_cost_usd", 0)
     print(f"Usage: {totals['api_calls']} API calls, "
           f"{totals['input_tokens']:,} input + {totals['output_tokens']:,} output "
           f"= {totals['total_tokens']:,} tokens")
+    print(f"  Estimated cost: ${cost:.4f}")
     if totals["web_search_requests"]:
         print(f"  Web: {totals['web_search_requests']} searches, "
               f"{totals['web_fetch_requests']} fetches")

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -9,7 +9,12 @@ from pathlib import Path
 from typing import Any
 
 from diogenes.api_client import APIClient, SubAgentError
-from diogenes.pipeline import step2_generate_hypotheses, step3_design_searches, write_step_output
+from diogenes.pipeline import (
+    step2_generate_hypotheses,
+    step3_design_searches,
+    step4_execute_searches,
+    write_step_output,
+)
 from diogenes.schema_validator import ValidationError, parse_input_file, validate_research_input
 
 # Resolve prompts directory relative to repo root
@@ -205,10 +210,21 @@ def execute(input_file: str, output: str, runs: int) -> int:
         plan_path = write_step_output(run_dir, "search-plans.json", search_plans)
         print(f"  Wrote: {plan_path}")
 
-        # Steps 4-11: not yet implemented
+        # Step 4: Execute searches and log
+        print("Step 4: Executing searches...")
+        try:
+            search_results = step4_execute_searches(research_input, search_plans, client)
+        except SubAgentError as e:
+            print(f"ERROR: {e}")
+            return 1
+
+        results_path = write_step_output(run_dir, "search-results.json", search_results)
+        print(f"  Wrote: {results_path}")
+
+        # Steps 5-11: not yet implemented
         print()
-        print(f"  Pipeline paused after step 3 for {run_dir.name}.")
-        print("  Steps 4-11 not yet implemented.")
+        print(f"  Pipeline paused after step 4 for {run_dir.name}.")
+        print("  Steps 5-11 not yet implemented.")
 
     print()
     print(f"Research complete. Output: {group_dir}")

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -15,6 +15,10 @@ from diogenes.pipeline import (
     step3_design_searches,
     step4_execute_searches,
     step5_score_sources,
+    step9_self_audit,
+    step10_report,
+    step11_archive,
+    steps678_synthesize_and_assess,
     write_step_output,
 )
 from diogenes.schema_validator import ValidationError, parse_input_file, validate_research_input
@@ -272,10 +276,61 @@ def execute(input_file: str, output: str, runs: int) -> int:
         scorecards_path = write_step_output(run_dir, "source-scorecards.json", scorecards)
         print(f"  Wrote: {scorecards_path}")
 
-        # Steps 6-11: not yet implemented
-        print()
-        print(f"  Pipeline paused after step 5 for {run_dir.name}.")
-        print("  Steps 6-11 not yet implemented.")
+        # Steps 6+7+8: Synthesize, assess, identify gaps
+        print("Steps 6-8: Synthesizing evidence and assessing...")
+        try:
+            synthesis = steps678_synthesize_and_assess(
+                research_input, hypotheses, scorecards, client,
+            )
+        except SubAgentError as e:
+            print(f"ERROR: {e}")
+            return 1
+
+        synthesis_path = write_step_output(run_dir, "synthesis.json", synthesis)
+        print(f"  Wrote: {synthesis_path}")
+
+        # Step 9: Self-audit, source-back verification, reading list
+        print("Step 9: Self-audit and verification...")
+        try:
+            audit = step9_self_audit(
+                research_input, hypotheses, search_results, scorecards,
+                synthesis, client,
+            )
+        except SubAgentError as e:
+            print(f"ERROR: {e}")
+            return 1
+
+        audit_path = write_step_output(run_dir, "self-audit.json", audit)
+        print(f"  Wrote: {audit_path}")
+
+        # Step 10: Final report
+        print("Step 10: Assembling final reports...")
+        try:
+            reports = step10_report(
+                research_input, hypotheses, search_results, scorecards,
+                synthesis, audit, client,
+            )
+        except SubAgentError as e:
+            print(f"ERROR: {e}")
+            return 1
+
+        reports_path = write_step_output(run_dir, "reports.json", reports)
+        print(f"  Wrote: {reports_path}")
+
+        # Step 11: Archive for temporal revisitation
+        print("Step 11: Archiving...")
+        all_outputs = {
+            "research_input": research_input,
+            "hypotheses": hypotheses,
+            "search_plans": search_plans,
+            "search_results": search_results,
+            "scorecards": scorecards,
+            "synthesis": synthesis,
+            "self_audit": audit,
+            "reports": reports,
+        }
+        archive_path = step11_archive(run_dir, all_outputs)
+        print(f"  Wrote: {archive_path}")
 
     # Write usage report
     usage_data = client.usage.to_dict()

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -226,7 +226,20 @@ def execute(input_file: str, output: str, runs: int) -> int:
         print(f"  Pipeline paused after step 4 for {run_dir.name}.")
         print("  Steps 5-11 not yet implemented.")
 
+    # Write usage report
+    usage_data = client.usage.to_dict()
+    usage_path = write_step_output(group_dir, "usage.json", usage_data)
+
     print()
     print(f"Research complete. Output: {group_dir}")
+    print()
+    totals = usage_data["totals"]
+    print(f"Usage: {totals['api_calls']} API calls, "
+          f"{totals['input_tokens']:,} input + {totals['output_tokens']:,} output "
+          f"= {totals['total_tokens']:,} tokens")
+    if totals["web_search_requests"]:
+        print(f"  Web: {totals['web_search_requests']} searches, "
+              f"{totals['web_fetch_requests']} fetches")
+    print(f"  Details: {usage_path}")
 
     return 0

--- a/src/diogenes/config.py
+++ b/src/diogenes/config.py
@@ -74,8 +74,8 @@ def load_config() -> DioConfig:
     Priority (highest to lowest):
 
     1. ``ANTHROPIC_API_KEY`` environment variable
-    2. ``api.key`` in ``./.dorc`` (project-level config, current directory)
-    3. ``api.key`` in ``~/.dorc`` (user-level config)
+    2. ``api.key`` in ``./.diorc`` (project-level config, current directory)
+    3. ``api.key`` in ``~/.diorc`` (user-level config)
     4. ``ANTHROPIC_API_KEY`` from ``.env`` file in the current directory (loaded with a warning)
 
     Returns:
@@ -85,8 +85,8 @@ def load_config() -> DioConfig:
         ConfigError: If no API key can be resolved from any source.
 
     """
-    user_toml = _load_toml(Path.home() / ".dorc")
-    project_toml = _load_toml(Path.cwd() / ".dorc")
+    user_toml = _load_toml(Path.home() / ".diorc")
+    project_toml = _load_toml(Path.cwd() / ".diorc")
 
     # Merge: project-level overrides user-level, section by section
     toml: dict[str, Any] = {**user_toml}
@@ -106,7 +106,7 @@ def load_config() -> DioConfig:
     # Priority 1: environment variable
     api_key: str = os.environ.get("ANTHROPIC_API_KEY", "")
 
-    # Priority 2 & 3: config file key (project or user .dorc)
+    # Priority 2 & 3: config file key (project or user .diorc)
     if not api_key:
         api_key = str(api_sect.get("key", ""))
 
@@ -121,7 +121,7 @@ def load_config() -> DioConfig:
     if not api_key:
         msg = (
             "No API key found. "
-            "Set ANTHROPIC_API_KEY, add api.key to .dorc, or create a .env file."
+            "Set ANTHROPIC_API_KEY, add api.key to .diorc, or create a .env file."
         )
         raise ConfigError(msg)
 
@@ -129,7 +129,7 @@ def load_config() -> DioConfig:
     search_sect = _section(toml, "search")
     search_provider = str(search_sect.get("provider", "serper"))
 
-    # Search API keys: env var > .dorc > .env
+    # Search API keys: env var > .diorc > .env
     dotenv_vars: dict[str, str] = {}
     if load_dotenv:
         dotenv_name = str(env_sect.get("dotenv_path", ".env"))

--- a/src/diogenes/config.py
+++ b/src/diogenes/config.py
@@ -127,7 +127,7 @@ def load_config() -> DioConfig:
 
     # Search provider configuration
     search_sect = _section(toml, "search")
-    search_provider = str(search_sect.get("provider", "brave"))
+    search_provider = str(search_sect.get("provider", "serper"))
 
     # Search API keys: env var > .dorc > .env
     dotenv_vars: dict[str, str] = {}

--- a/src/diogenes/config.py
+++ b/src/diogenes/config.py
@@ -24,6 +24,10 @@ class DioConfig:
     api_key: str
     base_url: str = DEFAULT_BASE_URL
     model: str = DEFAULT_MODEL
+    search_provider: str = "brave"
+    brave_api_key: str = ""
+    google_api_key: str = ""
+    google_search_engine_id: str = ""
 
 
 def _parse_dotenv(path: Path) -> dict[str, str]:
@@ -120,4 +124,40 @@ def load_config() -> DioConfig:
         )
         raise ConfigError(msg)
 
-    return DioConfig(api_key=api_key, base_url=base_url, model=model)
+    # Search provider configuration
+    search_sect = _section(toml, "search")
+    search_provider = str(search_sect.get("provider", "brave"))
+
+    # Search API keys: env var > .dorc > .env
+    dotenv_vars: dict[str, str] = {}
+    if load_dotenv:
+        dotenv_name = str(env_sect.get("dotenv_path", ".env"))
+        dotenv_path = Path(dotenv_name)
+        if dotenv_path.exists():
+            dotenv_vars = _parse_dotenv(dotenv_path)
+
+    brave_api_key = (
+        os.environ.get("BRAVE_API_KEY", "")
+        or str(search_sect.get("brave_api_key", ""))
+        or dotenv_vars.get("BRAVE_API_KEY", "")
+    )
+    google_api_key = (
+        os.environ.get("GOOGLE_API_KEY", "")
+        or str(search_sect.get("google_api_key", ""))
+        or dotenv_vars.get("GOOGLE_API_KEY", "")
+    )
+    google_search_engine_id = (
+        os.environ.get("GOOGLE_SEARCH_ENGINE_ID", "")
+        or str(search_sect.get("google_search_engine_id", ""))
+        or dotenv_vars.get("GOOGLE_SEARCH_ENGINE_ID", "")
+    )
+
+    return DioConfig(
+        api_key=api_key,
+        base_url=base_url,
+        model=model,
+        search_provider=search_provider,
+        brave_api_key=brave_api_key,
+        google_api_key=google_api_key,
+        google_search_engine_id=google_search_engine_id,
+    )

--- a/src/diogenes/config.py
+++ b/src/diogenes/config.py
@@ -24,7 +24,8 @@ class DioConfig:
     api_key: str
     base_url: str = DEFAULT_BASE_URL
     model: str = DEFAULT_MODEL
-    search_provider: str = "brave"
+    search_provider: str = "serper"
+    serper_api_key: str = ""
     brave_api_key: str = ""
     google_api_key: str = ""
     google_search_engine_id: str = ""
@@ -136,6 +137,11 @@ def load_config() -> DioConfig:
         if dotenv_path.exists():
             dotenv_vars = _parse_dotenv(dotenv_path)
 
+    serper_api_key = (
+        os.environ.get("SERPER_API_KEY", "")
+        or str(search_sect.get("serper_api_key", ""))
+        or dotenv_vars.get("SERPER_API_KEY", "")
+    )
     brave_api_key = (
         os.environ.get("BRAVE_API_KEY", "")
         or str(search_sect.get("brave_api_key", ""))
@@ -157,6 +163,7 @@ def load_config() -> DioConfig:
         base_url=base_url,
         model=model,
         search_provider=search_provider,
+        serper_api_key=serper_api_key,
         brave_api_key=brave_api_key,
         google_api_key=google_api_key,
         google_search_engine_id=google_search_engine_id,

--- a/src/diogenes/config.py
+++ b/src/diogenes/config.py
@@ -119,10 +119,7 @@ def load_config() -> DioConfig:
             api_key = _parse_dotenv(dotenv_path).get("ANTHROPIC_API_KEY", "")
 
     if not api_key:
-        msg = (
-            "No API key found. "
-            "Set ANTHROPIC_API_KEY, add api.key to .diorc, or create a .env file."
-        )
+        msg = "No API key found. Set ANTHROPIC_API_KEY, add api.key to .diorc, or create a .env file."
         raise ConfigError(msg)
 
     # Search provider configuration

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -207,13 +207,17 @@ def step4_execute_searches(
 
         # Phase 4B: LLM scores relevance in batches
         all_scored = _score_results_batched(
-            item, executions, client, scorer_prompt,
+            item,
+            executions,
+            client,
+            scorer_prompt,
         )
 
         # Phase 4C: Python filters and deduplicates
         selected, rejected = _filter_and_deduplicate(all_scored)
-        print(f"    {len(selected)} sources selected (score >= {_RELEVANCE_THRESHOLD}), "
-              f"{len(rejected)} below threshold")
+        print(
+            f"    {len(selected)} sources selected (score >= {_RELEVANCE_THRESHOLD}), {len(rejected)} below threshold"
+        )
 
         results[item_id] = {
             "id": item_id,
@@ -250,15 +254,12 @@ def _score_results_batched(
 
         # Process in batches
         for i in range(0, len(results_list), _RELEVANCE_BATCH_SIZE):
-            batch = results_list[i:i + _RELEVANCE_BATCH_SIZE]
+            batch = results_list[i : i + _RELEVANCE_BATCH_SIZE]
             batch_input = {
                 "item_id": item["id"],
                 "clarified_text": item.get("clarified_text", ""),
                 "search_intent": search_intent,
-                "results": [
-                    {"url": r.url, "title": r.title, "snippet": r.snippet}
-                    for r in batch
-                ],
+                "results": [{"url": r.url, "title": r.title, "snippet": r.snippet} for r in batch],
             }
 
             response = client.call_sub_agent(
@@ -359,17 +360,19 @@ def step5_score_sources(
             url = source.get("url", "")
             print(f"    Fetching {url[:60]}...")
             content = fetch_page_extract(url)
-            enriched_sources.append({
-                "url": url,
-                "title": source.get("title", ""),
-                "snippet": source.get("snippet", ""),
-                "content_extract": content,
-            })
+            enriched_sources.append(
+                {
+                    "url": url,
+                    "title": source.get("title", ""),
+                    "snippet": source.get("snippet", ""),
+                    "content_extract": content,
+                }
+            )
 
         # Phase B: LLM scores in batches
         all_scorecards: list[dict[str, Any]] = []
         for i in range(0, len(enriched_sources), _SCORING_BATCH_SIZE):
-            batch = enriched_sources[i:i + _SCORING_BATCH_SIZE]
+            batch = enriched_sources[i : i + _SCORING_BATCH_SIZE]
             batch_input = {
                 "item_id": item_id,
                 "clarified_text": item.get("clarified_text", ""),
@@ -562,7 +565,8 @@ def step10_report(
 
         results[item_id] = response
         verdict = response.get("assessment_summary", {}).get(
-            "verdict", response.get("assessment_summary", {}).get("answer", ""),
+            "verdict",
+            response.get("assessment_summary", {}).get("answer", ""),
         )
         print(f"    {item_id}: {verdict[:80]}")
 

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -153,17 +153,22 @@ def step3_design_searches(
     return results
 
 
+_RELEVANCE_BATCH_SIZE = 5
+_RELEVANCE_THRESHOLD = 5
+
+
 def step4_execute_searches(
     research_input: dict[str, Any],
     search_plans: dict[str, Any],
     client: APIClient,
     search_provider: SearchProvider,
 ) -> dict[str, Any]:
-    """Execute search plans and select results for each claim and query.
+    """Execute search plans and score results for each claim and query.
 
-    Part A: Python executes searches via the search provider (no LLM tokens).
-    Part B: LLM result-selector evaluates search results and selects sources
-    for the evidence base (uses only titles, URLs, snippets — not full pages).
+    Three phases:
+    - 4A (Python): Execute searches via search provider. Zero LLM tokens.
+    - 4B (LLM, batched): Score relevance 0-10 in batches of 5. Tiny calls.
+    - 4C (Python): Sort by score, filter by threshold, deduplicate.
 
     Args:
         research_input: The clarified research input (output of step 1).
@@ -178,7 +183,7 @@ def step4_execute_searches(
         SubAgentError: If a sub-agent call fails.
 
     """
-    prompt_path = _PROMPTS_DIR / "result-selector.md"
+    scorer_prompt = _PROMPTS_DIR / "relevance-scorer.md"
     results: dict[str, Any] = {}
 
     items = [*research_input.get("claims", []), *research_input.get("queries", [])]
@@ -189,32 +194,114 @@ def step4_execute_searches(
         searches = item_plan.get("searches", [])
         print(f"  Executing {len(searches)} searches for {item_id} via {search_provider.name}...")
 
-        # Part A: Python executes searches
+        # Phase 4A: Python executes searches
         executions = execute_search_plan(item_plan, search_provider)
         total_results = sum(len(e.results) for e in executions)
-        print(f"    {item_id}: {total_results} raw results from {len(executions)} searches")
+        print(f"    {total_results} raw results from {len(executions)} searches")
 
-        # Part B: LLM selects relevant results
-        agent_input = {
-            "item": item,
-            "search_plan": item_plan,
-            "search_executions": [e.to_dict() for e in executions],
-        }
-
-        response = client.call_sub_agent(
-            prompt_path=prompt_path,
-            user_input=agent_input,
-            output_schema="search-results.schema.json",
-            max_tokens=16384,
+        # Phase 4B: LLM scores relevance in batches
+        all_scored = _score_results_batched(
+            item, executions, client, scorer_prompt,
         )
 
-        results[item_id] = response
-        summary = response.get("summary", {})
-        selected = summary.get("total_selected", 0)
-        rejected = summary.get("total_rejected", 0)
-        print(f"    {item_id}: {selected} sources selected, {rejected} rejected")
+        # Phase 4C: Python filters and deduplicates
+        selected, rejected = _filter_and_deduplicate(all_scored)
+        print(f"    {len(selected)} sources selected (score >= {_RELEVANCE_THRESHOLD}), "
+              f"{len(rejected)} below threshold")
+
+        results[item_id] = {
+            "id": item_id,
+            "searches_executed": [e.to_dict() for e in executions],
+            "selected_sources": selected,
+            "rejected_sources": rejected,
+            "summary": {
+                "total_searches": len(executions),
+                "total_results_found": total_results,
+                "total_selected": len(selected),
+                "total_rejected": len(rejected),
+                "relevance_threshold": _RELEVANCE_THRESHOLD,
+            },
+        }
 
     return results
+
+
+def _score_results_batched(
+    item: dict[str, Any],
+    executions: list[Any],
+    client: APIClient,
+    scorer_prompt: Path,
+) -> list[dict[str, Any]]:
+    """Score all search results in batches via the relevance-scorer sub-agent."""
+    all_scored: list[dict[str, Any]] = []
+
+    for execution in executions:
+        results_list = execution.results
+        search_id = execution.search_id
+
+        # Determine search intent from the execution
+        search_intent = f"Search {search_id}: {' '.join(execution.terms[:3])}"
+
+        # Process in batches
+        for i in range(0, len(results_list), _RELEVANCE_BATCH_SIZE):
+            batch = results_list[i:i + _RELEVANCE_BATCH_SIZE]
+            batch_input = {
+                "item_id": item["id"],
+                "clarified_text": item.get("clarified_text", ""),
+                "search_intent": search_intent,
+                "results": [
+                    {"url": r.url, "title": r.title, "snippet": r.snippet}
+                    for r in batch
+                ],
+            }
+
+            response = client.call_sub_agent(
+                prompt_path=scorer_prompt,
+                user_input=batch_input,
+                output_schema="relevance-scores.schema.json",
+                include_guidelines=False,
+            )
+
+            # Enrich scores with metadata from original results
+            for score_entry in response.get("scores", []):
+                score_entry["search_id"] = search_id
+                # Find the original result for title/snippet
+                for r in batch:
+                    if r.url == score_entry["url"]:
+                        score_entry["title"] = r.title
+                        score_entry["snippet"] = r.snippet
+                        score_entry["page_age"] = r.page_age
+                        break
+                all_scored.append(score_entry)
+
+    return all_scored
+
+
+def _filter_and_deduplicate(
+    scored_results: list[dict[str, Any]],
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Filter by relevance threshold and deduplicate by URL."""
+    # Sort by score descending
+    scored_results.sort(key=lambda x: x.get("relevance_score", 0), reverse=True)
+
+    seen_urls: set[str] = set()
+    selected: list[dict[str, Any]] = []
+    rejected: list[dict[str, Any]] = []
+
+    for result in scored_results:
+        url = result.get("url", "")
+        score = result.get("relevance_score", 0)
+
+        if url in seen_urls:
+            continue
+        seen_urls.add(url)
+
+        if score >= _RELEVANCE_THRESHOLD:
+            selected.append(result)
+        else:
+            rejected.append(result)
+
+    return selected, rejected
 
 
 def write_step_output(

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -205,6 +205,7 @@ def step4_execute_searches(
             prompt_path=prompt_path,
             user_input=agent_input,
             output_schema="search-results.schema.json",
+            max_tokens=16384,
         )
 
         results[item_id] = response

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -1,0 +1,118 @@
+"""Research pipeline steps.
+
+Each step function takes the accumulated research state and an API client,
+calls the appropriate sub-agent for each item, and returns the enriched state.
+The coordinator (run command) calls these in sequence.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from diogenes.api_client import APIClient
+
+_PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts" / "sub-agents"
+
+
+def step2_generate_hypotheses(
+    research_input: dict[str, Any],
+    client: APIClient,
+) -> dict[str, Any]:
+    """Generate competing hypotheses for each claim and query.
+
+    Loops over claims and queries from the clarified input. For each item,
+    passes the item and axioms to the hypothesis-generator sub-agent. Enriches
+    the research state with hypothesis data per item.
+
+    Args:
+        research_input: The clarified research input (output of step 1).
+        client: Configured API client with common guidelines loaded.
+
+    Returns:
+        A dict mapping item IDs to their hypothesis results.
+
+    Raises:
+        SubAgentError: If a sub-agent call fails.
+
+    """
+    prompt_path = _PROMPTS_DIR / "hypothesis-generator.md"
+    axioms = research_input.get("axioms", [])
+    results: dict[str, Any] = {}
+
+    claims = research_input.get("claims", [])
+    queries = research_input.get("queries", [])
+
+    for claim in claims:
+        item_id = claim["id"]
+        print(f"  Generating hypotheses for {item_id}: {claim['clarified_text'][:60]}...")
+
+        agent_input = {
+            "mode": "claim",
+            "item": claim,
+            "axioms": axioms,
+        }
+
+        response = client.call_sub_agent(
+            prompt_path=prompt_path,
+            user_input=agent_input,
+        )
+
+        results[item_id] = response
+        _print_hypothesis_summary(item_id, response)
+
+    for query in queries:
+        item_id = query["id"]
+        print(f"  Generating hypotheses for {item_id}: {query['clarified_text'][:60]}...")
+
+        agent_input = {
+            "mode": "query",
+            "item": query,
+            "axioms": axioms,
+        }
+
+        response = client.call_sub_agent(
+            prompt_path=prompt_path,
+            user_input=agent_input,
+        )
+
+        results[item_id] = response
+        _print_hypothesis_summary(item_id, response)
+
+    return results
+
+
+def _print_hypothesis_summary(item_id: str, response: dict[str, Any]) -> None:
+    """Print a brief summary of hypothesis generation results."""
+    approach = response.get("approach", "unknown")
+    if approach == "hypotheses":
+        count = len(response.get("hypotheses", []))
+        print(f"    {item_id}: {count} hypotheses generated")
+    elif approach == "open-ended":
+        count = len(response.get("search_themes", []))
+        print(f"    {item_id}: open-ended, {count} search themes")
+    else:
+        print(f"    {item_id}: approach={approach}")
+
+
+def write_step_output(
+    output_dir: Path,
+    filename: str,
+    data: dict[str, Any] | list[Any],
+) -> Path:
+    """Write a pipeline step's output to a JSON file.
+
+    Args:
+        output_dir: Directory to write to.
+        filename: Name of the JSON file.
+        data: The data to serialize.
+
+    Returns:
+        Path to the written file.
+
+    """
+    path = output_dir / filename
+    path.write_text(json.dumps(data, indent=2) + "\n")
+    return path

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -99,6 +99,58 @@ def _print_hypothesis_summary(item_id: str, response: dict[str, Any]) -> None:
         print(f"    {item_id}: approach={approach}")
 
 
+def step3_design_searches(
+    research_input: dict[str, Any],
+    hypotheses: dict[str, Any],
+    client: APIClient,
+) -> dict[str, Any]:
+    """Design discriminating searches for each claim and query.
+
+    For each item, passes the clarified item (with vocabulary) and its
+    hypotheses to the search-designer sub-agent to produce a concrete
+    search plan.
+
+    Args:
+        research_input: The clarified research input (output of step 1).
+        hypotheses: The hypothesis results keyed by item ID (output of step 2).
+        client: Configured API client with common guidelines loaded.
+
+    Returns:
+        A dict mapping item IDs to their search plan results.
+
+    Raises:
+        SubAgentError: If a sub-agent call fails.
+
+    """
+    prompt_path = _PROMPTS_DIR / "search-designer.md"
+    results: dict[str, Any] = {}
+
+    items = [*research_input.get("claims", []), *research_input.get("queries", [])]
+
+    for item in items:
+        item_id = item["id"]
+        item_hypotheses = hypotheses.get(item_id, {})
+        print(f"  Designing searches for {item_id}...")
+
+        agent_input = {
+            "item": item,
+            "hypotheses": item_hypotheses,
+        }
+
+        response = client.call_sub_agent(
+            prompt_path=prompt_path,
+            user_input=agent_input,
+            output_schema="search-plan.schema.json",
+        )
+
+        results[item_id] = response
+        search_count = len(response.get("searches", []))
+        approach = response.get("approach", "unknown")
+        print(f"    {item_id}: {search_count} searches planned ({approach})")
+
+    return results
+
+
 def write_step_output(
     output_dir: Path,
     filename: str,

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -8,6 +8,7 @@ The coordinator (run command) calls these in sequence.
 from __future__ import annotations
 
 import json
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -382,6 +383,208 @@ def step5_score_sources(
         results[item_id] = {"id": item_id, "scorecards": all_scorecards}
 
     return results
+
+
+def steps678_synthesize_and_assess(
+    research_input: dict[str, Any],
+    hypotheses: dict[str, Any],
+    scorecards: dict[str, Any],
+    client: APIClient,
+) -> dict[str, Any]:
+    """Synthesize evidence, assess, and identify gaps (Steps 6+7+8 combined).
+
+    One LLM call per item. These steps are tightly coupled — synthesis informs
+    assessment, assessment reveals gaps.
+
+    Args:
+        research_input: The clarified research input (output of step 1).
+        hypotheses: Hypothesis results keyed by item ID (output of step 2).
+        scorecards: Source scorecards keyed by item ID (output of step 5).
+        client: Configured API client with common guidelines loaded.
+
+    Returns:
+        A dict mapping item IDs to their synthesis/assessment/gaps results.
+
+    """
+    prompt_path = _PROMPTS_DIR / "evidence-synthesizer.md"
+    results: dict[str, Any] = {}
+
+    items = [*research_input.get("claims", []), *research_input.get("queries", [])]
+
+    for item in items:
+        item_id = item["id"]
+        item_hypotheses = hypotheses.get(item_id, {})
+        item_scorecards = scorecards.get(item_id, {}).get("scorecards", [])
+        print(f"  Synthesizing {item_id} ({len(item_scorecards)} sources)...")
+
+        agent_input = {
+            "item": item,
+            "hypotheses": item_hypotheses,
+            "scorecards": item_scorecards,
+        }
+
+        response = client.call_sub_agent(
+            prompt_path=prompt_path,
+            user_input=agent_input,
+            output_schema="synthesis.schema.json",
+            max_tokens=16384,
+        )
+
+        results[item_id] = response
+        assessment = response.get("assessment", {})
+        verdict = assessment.get("verdict", assessment.get("answer", ""))
+        print(f"    {item_id}: {verdict[:80]}")
+
+    return results
+
+
+def step9_self_audit(
+    research_input: dict[str, Any],
+    hypotheses: dict[str, Any],
+    search_results: dict[str, Any],
+    scorecards: dict[str, Any],
+    synthesis: dict[str, Any],
+    client: APIClient,
+) -> dict[str, Any]:
+    """Self-audit, source-back verification, and reading list (Steps 9+9b+9c).
+
+    One LLM call per item. Reviews the entire research chain.
+
+    Args:
+        research_input: Clarified research input (step 1).
+        hypotheses: Hypothesis results (step 2).
+        search_results: Search results (step 4).
+        scorecards: Source scorecards (step 5).
+        synthesis: Synthesis/assessment/gaps (steps 6-8).
+        client: Configured API client.
+
+    Returns:
+        A dict mapping item IDs to their audit results.
+
+    """
+    prompt_path = _PROMPTS_DIR / "self-auditor.md"
+    results: dict[str, Any] = {}
+
+    items = [*research_input.get("claims", []), *research_input.get("queries", [])]
+
+    for item in items:
+        item_id = item["id"]
+        print(f"  Auditing {item_id}...")
+
+        agent_input = {
+            "item": item,
+            "hypotheses": hypotheses.get(item_id, {}),
+            "search_results": search_results.get(item_id, {}),
+            "scorecards": scorecards.get(item_id, {}).get("scorecards", []),
+            "synthesis": synthesis.get(item_id, {}),
+        }
+
+        response = client.call_sub_agent(
+            prompt_path=prompt_path,
+            user_input=agent_input,
+            output_schema="self-audit.schema.json",
+            max_tokens=16384,
+        )
+
+        results[item_id] = response
+        audit = response.get("process_audit", {})
+        ratings = [
+            audit.get("eligibility_criteria", {}).get("rating", "?"),
+            audit.get("search_comprehensiveness", {}).get("rating", "?"),
+            audit.get("evaluation_consistency", {}).get("rating", "?"),
+            audit.get("synthesis_fairness", {}).get("rating", "?"),
+        ]
+        print(f"    {item_id}: audit [{', '.join(ratings)}]")
+
+    return results
+
+
+def step10_report(
+    research_input: dict[str, Any],
+    hypotheses: dict[str, Any],
+    search_results: dict[str, Any],
+    scorecards: dict[str, Any],
+    synthesis: dict[str, Any],
+    audit: dict[str, Any],
+    client: APIClient,
+) -> dict[str, Any]:
+    """Assemble the final research report (Step 10).
+
+    One LLM call per item. Pulls together all prior steps into a structured report.
+
+    Args:
+        research_input: Clarified research input (step 1).
+        hypotheses: Hypothesis results (step 2).
+        search_results: Search results (step 4).
+        scorecards: Source scorecards (step 5).
+        synthesis: Synthesis/assessment/gaps (steps 6-8).
+        audit: Self-audit results (step 9).
+        client: Configured API client.
+
+    Returns:
+        A dict mapping item IDs to their final reports.
+
+    """
+    prompt_path = _PROMPTS_DIR / "report-assembler.md"
+    results: dict[str, Any] = {}
+
+    claims = research_input.get("claims", [])
+    queries = research_input.get("queries", [])
+    items = [*claims, *queries]
+
+    for item in items:
+        item_id = item["id"]
+        mode = "claim" if item_id.startswith("C") else "query"
+        print(f"  Assembling report for {item_id} ({mode})...")
+
+        agent_input = {
+            "item": item,
+            "hypotheses": hypotheses.get(item_id, {}),
+            "search_results": search_results.get(item_id, {}),
+            "scorecards": scorecards.get(item_id, {}).get("scorecards", []),
+            "synthesis": synthesis.get(item_id, {}),
+            "self_audit": audit.get(item_id, {}),
+        }
+
+        response = client.call_sub_agent(
+            prompt_path=prompt_path,
+            user_input=agent_input,
+            output_schema="report.schema.json",
+            max_tokens=16384,
+        )
+
+        results[item_id] = response
+        verdict = response.get("assessment_summary", {}).get(
+            "verdict", response.get("assessment_summary", {}).get("answer", ""),
+        )
+        print(f"    {item_id}: {verdict[:80]}")
+
+    return results
+
+
+def step11_archive(output_dir: Path, all_outputs: dict[str, Any]) -> Path:
+    """Archive all research outputs for temporal revisitation (Step 11).
+
+    Pure Python — no LLM call. Writes a single archive JSON with all
+    pipeline outputs and metadata.
+
+    Args:
+        output_dir: The run directory to write to.
+        all_outputs: Dict containing all pipeline step outputs.
+
+    Returns:
+        Path to the archive file.
+
+    """
+    archive = {
+        "archived_at": datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "pipeline_version": "0.1.0",
+        **all_outputs,
+    }
+
+    path = output_dir / "archive.json"
+    path.write_text(json.dumps(archive, indent=2) + "\n")
+    return path
 
 
 def write_step_output(

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -304,7 +304,7 @@ def _filter_and_deduplicate(
     return selected, rejected
 
 
-_SCORING_BATCH_SIZE = 2
+_SCORING_BATCH_SIZE = 1
 _MAX_SOURCES_TO_SCORE = 15
 
 

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -304,7 +304,8 @@ def _filter_and_deduplicate(
     return selected, rejected
 
 
-_SCORING_BATCH_SIZE = 3
+_SCORING_BATCH_SIZE = 2
+_MAX_SOURCES_TO_SCORE = 15
 
 
 def step5_score_sources(
@@ -337,8 +338,13 @@ def step5_score_sources(
     for item in items:
         item_id = item["id"]
         item_results = search_results.get(item_id, {})
-        selected = item_results.get("selected_sources", [])
-        print(f"  Scoring {len(selected)} sources for {item_id}...")
+        all_selected = item_results.get("selected_sources", [])
+        # Cap at top N by relevance score to control cost
+        selected = all_selected[:_MAX_SOURCES_TO_SCORE]
+        if len(all_selected) > _MAX_SOURCES_TO_SCORE:
+            print(f"  Scoring top {len(selected)} of {len(all_selected)} sources for {item_id}...")
+        else:
+            print(f"  Scoring {len(selected)} sources for {item_id}...")
 
         # Phase A: Python fetches page content
         enriched_sources = []
@@ -367,6 +373,7 @@ def step5_score_sources(
                 prompt_path=scorer_prompt,
                 user_input=batch_input,
                 output_schema="source-scorecards.schema.json",
+                max_tokens=8192,
             )
 
             all_scorecards.extend(response.get("scorecards", []))

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -19,6 +19,10 @@ if TYPE_CHECKING:
 
 _PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts" / "sub-agents"
 
+# Model overrides for cost optimization. Set to None to use the client default.
+# Scoring steps are classification tasks that can use cheaper models.
+_SCORING_MODEL: str | None = "claude-haiku-4-5-20251001"
+
 
 def step2_generate_hypotheses(
     research_input: dict[str, Any],
@@ -261,6 +265,7 @@ def _score_results_batched(
                 user_input=batch_input,
                 output_schema="relevance-scores.schema.json",
                 include_guidelines=False,
+                model=_SCORING_MODEL,
             )
 
             # Enrich scores with metadata from original results
@@ -375,6 +380,7 @@ def step5_score_sources(
                 user_input=batch_input,
                 output_schema="source-scorecards.schema.json",
                 max_tokens=8192,
+                model=_SCORING_MODEL,
             )
 
             all_scorecards.extend(response.get("scorecards", []))

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -11,6 +11,8 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from diogenes.search import SearchProvider, execute_search_plan
+
 if TYPE_CHECKING:
     from diogenes.api_client import APIClient
 
@@ -155,17 +157,19 @@ def step4_execute_searches(
     research_input: dict[str, Any],
     search_plans: dict[str, Any],
     client: APIClient,
+    search_provider: SearchProvider,
 ) -> dict[str, Any]:
-    """Execute search plans and log results for each claim and query.
+    """Execute search plans and select results for each claim and query.
 
-    For each item, passes the clarified item and its search plan to the
-    search-executor sub-agent with web search enabled. The model executes
-    the searches and returns a PRISMA-compliant search log.
+    Part A: Python executes searches via the search provider (no LLM tokens).
+    Part B: LLM result-selector evaluates search results and selects sources
+    for the evidence base (uses only titles, URLs, snippets — not full pages).
 
     Args:
         research_input: The clarified research input (output of step 1).
         search_plans: The search plans keyed by item ID (output of step 3).
         client: Configured API client with common guidelines loaded.
+        search_provider: Search provider for executing web searches.
 
     Returns:
         A dict mapping item IDs to their search results.
@@ -174,7 +178,7 @@ def step4_execute_searches(
         SubAgentError: If a sub-agent call fails.
 
     """
-    prompt_path = _PROMPTS_DIR / "search-executor.md"
+    prompt_path = _PROMPTS_DIR / "result-selector.md"
     results: dict[str, Any] = {}
 
     items = [*research_input.get("claims", []), *research_input.get("queries", [])]
@@ -182,20 +186,25 @@ def step4_execute_searches(
     for item in items:
         item_id = item["id"]
         item_plan = search_plans.get(item_id, {})
-        search_count = len(item_plan.get("searches", []))
-        print(f"  Executing {search_count} searches for {item_id}...")
+        searches = item_plan.get("searches", [])
+        print(f"  Executing {len(searches)} searches for {item_id} via {search_provider.name}...")
 
+        # Part A: Python executes searches
+        executions = execute_search_plan(item_plan, search_provider)
+        total_results = sum(len(e.results) for e in executions)
+        print(f"    {item_id}: {total_results} raw results from {len(executions)} searches")
+
+        # Part B: LLM selects relevant results
         agent_input = {
             "item": item,
             "search_plan": item_plan,
+            "search_executions": [e.to_dict() for e in executions],
         }
 
         response = client.call_sub_agent(
             prompt_path=prompt_path,
             user_input=agent_input,
             output_schema="search-results.schema.json",
-            enable_web_search=True,
-            max_tokens=16384,
         )
 
         results[item_id] = response

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -58,6 +58,7 @@ def step2_generate_hypotheses(
         response = client.call_sub_agent(
             prompt_path=prompt_path,
             user_input=agent_input,
+            output_schema="hypotheses.schema.json",
         )
 
         results[item_id] = response
@@ -76,6 +77,7 @@ def step2_generate_hypotheses(
         response = client.call_sub_agent(
             prompt_path=prompt_path,
             user_input=agent_input,
+            output_schema="hypotheses.schema.json",
         )
 
         results[item_id] = response

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -11,7 +11,7 @@ import json
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from diogenes.search import SearchProvider, execute_search_plan
+from diogenes.search import SearchProvider, execute_search_plan, fetch_page_extract
 
 if TYPE_CHECKING:
     from diogenes.api_client import APIClient
@@ -302,6 +302,79 @@ def _filter_and_deduplicate(
             rejected.append(result)
 
     return selected, rejected
+
+
+_SCORING_BATCH_SIZE = 3
+
+
+def step5_score_sources(
+    research_input: dict[str, Any],
+    search_results: dict[str, Any],
+    client: APIClient,
+) -> dict[str, Any]:
+    """Score each selected source with reliability, relevance, and bias assessment.
+
+    For each item, fetches page content (Python, zero tokens), then scores
+    sources in batches of 3 via the source-scorer sub-agent.
+
+    Args:
+        research_input: The clarified research input (output of step 1).
+        search_results: The search results keyed by item ID (output of step 4).
+        client: Configured API client with common guidelines loaded.
+
+    Returns:
+        A dict mapping item IDs to their source scorecards.
+
+    Raises:
+        SubAgentError: If a sub-agent call fails.
+
+    """
+    scorer_prompt = _PROMPTS_DIR / "source-scorer.md"
+    results: dict[str, Any] = {}
+
+    items = [*research_input.get("claims", []), *research_input.get("queries", [])]
+
+    for item in items:
+        item_id = item["id"]
+        item_results = search_results.get(item_id, {})
+        selected = item_results.get("selected_sources", [])
+        print(f"  Scoring {len(selected)} sources for {item_id}...")
+
+        # Phase A: Python fetches page content
+        enriched_sources = []
+        for source in selected:
+            url = source.get("url", "")
+            print(f"    Fetching {url[:60]}...")
+            content = fetch_page_extract(url)
+            enriched_sources.append({
+                "url": url,
+                "title": source.get("title", ""),
+                "snippet": source.get("snippet", ""),
+                "content_extract": content,
+            })
+
+        # Phase B: LLM scores in batches
+        all_scorecards: list[dict[str, Any]] = []
+        for i in range(0, len(enriched_sources), _SCORING_BATCH_SIZE):
+            batch = enriched_sources[i:i + _SCORING_BATCH_SIZE]
+            batch_input = {
+                "item_id": item_id,
+                "clarified_text": item.get("clarified_text", ""),
+                "sources": batch,
+            }
+
+            response = client.call_sub_agent(
+                prompt_path=scorer_prompt,
+                user_input=batch_input,
+                output_schema="source-scorecards.schema.json",
+            )
+
+            all_scorecards.extend(response.get("scorecards", []))
+
+        print(f"    {item_id}: {len(all_scorecards)} sources scored")
+        results[item_id] = {"id": item_id, "scorecards": all_scorecards}
+
+    return results
 
 
 def write_step_output(

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -151,6 +151,62 @@ def step3_design_searches(
     return results
 
 
+def step4_execute_searches(
+    research_input: dict[str, Any],
+    search_plans: dict[str, Any],
+    client: APIClient,
+) -> dict[str, Any]:
+    """Execute search plans and log results for each claim and query.
+
+    For each item, passes the clarified item and its search plan to the
+    search-executor sub-agent with web search enabled. The model executes
+    the searches and returns a PRISMA-compliant search log.
+
+    Args:
+        research_input: The clarified research input (output of step 1).
+        search_plans: The search plans keyed by item ID (output of step 3).
+        client: Configured API client with common guidelines loaded.
+
+    Returns:
+        A dict mapping item IDs to their search results.
+
+    Raises:
+        SubAgentError: If a sub-agent call fails.
+
+    """
+    prompt_path = _PROMPTS_DIR / "search-executor.md"
+    results: dict[str, Any] = {}
+
+    items = [*research_input.get("claims", []), *research_input.get("queries", [])]
+
+    for item in items:
+        item_id = item["id"]
+        item_plan = search_plans.get(item_id, {})
+        search_count = len(item_plan.get("searches", []))
+        print(f"  Executing {search_count} searches for {item_id}...")
+
+        agent_input = {
+            "item": item,
+            "search_plan": item_plan,
+        }
+
+        response = client.call_sub_agent(
+            prompt_path=prompt_path,
+            user_input=agent_input,
+            output_schema="search-results.schema.json",
+            enable_web_search=True,
+            max_tokens=16384,
+        )
+
+        results[item_id] = response
+        summary = response.get("summary", {})
+        selected = summary.get("total_selected", 0)
+        rejected = summary.get("total_rejected", 0)
+        print(f"    {item_id}: {selected} sources selected, {rejected} rejected")
+
+    return results
+
+
 def write_step_output(
     output_dir: Path,
     filename: str,

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -20,8 +20,9 @@ if TYPE_CHECKING:
 _PROMPTS_DIR = Path(__file__).parent.parent.parent / "prompts" / "sub-agents"
 
 # Model overrides for cost optimization. Set to None to use the client default.
-# Scoring steps are classification tasks that can use cheaper models.
-_SCORING_MODEL: str | None = "claude-haiku-4-5-20251001"
+# Testing showed Haiku produces different verdicts than Sonnet on scoring steps,
+# which changes downstream assessments. Correctness > cost. See issue #84.
+_SCORING_MODEL: str | None = None
 
 
 def step2_generate_hypotheses(

--- a/src/diogenes/schema_validator.py
+++ b/src/diogenes/schema_validator.py
@@ -8,9 +8,8 @@ from typing import Any
 
 import jsonschema
 
-# Resolve schema directory relative to the repo root
-_REPO_ROOT = Path(__file__).parent.parent.parent
-_SCHEMAS_DIR = _REPO_ROOT / "docs" / "design" / "schemas"
+# Schemas are packaged with the module
+_SCHEMAS_DIR = Path(__file__).parent / "schemas"
 
 
 class ValidationError(Exception):

--- a/src/diogenes/schemas/clarified-input.schema.json
+++ b/src/diogenes/schemas/clarified-input.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/wphillipmoore/ai-research-methodology/schemas/clarified-input.schema.json",
+  "$id": "https://raw.githubusercontent.com/wphillipmoore/ai-research-methodology/main/src/diogenes/schemas/clarified-input.schema.json",
   "title": "Clarified Research Input",
   "description": "Output of the input-clarifier sub-agent. Contains clarified claims, queries, and axioms with surfaced assumptions, scope, and vocabulary mappings.",
   "type": "object",

--- a/src/diogenes/schemas/clarified-input.schema.json
+++ b/src/diogenes/schemas/clarified-input.schema.json
@@ -1,0 +1,180 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/wphillipmoore/ai-research-methodology/schemas/clarified-input.schema.json",
+  "title": "Clarified Research Input",
+  "description": "Output of the input-clarifier sub-agent. Contains clarified claims, queries, and axioms with surfaced assumptions, scope, and vocabulary mappings.",
+  "type": "object",
+  "properties": {
+    "claims": {
+      "type": "array",
+      "description": "Clarified claims ready for hypothesis generation.",
+      "items": { "$ref": "#/$defs/clarified_claim" }
+    },
+    "queries": {
+      "type": "array",
+      "description": "Clarified queries ready for hypothesis generation.",
+      "items": { "$ref": "#/$defs/clarified_query" }
+    },
+    "axioms": {
+      "type": "array",
+      "description": "Axioms passed through with assigned IDs.",
+      "items": { "$ref": "#/$defs/clarified_axiom" }
+    },
+    "metadata": {
+      "$ref": "#/$defs/metadata"
+    }
+  },
+  "anyOf": [
+    { "required": ["claims"] },
+    { "required": ["queries"] }
+  ],
+  "$defs": {
+    "clarified_claim": {
+      "type": "object",
+      "required": ["id", "original_text", "clarified_text", "assumptions_surfaced", "scope", "vocabulary"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^C[0-9]+$",
+          "description": "Sequential claim ID (C001, C002, ...)."
+        },
+        "original_text": {
+          "type": "string",
+          "description": "The claim as received from the researcher."
+        },
+        "clarified_text": {
+          "type": "string",
+          "description": "The claim restated for testability."
+        },
+        "assumptions_surfaced": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Embedded assumptions identified in the claim."
+        },
+        "scope": { "$ref": "#/$defs/scope" },
+        "vocabulary": { "$ref": "#/$defs/vocabulary" },
+        "candidate_evidence": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/candidate_evidence_item" },
+          "description": "Researcher-provided candidate evidence, preserved from input."
+        }
+      },
+      "additionalProperties": false
+    },
+    "clarified_query": {
+      "type": "object",
+      "required": ["id", "original_text", "clarified_text", "assumptions_surfaced", "scope", "vocabulary"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^Q[0-9]+$",
+          "description": "Sequential query ID (Q001, Q002, ...)."
+        },
+        "original_text": {
+          "type": "string",
+          "description": "The query as received from the researcher."
+        },
+        "clarified_text": {
+          "type": "string",
+          "description": "The query restated precisely."
+        },
+        "sub_questions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Decomposed sub-questions for compound queries."
+        },
+        "assumptions_surfaced": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Embedded assumptions identified in the query."
+        },
+        "scope": { "$ref": "#/$defs/scope" },
+        "vocabulary": { "$ref": "#/$defs/vocabulary" }
+      },
+      "additionalProperties": false
+    },
+    "clarified_axiom": {
+      "type": "object",
+      "required": ["id", "text"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^A[0-9]+$",
+          "description": "Sequential axiom ID (A001, A002, ...)."
+        },
+        "text": {
+          "type": "string",
+          "description": "The axiom as declared by the researcher."
+        }
+      },
+      "additionalProperties": false
+    },
+    "scope": {
+      "type": "object",
+      "required": ["domain", "timeframe", "testability"],
+      "properties": {
+        "domain": {
+          "type": "string",
+          "description": "Subject area or field."
+        },
+        "timeframe": {
+          "type": "string",
+          "description": "Temporal scope of the claim or query."
+        },
+        "testability": {
+          "type": "string",
+          "description": "How this claim or query can be verified."
+        }
+      },
+      "additionalProperties": false
+    },
+    "vocabulary": {
+      "type": "object",
+      "required": ["primary_terms", "domain_variants", "related_concepts"],
+      "properties": {
+        "primary_terms": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Key terms to search."
+        },
+        "domain_variants": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Alternative terms used in other fields."
+        },
+        "related_concepts": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Broader or narrower related terms."
+        }
+      },
+      "additionalProperties": false
+    },
+    "candidate_evidence_item": {
+      "type": "object",
+      "required": ["url"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the candidate evidence source."
+        },
+        "description": {
+          "type": "string",
+          "description": "Brief description of what this source contains."
+        }
+      },
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object",
+      "properties": {
+        "claims_count": { "type": "integer" },
+        "queries_count": { "type": "integer" },
+        "axioms_count": { "type": "integer" },
+        "candidate_evidence_count": { "type": "integer" }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/diogenes/schemas/hypotheses.schema.json
+++ b/src/diogenes/schemas/hypotheses.schema.json
@@ -1,0 +1,146 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/wphillipmoore/ai-research-methodology/schemas/hypotheses.schema.json",
+  "title": "Hypothesis Generation Output",
+  "description": "Output of the hypothesis-generator sub-agent for a single claim or query. Uses either a hypotheses approach (claim mode, enumerable query mode) or an open-ended approach (open-ended query mode).",
+  "type": "object",
+  "required": ["id", "mode", "approach"],
+  "oneOf": [
+    { "$ref": "#/$defs/hypotheses_output" },
+    { "$ref": "#/$defs/open_ended_output" }
+  ],
+  "$defs": {
+    "hypotheses_output": {
+      "type": "object",
+      "required": ["id", "mode", "approach", "hypotheses", "discriminating_questions"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[CQ][0-9]+$",
+          "description": "The claim or query ID this output corresponds to."
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["claim", "query"]
+        },
+        "approach": {
+          "type": "string",
+          "const": "hypotheses"
+        },
+        "hypotheses": {
+          "type": "array",
+          "minItems": 3,
+          "items": { "$ref": "#/$defs/hypothesis" },
+          "description": "Competing hypotheses. Minimum three required."
+        },
+        "axiom_constraints": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "How declared axioms constrain the hypothesis space."
+        },
+        "discriminating_questions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Questions whose answers would distinguish between hypotheses."
+        }
+      },
+      "additionalProperties": false
+    },
+    "open_ended_output": {
+      "type": "object",
+      "required": ["id", "mode", "approach", "rationale", "search_themes"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^Q[0-9]+$",
+          "description": "The query ID. Open-ended approach is only valid for queries."
+        },
+        "mode": {
+          "type": "string",
+          "const": "query"
+        },
+        "approach": {
+          "type": "string",
+          "const": "open-ended"
+        },
+        "rationale": {
+          "type": "string",
+          "description": "Why hypotheses are not appropriate for this query."
+        },
+        "search_themes": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/search_theme" },
+          "description": "Thematic search targets derived from sub-questions."
+        },
+        "axiom_constraints": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "How declared axioms constrain the search space."
+        }
+      },
+      "additionalProperties": false
+    },
+    "hypothesis": {
+      "type": "object",
+      "required": ["id", "statement", "supporting_evidence", "eliminating_evidence"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^H[0-9]+$",
+          "description": "Sequential hypothesis ID (H1, H2, H3, ...)."
+        },
+        "statement": {
+          "type": "string",
+          "description": "The hypothesis stated clearly in plain language."
+        },
+        "supporting_evidence": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Descriptions of evidence that would support this hypothesis."
+        },
+        "eliminating_evidence": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Descriptions of evidence that would eliminate this hypothesis."
+        },
+        "depends_on_assumptions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Which surfaced assumptions this hypothesis relies on."
+        }
+      },
+      "additionalProperties": false
+    },
+    "search_theme": {
+      "type": "object",
+      "required": ["id", "theme", "derived_from", "look_for", "perspectives"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^T[0-9]+$",
+          "description": "Sequential theme ID (T1, T2, ...)."
+        },
+        "theme": {
+          "type": "string",
+          "description": "Description of the search theme."
+        },
+        "derived_from": {
+          "type": "string",
+          "description": "Which sub-question this theme addresses."
+        },
+        "look_for": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Specific types of evidence to seek."
+        },
+        "perspectives": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Perspectives to cover: mainstream, dissenting, primary data, boundary of knowledge."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/diogenes/schemas/hypotheses.schema.json
+++ b/src/diogenes/schemas/hypotheses.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/wphillipmoore/ai-research-methodology/schemas/hypotheses.schema.json",
+  "$id": "https://raw.githubusercontent.com/wphillipmoore/ai-research-methodology/main/src/diogenes/schemas/hypotheses.schema.json",
   "title": "Hypothesis Generation Output",
   "description": "Output of the hypothesis-generator sub-agent for a single claim or query. Uses either a hypotheses approach (claim mode, enumerable query mode) or an open-ended approach (open-ended query mode).",
   "type": "object",

--- a/src/diogenes/schemas/relevance-scores.schema.json
+++ b/src/diogenes/schemas/relevance-scores.schema.json
@@ -1,0 +1,47 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/wphillipmoore/ai-research-methodology/main/src/diogenes/schemas/relevance-scores.schema.json",
+  "title": "Relevance Scores",
+  "description": "Output of the relevance-scorer sub-agent. Contains relevance scores for a batch of search results.",
+  "type": "object",
+  "required": ["scores"],
+  "properties": {
+    "scores": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/scored_result" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "scored_result": {
+      "type": "object",
+      "required": ["url", "relevance_score", "rationale"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "URL of the search result."
+        },
+        "title": {
+          "type": "string",
+          "description": "Title of the search result."
+        },
+        "snippet": {
+          "type": "string",
+          "description": "Snippet from the search result."
+        },
+        "relevance_score": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10,
+          "description": "Relevance score from 0 (not relevant) to 10 (highly relevant)."
+        },
+        "rationale": {
+          "type": "string",
+          "description": "One-sentence explanation of the score."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/diogenes/schemas/report.schema.json
+++ b/src/diogenes/schemas/report.schema.json
@@ -1,0 +1,176 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/wphillipmoore/ai-research-methodology/main/src/diogenes/schemas/report.schema.json",
+  "title": "Research Report",
+  "description": "Final structured report for a single claim or query (Step 10).",
+  "type": "object",
+  "required": ["id", "mode", "input_summary", "assessment_summary", "evidence_summary", "synthesis_summary", "gaps_summary", "audit_summary", "revisit_triggers"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[CQ][0-9]+$"
+    },
+    "mode": {
+      "type": "string",
+      "enum": ["claim", "query"]
+    },
+    "input_summary": {
+      "type": "object",
+      "required": ["original_text", "clarified_text"],
+      "properties": {
+        "original_text": { "type": "string" },
+        "clarified_text": { "type": "string" },
+        "axioms": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "sub_questions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Query mode only."
+        }
+      },
+      "additionalProperties": false
+    },
+    "hypotheses_summary": {
+      "type": "object",
+      "properties": {
+        "approach": {
+          "type": "string",
+          "enum": ["hypotheses", "open-ended"]
+        },
+        "hypotheses": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["id", "statement", "status"],
+            "properties": {
+              "id": { "type": "string" },
+              "statement": { "type": "string" },
+              "status": { "type": "string" }
+            },
+            "additionalProperties": false
+          }
+        },
+        "thematic_summary": {
+          "type": "string",
+          "description": "Open-ended queries: summary of thematic analysis."
+        }
+      },
+      "additionalProperties": false
+    },
+    "assessment_summary": {
+      "type": "object",
+      "required": ["conclusion", "reasoning"],
+      "properties": {
+        "verdict": {
+          "type": "string",
+          "description": "Claim mode: the claim is [probability term] ([range])."
+        },
+        "answer": {
+          "type": "string",
+          "description": "Query mode: the answer."
+        },
+        "confidence": { "type": "string" },
+        "conclusion": {
+          "type": "string",
+          "description": "One-paragraph conclusion."
+        },
+        "reasoning": {
+          "type": "string",
+          "description": "Reasoning chain from evidence to conclusion."
+        }
+      },
+      "additionalProperties": false
+    },
+    "evidence_summary": {
+      "type": "object",
+      "required": ["sources_count", "key_sources"],
+      "properties": {
+        "sources_count": { "type": "integer" },
+        "key_sources": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["url", "contribution"],
+            "properties": {
+              "url": { "type": "string" },
+              "title": { "type": "string" },
+              "contribution": { "type": "string" },
+              "reliability": { "type": "string" },
+              "relevance": { "type": "string" }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "synthesis_summary": {
+      "type": "object",
+      "required": ["evidence_quality", "source_agreement"],
+      "properties": {
+        "evidence_quality": { "type": "string" },
+        "source_agreement": { "type": "string" },
+        "independence": { "type": "string" },
+        "notable_outliers": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "gaps_summary": {
+      "type": "object",
+      "required": ["key_gaps", "impact"],
+      "properties": {
+        "key_gaps": {
+          "type": "array",
+          "items": { "type": "string" }
+        },
+        "impact": { "type": "string" }
+      },
+      "additionalProperties": false
+    },
+    "audit_summary": {
+      "type": "object",
+      "required": ["overall_rating", "domains"],
+      "properties": {
+        "overall_rating": {
+          "type": "string",
+          "enum": ["Pass", "Concern", "Fail"]
+        },
+        "domains": {
+          "type": "object",
+          "properties": {
+            "eligibility_criteria": { "type": "string" },
+            "search_comprehensiveness": { "type": "string" },
+            "evaluation_consistency": { "type": "string" },
+            "synthesis_fairness": { "type": "string" },
+            "source_verification": { "type": "string" }
+          },
+          "additionalProperties": false
+        },
+        "discrepancies_found": { "type": "integer" }
+      },
+      "additionalProperties": false
+    },
+    "revisit_triggers": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "object",
+        "required": ["trigger", "type"],
+        "properties": {
+          "trigger": {
+            "type": "string",
+            "description": "Specific, testable condition."
+          },
+          "type": {
+            "type": "string",
+            "enum": ["study", "event", "time", "data_update", "policy", "organization"]
+          }
+        },
+        "additionalProperties": false
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/src/diogenes/schemas/research-input.example.json
+++ b/src/diogenes/schemas/research-input.example.json
@@ -1,0 +1,35 @@
+{
+  "claims": [
+    {
+      "text": "AI research communities show 83% homophily between safety and ethics subfields.",
+      "candidate_evidence": [
+        {
+          "url": "https://arxiv.org/html/2512.10058",
+          "description": "Roytburg & Miller, 'Mind the Gap!' — Figure 1 caption states 83.1% homophily."
+        }
+      ]
+    },
+    {
+      "text": "DeepSeek V3, trained with GRPO, was among the most sycophantic models tested."
+    }
+  ],
+  "queries": [
+    {
+      "text": "What is the current state of AI watermarking technology for detecting AI-generated text?"
+    }
+  ],
+  "axioms": [
+    {
+      "text": "This research is conducted in the context of consumer AI products, not classified military systems."
+    }
+  ],
+  "config": {
+    "output": "docs/site/docs/research/R0060-example",
+    "runs": 3,
+    "mode": "research"
+  },
+  "researcher_profile": {
+    "expertise": ["infrastructure engineering", "non-linear dynamics"],
+    "known_biases": ["skeptical of AI reliability claims", "engineering-first perspective"]
+  }
+}

--- a/src/diogenes/schemas/research-input.schema.json
+++ b/src/diogenes/schemas/research-input.schema.json
@@ -1,0 +1,167 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/wphillipmoore/ai-research-methodology/schemas/research-input.schema.json",
+  "title": "Research Input",
+  "description": "Input specification for a research run. Must contain at least one claim, query, or axiom.",
+  "type": "object",
+  "required": [],
+  "properties": {
+    "claims": {
+      "type": "array",
+      "description": "Assertions to be tested against evidence.",
+      "items": {
+        "$ref": "#/$defs/claim"
+      }
+    },
+    "queries": {
+      "type": "array",
+      "description": "Questions to be answered with evidence.",
+      "items": {
+        "$ref": "#/$defs/query"
+      }
+    },
+    "axioms": {
+      "type": "array",
+      "description": "Facts declared by the researcher to be assumed true. Not tested.",
+      "items": {
+        "$ref": "#/$defs/axiom"
+      }
+    },
+    "config": {
+      "$ref": "#/$defs/config"
+    },
+    "researcher_profile": {
+      "$ref": "#/$defs/researcher_profile"
+    }
+  },
+  "anyOf": [
+    { "required": ["claims"] },
+    { "required": ["queries"] }
+  ],
+  "$defs": {
+    "claim": {
+      "type": "object",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The factual assertion to be tested."
+        },
+        "candidate_evidence": {
+          "type": "array",
+          "description": "Researcher-provided URLs that may be relevant to this claim. Scored on equal terms with search-discovered sources.",
+          "items": {
+            "$ref": "#/$defs/candidate_evidence_item"
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "query": {
+      "type": "object",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "The research question to be answered."
+        }
+      },
+      "additionalProperties": false
+    },
+    "axiom": {
+      "type": "object",
+      "required": ["text"],
+      "properties": {
+        "text": {
+          "type": "string",
+          "description": "A fact to be assumed true for the duration of the research."
+        }
+      },
+      "additionalProperties": false
+    },
+    "candidate_evidence_item": {
+      "type": "object",
+      "required": ["url"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL of the candidate evidence source."
+        },
+        "description": {
+          "type": "string",
+          "description": "Brief description of what this source contains and why the researcher believes it is relevant."
+        }
+      },
+      "additionalProperties": false
+    },
+    "config": {
+      "type": "object",
+      "description": "Research run configuration. All fields optional with sensible defaults.",
+      "properties": {
+        "output": {
+          "type": "string",
+          "description": "Output directory path."
+        },
+        "runs": {
+          "type": "integer",
+          "minimum": 1,
+          "default": 3,
+          "description": "Number of independent runs. Default 3."
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["research", "fact-check", "rerun"],
+          "default": "research",
+          "description": "Execution mode. 'research' = standard run. 'fact-check' = extract claims from document first. 'rerun' = re-execute from existing research-input.md."
+        },
+        "source_document": {
+          "type": "string",
+          "description": "Path or URL to document for fact-check mode. Required when mode is 'fact-check'."
+        },
+        "rerun_path": {
+          "type": "string",
+          "description": "Path to existing research instance for rerun mode. Required when mode is 'rerun'."
+        },
+        "model_overrides": {
+          "type": "object",
+          "description": "Override default model tier for specific sub-agents.",
+          "properties": {
+            "clarifier": { "type": "string" },
+            "hypothesizer": { "type": "string" },
+            "search_designer": { "type": "string" },
+            "result_selector": { "type": "string" },
+            "source_scorer": { "type": "string" },
+            "evidence_extractor": { "type": "string" },
+            "evaluator": { "type": "string" },
+            "auditor": { "type": "string" },
+            "synthesizer": { "type": "string" }
+          },
+          "additionalProperties": false
+        }
+      },
+      "additionalProperties": false
+    },
+    "researcher_profile": {
+      "type": "object",
+      "description": "EXPERIMENTAL — placeholder. Researcher bias and expertise disclosure for calibration. This feature is not yet implemented and will likely become its own JSON schema. Do not treat this as a stable interface.",
+      "properties": {
+        "expertise": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Domains of expertise that may bias the researcher's framing."
+        },
+        "known_biases": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Self-declared biases or conflicts of interest."
+        },
+        "profile_path": {
+          "type": "string",
+          "description": "Path to an external researcher profile file."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/diogenes/schemas/research-input.schema.json
+++ b/src/diogenes/schemas/research-input.schema.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://github.com/wphillipmoore/ai-research-methodology/schemas/research-input.schema.json",
+  "$id": "https://raw.githubusercontent.com/wphillipmoore/ai-research-methodology/main/src/diogenes/schemas/research-input.schema.json",
   "title": "Research Input",
   "description": "Input specification for a research run. Must contain at least one claim, query, or axiom.",
   "type": "object",

--- a/src/diogenes/schemas/search-plan.schema.json
+++ b/src/diogenes/schemas/search-plan.schema.json
@@ -1,0 +1,182 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/wphillipmoore/ai-research-methodology/main/src/diogenes/schemas/search-plan.schema.json",
+  "title": "Search Plan",
+  "description": "Output of the search-designer sub-agent for a single claim or query. Contains planned searches with terms, sources, and expected outcomes.",
+  "type": "object",
+  "required": ["id", "approach", "searches"],
+  "oneOf": [
+    { "$ref": "#/$defs/hypothesis_plan" },
+    { "$ref": "#/$defs/open_ended_plan" }
+  ],
+  "$defs": {
+    "hypothesis_plan": {
+      "type": "object",
+      "required": ["id", "approach", "searches", "vocabulary_coverage"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[CQ][0-9]+$",
+          "description": "The claim or query ID."
+        },
+        "approach": {
+          "type": "string",
+          "const": "hypotheses"
+        },
+        "searches": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/hypothesis_search" }
+        },
+        "vocabulary_coverage": {
+          "$ref": "#/$defs/vocabulary_coverage"
+        },
+        "meaningful_absences": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/meaningful_absence" },
+          "description": "What absence of evidence would be significant."
+        }
+      },
+      "additionalProperties": false
+    },
+    "open_ended_plan": {
+      "type": "object",
+      "required": ["id", "approach", "searches", "vocabulary_coverage"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^Q[0-9]+$",
+          "description": "The query ID."
+        },
+        "approach": {
+          "type": "string",
+          "const": "open-ended"
+        },
+        "searches": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/theme_search" }
+        },
+        "vocabulary_coverage": {
+          "$ref": "#/$defs/vocabulary_coverage"
+        },
+        "meaningful_absences": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/meaningful_absence" },
+          "description": "What absence of evidence would be significant."
+        }
+      },
+      "additionalProperties": false
+    },
+    "hypothesis_search": {
+      "type": "object",
+      "required": ["id", "target_hypothesis", "intent", "terms", "sources", "useful_result", "absence_meaning"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^S[0-9]+$",
+          "description": "Sequential search ID (S01, S02, ...)."
+        },
+        "target_hypothesis": {
+          "type": "string",
+          "description": "Which hypothesis this search targets (e.g., H1, H2)."
+        },
+        "intent": {
+          "type": "string",
+          "enum": ["support", "eliminate", "discriminate"],
+          "description": "Whether seeking supporting, eliminating, or discriminating evidence."
+        },
+        "terms": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "description": "Search terms to use, including vocabulary variants."
+        },
+        "sources": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "description": "Sources or databases to search."
+        },
+        "useful_result": {
+          "type": "string",
+          "description": "What a useful result from this search would look like."
+        },
+        "absence_meaning": {
+          "type": "string",
+          "description": "What it means if this search returns no relevant results."
+        }
+      },
+      "additionalProperties": false
+    },
+    "theme_search": {
+      "type": "object",
+      "required": ["id", "target_theme", "perspective", "terms", "sources"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^S[0-9]+$",
+          "description": "Sequential search ID (S01, S02, ...)."
+        },
+        "target_theme": {
+          "type": "string",
+          "description": "Which search theme this addresses (e.g., T1, T2)."
+        },
+        "perspective": {
+          "type": "string",
+          "description": "Which perspective this search is intended to surface."
+        },
+        "terms": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "description": "Search terms to use, including vocabulary variants."
+        },
+        "sources": {
+          "type": "array",
+          "minItems": 1,
+          "items": { "type": "string" },
+          "description": "Sources or databases to search."
+        }
+      },
+      "additionalProperties": false
+    },
+    "vocabulary_coverage": {
+      "type": "object",
+      "required": ["terms_used", "domains_covered"],
+      "properties": {
+        "terms_used": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "All vocabulary terms used across searches."
+        },
+        "domains_covered": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Domains covered by vocabulary variant searches."
+        },
+        "gaps": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Vocabulary terms from Step 1 not used and why."
+        }
+      },
+      "additionalProperties": false
+    },
+    "meaningful_absence": {
+      "type": "object",
+      "required": ["description", "implication"],
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "What evidence was looked for."
+        },
+        "implication": {
+          "type": "string",
+          "description": "What it means if this evidence is not found."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/diogenes/schemas/search-results.schema.json
+++ b/src/diogenes/schemas/search-results.schema.json
@@ -1,0 +1,205 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/wphillipmoore/ai-research-methodology/main/src/diogenes/schemas/search-results.schema.json",
+  "title": "Search Results",
+  "description": "Output of the search-executor sub-agent. Contains the PRISMA-compliant search log with selected and rejected results.",
+  "type": "object",
+  "required": ["id", "searches_executed", "selected_sources", "summary"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[CQ][0-9]+$",
+      "description": "The claim or query ID."
+    },
+    "searches_executed": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/executed_search" },
+      "description": "Log of every search performed."
+    },
+    "selected_sources": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/selected_source" },
+      "description": "Sources selected for the evidence base."
+    },
+    "rejected_sources": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/rejected_source" },
+      "description": "Sources reviewed but not selected."
+    },
+    "candidate_evidence_results": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/candidate_evidence_result" },
+      "description": "Disposition of researcher-provided candidate evidence."
+    },
+    "summary": {
+      "$ref": "#/$defs/search_summary"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "executed_search": {
+      "type": "object",
+      "required": ["search_id", "terms_used", "sources_searched", "results_found", "results_selected", "results_rejected"],
+      "properties": {
+        "search_id": {
+          "type": "string",
+          "description": "The search ID from the search plan (S01, S02, ...)."
+        },
+        "terms_used": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Actual search terms used (may include variations)."
+        },
+        "sources_searched": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Sources or databases searched."
+        },
+        "date": {
+          "type": "string",
+          "description": "Date of search execution (ISO 8601)."
+        },
+        "results_found": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Total number of results returned."
+        },
+        "results_selected": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of results selected for review."
+        },
+        "results_rejected": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Number of results reviewed and rejected."
+        },
+        "no_relevant_results": {
+          "type": "boolean",
+          "description": "True if the search returned no relevant results."
+        },
+        "notes": {
+          "type": "string",
+          "description": "Any notes about the search execution."
+        }
+      },
+      "additionalProperties": false
+    },
+    "selected_source": {
+      "type": "object",
+      "required": ["id", "url", "title", "selection_rationale", "origin"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^SRC[0-9]+$",
+          "description": "Sequential source ID (SRC001, SRC002, ...)."
+        },
+        "url": {
+          "type": "string",
+          "description": "URL of the source."
+        },
+        "title": {
+          "type": "string",
+          "description": "Title of the source."
+        },
+        "snippet": {
+          "type": "string",
+          "description": "Brief excerpt or summary of the relevant content."
+        },
+        "selection_rationale": {
+          "type": "string",
+          "description": "Why this source was selected for the evidence base."
+        },
+        "origin": {
+          "type": "string",
+          "enum": ["search-discovered", "researcher-provided"],
+          "description": "How this source was found."
+        },
+        "discovered_by_search": {
+          "type": "string",
+          "description": "Which search ID found this source (S01, S02, etc.)."
+        },
+        "page_age": {
+          "type": "string",
+          "description": "Age or date of the page if available."
+        }
+      },
+      "additionalProperties": false
+    },
+    "rejected_source": {
+      "type": "object",
+      "required": ["url", "title", "rejection_rationale"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "URL of the rejected source."
+        },
+        "title": {
+          "type": "string",
+          "description": "Title of the rejected source."
+        },
+        "rejection_rationale": {
+          "type": "string",
+          "description": "Why this source was not selected."
+        },
+        "discovered_by_search": {
+          "type": "string",
+          "description": "Which search ID found this source."
+        }
+      },
+      "additionalProperties": false
+    },
+    "candidate_evidence_result": {
+      "type": "object",
+      "required": ["url", "status", "rationale"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "URL of the researcher-provided evidence."
+        },
+        "status": {
+          "type": "string",
+          "enum": ["selected", "rejected"],
+          "description": "Whether the candidate evidence was selected."
+        },
+        "rationale": {
+          "type": "string",
+          "description": "Why the candidate evidence was selected or rejected."
+        }
+      },
+      "additionalProperties": false
+    },
+    "search_summary": {
+      "type": "object",
+      "required": ["total_searches", "total_results_found", "total_selected", "total_rejected"],
+      "properties": {
+        "total_searches": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "total_results_found": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total_selected": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "total_rejected": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "searches_with_no_results": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "coverage_assessment": {
+          "type": "string",
+          "description": "Assessment of whether the search was comprehensive enough."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/diogenes/schemas/search-results.schema.json
+++ b/src/diogenes/schemas/search-results.schema.json
@@ -121,7 +121,7 @@
           "description": "Which search ID found this source (S01, S02, etc.)."
         },
         "page_age": {
-          "type": "string",
+          "type": ["string", "null"],
           "description": "Age or date of the page if available."
         }
       },
@@ -138,6 +138,10 @@
         "title": {
           "type": "string",
           "description": "Title of the rejected source."
+        },
+        "snippet": {
+          "type": "string",
+          "description": "Brief excerpt from the source."
         },
         "rejection_rationale": {
           "type": "string",

--- a/src/diogenes/schemas/self-audit.schema.json
+++ b/src/diogenes/schemas/self-audit.schema.json
@@ -1,0 +1,103 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/wphillipmoore/ai-research-methodology/main/src/diogenes/schemas/self-audit.schema.json",
+  "title": "Self-Audit, Source-Back Verification, and Reading List",
+  "description": "Combined output of Steps 9, 9b, and 9c for a single claim or query.",
+  "type": "object",
+  "required": ["id", "process_audit", "source_verification", "reading_list"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[CQ][0-9]+$"
+    },
+    "process_audit": { "$ref": "#/$defs/process_audit" },
+    "source_verification": { "$ref": "#/$defs/source_verification" },
+    "reading_list": {
+      "type": "array",
+      "items": { "$ref": "#/$defs/reading_list_entry" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "process_audit": {
+      "type": "object",
+      "required": ["eligibility_criteria", "search_comprehensiveness", "evaluation_consistency", "synthesis_fairness"],
+      "properties": {
+        "eligibility_criteria": { "$ref": "#/$defs/audit_domain" },
+        "search_comprehensiveness": { "$ref": "#/$defs/audit_domain" },
+        "evaluation_consistency": { "$ref": "#/$defs/audit_domain" },
+        "synthesis_fairness": { "$ref": "#/$defs/audit_domain" },
+        "researcher_bias_impact": {
+          "type": "string",
+          "description": "Assessment of whether researcher biases influenced the process."
+        }
+      },
+      "additionalProperties": false
+    },
+    "audit_domain": {
+      "type": "object",
+      "required": ["rating", "rationale"],
+      "properties": {
+        "rating": {
+          "type": "string",
+          "enum": ["Pass", "Concern", "Fail"]
+        },
+        "rationale": { "type": "string" },
+        "impact": {
+          "type": "string",
+          "description": "Impact on conclusions if Concern or Fail."
+        }
+      },
+      "additionalProperties": false
+    },
+    "source_verification": {
+      "type": "object",
+      "required": ["sources_verified", "discrepancies"],
+      "properties": {
+        "sources_verified": {
+          "type": "integer",
+          "minimum": 0
+        },
+        "discrepancies": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["source_url", "claim_in_assessment", "actual_source_says", "severity"],
+            "properties": {
+              "source_url": { "type": "string" },
+              "claim_in_assessment": { "type": "string" },
+              "actual_source_says": { "type": "string" },
+              "severity": {
+                "type": "string",
+                "enum": ["minor", "major"]
+              }
+            },
+            "additionalProperties": false
+          }
+        }
+      },
+      "additionalProperties": false
+    },
+    "reading_list_entry": {
+      "type": "object",
+      "required": ["url", "summary", "priority"],
+      "properties": {
+        "url": { "type": "string" },
+        "title": { "type": "string" },
+        "summary": {
+          "type": "string",
+          "description": "One-sentence summary of what this source contributes."
+        },
+        "priority": {
+          "type": "string",
+          "enum": ["must read", "should read", "reference"]
+        },
+        "origin": {
+          "type": "string",
+          "enum": ["search-discovered", "researcher-provided"]
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/diogenes/schemas/source-scorecards.schema.json
+++ b/src/diogenes/schemas/source-scorecards.schema.json
@@ -1,0 +1,88 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/wphillipmoore/ai-research-methodology/main/src/diogenes/schemas/source-scorecards.schema.json",
+  "title": "Source Scorecards",
+  "description": "Output of the source-scorer sub-agent. Contains reliability, relevance, and bias scorecards for a batch of sources.",
+  "type": "object",
+  "required": ["scorecards"],
+  "properties": {
+    "scorecards": {
+      "type": "array",
+      "minItems": 1,
+      "items": { "$ref": "#/$defs/source_scorecard" }
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "source_scorecard": {
+      "type": "object",
+      "required": ["url", "reliability", "relevance", "bias_assessment"],
+      "properties": {
+        "url": {
+          "type": "string",
+          "description": "URL of the scored source."
+        },
+        "reliability": {
+          "$ref": "#/$defs/rating_with_rationale",
+          "description": "How trustworthy is this source."
+        },
+        "relevance": {
+          "$ref": "#/$defs/rating_with_rationale",
+          "description": "How directly this addresses the research item."
+        },
+        "bias_assessment": {
+          "$ref": "#/$defs/bias_assessment"
+        },
+        "overall_quality": {
+          "type": "string",
+          "enum": ["strong", "moderate", "weak"],
+          "description": "Summary quality rating derived from the three components."
+        }
+      },
+      "additionalProperties": false
+    },
+    "rating_with_rationale": {
+      "type": "object",
+      "required": ["rating", "rationale"],
+      "properties": {
+        "rating": {
+          "type": "string",
+          "enum": ["High", "Medium", "Low"]
+        },
+        "rationale": {
+          "type": "string",
+          "description": "Brief explanation of the rating."
+        }
+      },
+      "additionalProperties": false
+    },
+    "bias_assessment": {
+      "type": "object",
+      "required": ["missing_data", "measurement", "selective_reporting", "randomization", "protocol_deviation", "conflict_of_interest"],
+      "properties": {
+        "missing_data": { "$ref": "#/$defs/bias_domain" },
+        "measurement": { "$ref": "#/$defs/bias_domain" },
+        "selective_reporting": { "$ref": "#/$defs/bias_domain" },
+        "randomization": { "$ref": "#/$defs/bias_domain" },
+        "protocol_deviation": { "$ref": "#/$defs/bias_domain" },
+        "conflict_of_interest": { "$ref": "#/$defs/bias_domain" }
+      },
+      "additionalProperties": false
+    },
+    "bias_domain": {
+      "type": "object",
+      "required": ["rating", "rationale"],
+      "properties": {
+        "rating": {
+          "type": "string",
+          "enum": ["Low risk", "Some concerns", "High risk", "N/A"]
+        },
+        "rationale": {
+          "type": "string",
+          "description": "Brief explanation."
+        }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/diogenes/schemas/source-scorecards.schema.json
+++ b/src/diogenes/schemas/source-scorecards.schema.json
@@ -22,6 +22,14 @@
           "type": "string",
           "description": "URL of the scored source."
         },
+        "title": {
+          "type": "string",
+          "description": "Title of the source."
+        },
+        "snippet": {
+          "type": "string",
+          "description": "Snippet from the source."
+        },
         "reliability": {
           "$ref": "#/$defs/rating_with_rationale",
           "description": "How trustworthy is this source."

--- a/src/diogenes/schemas/synthesis.schema.json
+++ b/src/diogenes/schemas/synthesis.schema.json
@@ -1,0 +1,162 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://raw.githubusercontent.com/wphillipmoore/ai-research-methodology/main/src/diogenes/schemas/synthesis.schema.json",
+  "title": "Evidence Synthesis, Assessment, and Gaps",
+  "description": "Combined output of Steps 6 (synthesis), 7 (assessment), and 8 (gaps) for a single claim or query.",
+  "type": "object",
+  "required": ["id", "synthesis", "assessment", "gaps"],
+  "properties": {
+    "id": {
+      "type": "string",
+      "pattern": "^[CQ][0-9]+$"
+    },
+    "synthesis": { "$ref": "#/$defs/synthesis" },
+    "assessment": { "$ref": "#/$defs/assessment" },
+    "gaps": { "$ref": "#/$defs/gaps" }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "synthesis": {
+      "type": "object",
+      "required": ["evidence_quality", "source_agreement", "independence", "outliers"],
+      "properties": {
+        "evidence_quality": { "$ref": "#/$defs/rated_field" },
+        "source_agreement": { "$ref": "#/$defs/rated_field" },
+        "independence": {
+          "type": "object",
+          "required": ["assessment", "shared_origins"],
+          "properties": {
+            "assessment": { "type": "string" },
+            "shared_origins": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "additionalProperties": false
+        },
+        "outliers": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["source_url", "divergence", "explanation"],
+            "properties": {
+              "source_url": { "type": "string" },
+              "divergence": { "type": "string" },
+              "explanation": { "type": "string" }
+            },
+            "additionalProperties": false
+          }
+        },
+        "thematic_clusters": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["theme", "sources", "finding"],
+            "properties": {
+              "theme": { "type": "string" },
+              "sources": { "type": "array", "items": { "type": "string" } },
+              "finding": { "type": "string" }
+            },
+            "additionalProperties": false
+          },
+          "description": "Open-ended queries only: themes that emerged from the evidence."
+        },
+        "convergence_analysis": {
+          "type": "string",
+          "description": "Open-ended queries only: where sources converge and diverge."
+        },
+        "emerging_answer": {
+          "type": "string",
+          "description": "Open-ended queries only: draft finding based on evidence."
+        }
+      },
+      "additionalProperties": false
+    },
+    "assessment": {
+      "type": "object",
+      "required": ["approach"],
+      "properties": {
+        "approach": {
+          "type": "string",
+          "enum": ["probability", "confidence"]
+        },
+        "hypothesis_ratings": {
+          "type": "array",
+          "items": {
+            "type": "object",
+            "required": ["hypothesis_id", "probability_term", "probability_range", "reasoning"],
+            "properties": {
+              "hypothesis_id": { "type": "string" },
+              "probability_term": { "type": "string" },
+              "probability_range": { "type": "string" },
+              "reasoning": { "type": "string" }
+            },
+            "additionalProperties": false
+          },
+          "description": "For hypotheses approach: probability rating per hypothesis."
+        },
+        "verdict": {
+          "type": "string",
+          "description": "For claims: the claim is [probability term] ([range])."
+        },
+        "answer": {
+          "type": "string",
+          "description": "For open-ended queries: the synthesized answer."
+        },
+        "confidence": {
+          "type": "string",
+          "enum": ["High", "Medium", "Low"],
+          "description": "For open-ended queries: confidence level."
+        },
+        "reasoning_chain": {
+          "type": "string",
+          "description": "Explicit reasoning from evidence through synthesis to conclusion."
+        },
+        "caveats": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Conditions, qualifications, or limitations."
+        }
+      },
+      "additionalProperties": false
+    },
+    "gaps": {
+      "type": "object",
+      "required": ["expected_not_found", "unanswered_questions", "impact_on_confidence"],
+      "properties": {
+        "expected_not_found": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Evidence expected but not found."
+        },
+        "no_result_searches": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Searches that produced no relevant results."
+        },
+        "unanswered_questions": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Questions that remain unanswered."
+        },
+        "impact_on_confidence": {
+          "type": "string",
+          "description": "How these gaps affect the confidence of the assessment."
+        }
+      },
+      "additionalProperties": false
+    },
+    "rated_field": {
+      "type": "object",
+      "required": ["rating", "rationale"],
+      "properties": {
+        "rating": {
+          "type": "string",
+          "enum": ["Robust", "Medium", "Limited", "High", "Low"]
+        },
+        "rationale": { "type": "string" }
+      },
+      "additionalProperties": false
+    }
+  }
+}

--- a/src/diogenes/search.py
+++ b/src/diogenes/search.py
@@ -1,0 +1,115 @@
+"""Search provider protocol and implementations.
+
+Search execution is handled by Python, not by the LLM. This keeps token
+costs manageable — the LLM only sees titles, URLs, and snippets for
+result selection, not full page content.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+
+@dataclass
+class SearchResult:
+    """A single search result from a provider."""
+
+    title: str
+    url: str
+    snippet: str
+    page_age: str | None = None
+
+
+@dataclass
+class SearchExecution:
+    """Record of a single search execution (PRISMA log entry)."""
+
+    search_id: str
+    terms: list[str]
+    provider: str
+    date: str
+    results: list[SearchResult]
+    total_results_available: int
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize for JSON output."""
+        return {
+            "search_id": self.search_id,
+            "terms_used": self.terms,
+            "provider": self.provider,
+            "date": self.date,
+            "results_found": len(self.results),
+            "total_available": self.total_results_available,
+            "results": [
+                {
+                    "title": r.title,
+                    "url": r.url,
+                    "snippet": r.snippet,
+                    "page_age": r.page_age,
+                }
+                for r in self.results
+            ],
+        }
+
+
+class SearchProvider(Protocol):
+    """Protocol for search providers."""
+
+    @property
+    def name(self) -> str:
+        """Provider name for logging."""
+        ...
+
+    def search(self, query: str, max_results: int = 10) -> tuple[list[SearchResult], int]:
+        """Execute a search and return results.
+
+        Args:
+            query: The search query string.
+            max_results: Maximum results to return.
+
+        Returns:
+            Tuple of (results list, total results available from provider).
+
+        """
+        ...
+
+
+def execute_search_plan(
+    search_plan: dict[str, Any],
+    provider: SearchProvider,
+) -> list[SearchExecution]:
+    """Execute all searches in a search plan using the given provider.
+
+    Args:
+        search_plan: The search plan from Step 3 (for one item).
+        provider: The search provider to use.
+
+    Returns:
+        List of SearchExecution records (one per search in the plan).
+
+    """
+    executions: list[SearchExecution] = []
+    searches = search_plan.get("searches", [])
+    now = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    for search in searches:
+        search_id = search.get("id", "S??")
+        terms = search.get("terms", [])
+
+        # Combine terms into a single query
+        query = " ".join(terms[:3])
+
+        results, total_available = provider.search(query)
+
+        executions.append(SearchExecution(
+            search_id=search_id,
+            terms=terms,
+            provider=provider.name,
+            date=now,
+            results=results,
+            total_results_available=total_available,
+        ))
+
+    return executions

--- a/src/diogenes/search.py
+++ b/src/diogenes/search.py
@@ -79,7 +79,7 @@ class SearchProvider(Protocol):
 def execute_search_plan(
     search_plan: dict[str, Any],
     provider: SearchProvider,
-    max_results_per_search: int = 3,
+    max_results_per_search: int = 5,
 ) -> list[SearchExecution]:
     """Execute all searches in a search plan using the given provider.
 

--- a/src/diogenes/search.py
+++ b/src/diogenes/search.py
@@ -7,9 +7,12 @@ result selection, not full page content.
 
 from __future__ import annotations
 
+import re
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any, Protocol
+
+import requests
 
 
 @dataclass
@@ -74,6 +77,39 @@ class SearchProvider(Protocol):
 
         """
         ...
+
+
+_FETCH_TIMEOUT = 10
+_CONTENT_EXTRACT_LENGTH = 2000
+
+
+def fetch_page_extract(url: str) -> str:
+    """Fetch a page and return a text extract of the content.
+
+    Returns the first ~2000 characters of visible text, or an empty
+    string if the fetch fails. This is intentionally simple — we only
+    need enough context for the scorer to assess quality and relevance.
+    """
+    try:
+        resp = requests.get(
+            url,
+            timeout=_FETCH_TIMEOUT,
+            headers={"User-Agent": "Diogenes/0.1 (research-methodology)"},
+        )
+        resp.raise_for_status()
+    except (requests.RequestException, ValueError):
+        return ""
+
+    # Simple text extraction: strip HTML tags
+    text = resp.text
+    # Remove script and style blocks
+    text = re.sub(r"<(script|style)[^>]*>.*?</\1>", "", text, flags=re.DOTALL | re.IGNORECASE)
+    # Remove HTML tags
+    text = re.sub(r"<[^>]+>", " ", text)
+    # Collapse whitespace
+    text = re.sub(r"\s+", " ", text).strip()
+
+    return text[:_CONTENT_EXTRACT_LENGTH]
 
 
 def execute_search_plan(

--- a/src/diogenes/search.py
+++ b/src/diogenes/search.py
@@ -79,12 +79,14 @@ class SearchProvider(Protocol):
 def execute_search_plan(
     search_plan: dict[str, Any],
     provider: SearchProvider,
+    max_results_per_search: int = 3,
 ) -> list[SearchExecution]:
     """Execute all searches in a search plan using the given provider.
 
     Args:
         search_plan: The search plan from Step 3 (for one item).
         provider: The search provider to use.
+        max_results_per_search: Maximum results to request per search.
 
     Returns:
         List of SearchExecution records (one per search in the plan).
@@ -101,7 +103,7 @@ def execute_search_plan(
         # Combine terms into a single query
         query = " ".join(terms[:3])
 
-        results, total_available = provider.search(query)
+        results, total_available = provider.search(query, max_results=max_results_per_search)
 
         executions.append(SearchExecution(
             search_id=search_id,

--- a/src/diogenes/search.py
+++ b/src/diogenes/search.py
@@ -141,13 +141,15 @@ def execute_search_plan(
 
         results, total_available = provider.search(query, max_results=max_results_per_search)
 
-        executions.append(SearchExecution(
-            search_id=search_id,
-            terms=terms,
-            provider=provider.name,
-            date=now,
-            results=results,
-            total_results_available=total_available,
-        ))
+        executions.append(
+            SearchExecution(
+                search_id=search_id,
+                terms=terms,
+                provider=provider.name,
+                date=now,
+                results=results,
+                total_results_available=total_available,
+            )
+        )
 
     return executions

--- a/src/diogenes/search_providers.py
+++ b/src/diogenes/search_providers.py
@@ -1,0 +1,114 @@
+"""Search provider implementations."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+from diogenes.search import SearchResult
+
+_DEFAULT_TIMEOUT = 10
+
+
+class BraveSearchProvider:
+    """Brave Search API provider.
+
+    Requires a BRAVE_API_KEY in config. Free tier: 2,000 queries/month.
+    https://brave.com/search/api/
+    """
+
+    API_URL = "https://api.search.brave.com/res/v1/web/search"
+
+    def __init__(self, api_key: str) -> None:
+        """Initialize with a Brave Search API key."""
+        self._api_key = api_key
+
+    @property
+    def name(self) -> str:
+        """Provider name for logging."""
+        return "brave"
+
+    def search(self, query: str, max_results: int = 10) -> tuple[list[SearchResult], int]:
+        """Execute a Brave web search."""
+        headers = {
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip",
+            "X-Subscription-Token": self._api_key,
+        }
+        params: dict[str, Any] = {
+            "q": query,
+            "count": max_results,
+        }
+
+        resp = requests.get(
+            self.API_URL,
+            headers=headers,
+            params=params,
+            timeout=_DEFAULT_TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        web_results = data.get("web", {}).get("results", [])
+        total = data.get("web", {}).get("totalEstimatedMatches", len(web_results))
+
+        results = [
+            SearchResult(
+                title=r.get("title", ""),
+                url=r.get("url", ""),
+                snippet=r.get("description", ""),
+                page_age=r.get("page_age"),
+            )
+            for r in web_results
+        ]
+
+        return results, total
+
+
+class GoogleSearchProvider:
+    """Google Custom Search API provider.
+
+    Requires GOOGLE_API_KEY and GOOGLE_SEARCH_ENGINE_ID in config.
+    Free tier: 100 queries/day.
+    https://developers.google.com/custom-search/v1/overview
+    """
+
+    API_URL = "https://www.googleapis.com/customsearch/v1"
+
+    def __init__(self, api_key: str, search_engine_id: str) -> None:
+        """Initialize with Google API key and Custom Search Engine ID."""
+        self._api_key = api_key
+        self._search_engine_id = search_engine_id
+
+    @property
+    def name(self) -> str:
+        """Provider name for logging."""
+        return "google"
+
+    def search(self, query: str, max_results: int = 10) -> tuple[list[SearchResult], int]:
+        """Execute a Google Custom Search."""
+        params: dict[str, Any] = {
+            "key": self._api_key,
+            "cx": self._search_engine_id,
+            "q": query,
+            "num": min(max_results, 10),
+        }
+
+        resp = requests.get(self.API_URL, params=params, timeout=_DEFAULT_TIMEOUT)
+        resp.raise_for_status()
+        data = resp.json()
+
+        items = data.get("items", [])
+        total = int(data.get("searchInformation", {}).get("totalResults", len(items)))
+
+        results = [
+            SearchResult(
+                title=r.get("title", ""),
+                url=r.get("link", ""),
+                snippet=r.get("snippet", ""),
+            )
+            for r in items
+        ]
+
+        return results, total

--- a/src/diogenes/search_providers.py
+++ b/src/diogenes/search_providers.py
@@ -11,6 +11,61 @@ from diogenes.search import SearchResult
 _DEFAULT_TIMEOUT = 10
 
 
+class SerperSearchProvider:
+    """Serper.dev search provider (Google results).
+
+    Free tier: 2,500 queries/month. Simple JSON API.
+    https://serper.dev/
+    """
+
+    API_URL = "https://google.serper.dev/search"
+
+    def __init__(self, api_key: str) -> None:
+        """Initialize with a Serper.dev API key."""
+        self._api_key = api_key
+
+    @property
+    def name(self) -> str:
+        """Provider name for logging."""
+        return "serper"
+
+    def search(self, query: str, max_results: int = 10) -> tuple[list[SearchResult], int]:
+        """Execute a Serper.dev web search (Google results)."""
+        headers = {
+            "X-API-KEY": self._api_key,
+            "Content-Type": "application/json",
+        }
+        payload: dict[str, Any] = {
+            "q": query,
+            "num": max_results,
+        }
+
+        resp = requests.post(
+            self.API_URL,
+            headers=headers,
+            json=payload,
+            timeout=_DEFAULT_TIMEOUT,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+
+        organic = data.get("organic", [])
+        # Serper doesn't return a total count; use organic length
+        total = len(organic)
+
+        results = [
+            SearchResult(
+                title=r.get("title", ""),
+                url=r.get("link", ""),
+                snippet=r.get("snippet", ""),
+                page_age=r.get("date"),
+            )
+            for r in organic
+        ]
+
+        return results, total
+
+
 class BraveSearchProvider:
     """Brave Search API provider.
 

--- a/tests/fixtures/sample-text-input.md
+++ b/tests/fixtures/sample-text-input.md
@@ -1,0 +1,12 @@
+# Test claims for Diogenes CLI
+
+## Claims
+
+1. AI models trained with RLHF exhibit sycophantic behavior where they
+   agree with users rather than providing accurate information.
+
+2. The EU AI Act mandates watermarking of AI-generated content by August 2026.
+
+## Queries
+
+1. What alternatives to RLHF are being explored for training language models?

--- a/uv.lock
+++ b/uv.lock
@@ -299,6 +299,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "types-jsonschema" },
+    { name = "types-requests" },
 ]
 
 [package.metadata]
@@ -318,6 +319,7 @@ dev = [
     { name = "pytest-cov" },
     { name = "ruff" },
     { name = "types-jsonschema" },
+    { name = "types-requests" },
 ]
 
 [[package]]
@@ -1261,6 +1263,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/9f/4c/2ef5483ef81e7b6e1b901eb2994fd280cb19860134a20ff99e72748f3ccb/types_jsonschema-4.26.0.20260408.tar.gz", hash = "sha256:82b75a976ed1507c473b8dee2d4841bd65926758c6d672bb93d08bf5e16f1b3f", size = 16553, upload-time = "2026-04-08T04:36:00.543Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/12/3c/724ad6ecaea06e8c6c8a8c9949a0979e6a2149b8aec4fe160135c64dd5ac/types_jsonschema-4.26.0.20260408-py3-none-any.whl", hash = "sha256:1ab0058c2612b0b81fc4e3c88ec3f9ad9b0af3fd31a176030d78b6d6cefb6e7b", size = 16081, upload-time = "2026-04-08T04:35:59.678Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260408"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/6a/749dc53a54a3f35842c1f8197b3ca6b54af6d7458a1bfc75f6629b6da666/types_requests-2.33.0.20260408.tar.gz", hash = "sha256:95b9a86376807a216b2fb412b47617b202091c3ea7c078f47cc358d5528ccb7b", size = 23882, upload-time = "2026-04-08T04:34:49.33Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/b8/78fd6c037de4788c040fdd323b3369804400351b7827473920f6c1d03c10/types_requests-2.33.0.20260408-py3-none-any.whl", hash = "sha256:81f31d5ea4acb39f03be7bc8bed569ba6d5a9c5d97e89f45ac43d819b68ca50f", size = 20739, upload-time = "2026-04-08T04:34:48.325Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Full implementation of the Diogenes 11-step research pipeline as a Python
coordinator calling AI sub-agents via the Anthropic API.

- **Steps 1-11** all working end-to-end with schema validation
- **Python search execution** via Serper.dev (93% token reduction vs AI web search)
- **Batched relevance scoring** (many small LLM calls vs one massive call)
- **Prompt caching** on common guidelines (26% cost reduction)
- **Token usage tracking** with per-call breakdown and USD cost estimates
- **JSON Schema** for every sub-agent input/output (single source of truth)

### Architecture

```
common-guidelines.md (cached) + sub-agent prompt + JSON schema
    → composed at call time by API client
    → sent to Anthropic API
    → response validated against schema
    → passed to next pipeline step
```

### Cost progression (2 claims + 1 query)

| Optimization | Cost |
|-------------|------|
| Anthropic web search (rejected) | ~$5+ |
| Python search, no caching | $2.62 |
| **Python search + prompt caching** | **$1.93** |
| Haiku scoring (rejected — wrong verdicts) | $1.58 |

### Files added/changed

- 8 sub-agent prompts in `prompts/sub-agents/`
- 1 common guidelines file in `prompts/`
- 8 JSON schemas in `src/diogenes/schemas/`
- `src/diogenes/pipeline.py` — step functions
- `src/diogenes/search.py` — search provider protocol, page fetcher
- `src/diogenes/search_providers.py` — Serper, Brave, Google
- `src/diogenes/api_client.py` — prompt caching, schema injection, usage tracking
- `src/diogenes/config.py` — search provider config, .diorc support

### Issues created during this work

- #73 pluggable search providers
- #75 curated academic sources (Scholar, arXiv, PubMed)
- #76 configurable pipeline parameters via .diorc
- #77 retry logic for transient API failures
- #78 MCP server for Claude Code plugin
- #79 local LLM support
- #80 service decomposition design
- #81 cloud LLM cost analysis
- #82 cost optimization roadmap
- #83 parallelize pipeline calls
- #84 model tier cost comparison (with run data)
- #85 model version pinning strategy

## Test plan

- [x] Full 11-step run with sample input (2 claims + 1 query)
- [x] Schema validation on all sub-agent responses
- [x] Cost tracking in usage.json
- [x] Prompt caching verified (171K cached tokens)
- [x] Haiku comparison tested and rejected (verdict divergence)
- [ ] CI checks (ruff, mypy, pytest, markdownlint)

Closes #61 (partial — CLI pipeline component)

:robot: Generated with [Claude Code](https://claude.com/claude-code)