### PR TITLE
feat: dio render — JSON-to-markdown renderer + reading-list denormalization

### DIFF
--- a/ai-research-methodology/standalone/research.md
+++ b/ai-research-methodology/standalone/research.md
@@ -873,8 +873,22 @@ Produce a prioritized reading list from the scored sources:
 - **Should read**: High reliability OR High relevance (not both)
 - **Reference**: Everything else
 
-For each source include: URL, one-sentence summary of its contribution,
-priority ranking, origin (search-discovered or researcher-provided).
+Each reading-list entry must stand alone as a complete article reference —
+downstream renderers should never need to join back against the scorecards
+to present an entry. Copy the following fields verbatim from the matching
+source scorecard: `title`, `authors`, `date`, and `content_summary`.
+If a scorecard field is missing or unknown, omit that field from the
+entry rather than inventing a value.
+
+Then add the following entry-specific fields:
+
+- `url` — the source URL
+- `reason` — a one-sentence explanation of why a reader should consult
+  this source for *this* research question. Distinct from
+  `content_summary`, which is neutral about the reader's purpose.
+- `items` — the IDs of the claims or queries this source supports
+- `priority` — must read / should read / reference
+- `origin` — search-discovered or researcher-provided
 
 ## Output
 

--- a/prompts/compiled/self-auditor.md
+++ b/prompts/compiled/self-auditor.md
@@ -347,8 +347,22 @@ Produce a prioritized reading list from the scored sources:
 - **Should read**: High reliability OR High relevance (not both)
 - **Reference**: Everything else
 
-For each source include: URL, one-sentence summary of its contribution,
-priority ranking, origin (search-discovered or researcher-provided).
+Each reading-list entry must stand alone as a complete article reference —
+downstream renderers should never need to join back against the scorecards
+to present an entry. Copy the following fields verbatim from the matching
+source scorecard: `title`, `authors`, `date`, and `content_summary`.
+If a scorecard field is missing or unknown, omit that field from the
+entry rather than inventing a value.
+
+Then add the following entry-specific fields:
+
+- `url` — the source URL
+- `reason` — a one-sentence explanation of why a reader should consult
+  this source for *this* research question. Distinct from
+  `content_summary`, which is neutral about the reader's purpose.
+- `items` — the IDs of the claims or queries this source supports
+- `priority` — must read / should read / reference
+- `origin` — search-discovered or researcher-provided
 
 ## Output
 
@@ -447,13 +461,34 @@ Your output MUST conform to this JSON Schema. This is the canonical specificatio
     },
     "reading_list_entry": {
       "type": "object",
-      "required": ["url", "summary", "priority"],
+      "description": "Stands alone as a rich article reference — all metadata needed to cite and describe the source is denormalized onto the entry so downstream renderers do not need to join back against the source scorecards.",
+      "required": ["url", "title", "reason", "priority"],
       "properties": {
         "url": { "type": "string" },
-        "title": { "type": "string" },
-        "summary": {
+        "title": {
           "type": "string",
-          "description": "One-sentence summary of what this source contributes."
+          "description": "Title of the source, copied from the matching scorecard."
+        },
+        "authors": {
+          "type": "string",
+          "description": "Author line (names, institutions, or publisher as appropriate) copied from the scorecard."
+        },
+        "date": {
+          "type": "string",
+          "description": "Publication or last-updated date copied from the scorecard."
+        },
+        "content_summary": {
+          "type": "string",
+          "description": "Short neutral description of what the source says, copied from the scorecard."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Why this entry is on the reading list — how it advances the research question. Distinct from content_summary, which is neutral about the reader's purpose."
+        },
+        "items": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "IDs of claims or queries this source speaks to."
         },
         "priority": {
           "type": "string",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ docstring-quotes = "double"
     "C901",    # Renderer functions handle multiple JSON schema variants.
     "PERF401", # Conditional list-building is clearer with append loops.
     "PLR0912", # Renderer branches on schema variants (CLI vs plugin).
+    "PLR0913", # Renderers take many step-output args to build rich index pages.
     "PLR0915", # Markdown writers have many statements by nature.
     "TC003",   # pathlib.Path needed at runtime for type checks and operations.
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,6 +116,13 @@ docstring-quotes = "double"
     "PLR0913", # call_sub_agent has keyword-only params for composability.
     "C901",    # _parse_json_response handles multiple extraction strategies.
 ]
+"src/diogenes/renderer.py" = [
+    "C901",    # Renderer functions handle multiple JSON schema variants.
+    "PERF401", # Conditional list-building is clearer with append loops.
+    "PLR0912", # Renderer branches on schema variants (CLI vs plugin).
+    "PLR0915", # Markdown writers have many statements by nature.
+    "TC003",   # pathlib.Path needed at runtime for type checks and operations.
+]
 
 [tool.ruff.format]
 quote-style = "double"

--- a/src/diogenes/cli.py
+++ b/src/diogenes/cli.py
@@ -78,6 +78,21 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Number of independent runs (default: 3)",
     )
 
+    # --- dio render ---
+    render_parser = subparsers.add_parser(
+        "render",
+        help="Render a JSON research output directory to linked markdown",
+    )
+    render_parser.add_argument(
+        "input_dir",
+        help="Path to a run group directory (containing run-N/ subdirs) or a single run directory",
+    )
+    render_parser.add_argument(
+        "--output",
+        required=True,
+        help="Output directory for rendered markdown tree",
+    )
+
     return parser
 
 
@@ -100,6 +115,26 @@ def main() -> int:
         print(f"dio fact-check: doc={args.document} output={args.output} runs={args.runs}")
         print("Not yet implemented.")
         return 1
+
+    if args.command == "render":
+        from pathlib import Path
+
+        from diogenes.renderer import render_run, render_run_group
+
+        input_path = Path(args.input_file if hasattr(args, "input_file") else args.input_dir)
+        output_path = Path(args.output)
+
+        # Detect: run-N directory (single run) vs run group (contains run-N subdirs)
+        has_run_subdirs = any(d.is_dir() and d.name.startswith("run-") for d in input_path.iterdir())
+        if has_run_subdirs:
+            print(f"Rendering run group: {input_path}")
+            render_run_group(input_path, output_path)
+        else:
+            print(f"Rendering single run: {input_path}")
+            render_run(input_path, output_path)
+
+        print(f"Rendered to: {output_path}")
+        return 0
 
     return 1
 

--- a/src/diogenes/mcp_server.py
+++ b/src/diogenes/mcp_server.py
@@ -19,11 +19,13 @@ Usage with Claude Code:
 from __future__ import annotations
 
 import json
+from pathlib import Path
 from typing import Any
 
 from mcp.server.fastmcp import FastMCP
 
 from diogenes.config import ConfigError, load_config
+from diogenes.renderer import render_run, render_run_group
 from diogenes.search import fetch_page_extract
 from diogenes.search_providers import BraveSearchProvider, GoogleSearchProvider, SerperSearchProvider
 
@@ -171,6 +173,56 @@ def dio_search_batch(queries: list[str], max_results_per_query: int = 5) -> str:
         "results": all_results,
     }
     return json.dumps(output, indent=2)
+
+
+@server.tool(
+    name="dio_render",
+    description=(
+        "Render a Diogenes JSON research output directory to a tree of "
+        "linked markdown files. Pure Python — zero LLM tokens. Reads the "
+        "JSON files written by the /research workflow (research-input.json, "
+        "hypotheses.json, reports.json, etc.) and produces clean browsable "
+        "markdown with relative links. ONLY use within /research workflows."
+    ),
+)
+def dio_render(input_dir: str, output_dir: str) -> str:
+    """Render JSON research output to linked markdown.
+
+    Args:
+        input_dir: Path to a run directory (with JSON files) or a run group
+            directory (containing run-N/ subdirectories).
+        output_dir: Path where the markdown tree should be written.
+
+    Returns:
+        JSON status report with paths and counts.
+
+    """
+    input_path = Path(input_dir)
+    output_path = Path(output_dir)
+
+    if not input_path.exists():
+        return json.dumps({"error": True, "message": f"Input directory not found: {input_dir}"})
+
+    has_run_subdirs = any(d.is_dir() and d.name.startswith("run-") for d in input_path.iterdir())
+
+    if has_run_subdirs:
+        render_run_group(input_path, output_path)
+        mode = "run-group"
+    else:
+        render_run(input_path, output_path)
+        mode = "single-run"
+
+    md_files = list(output_path.rglob("*.md"))
+    return json.dumps(
+        {
+            "mode": mode,
+            "input_dir": str(input_path),
+            "output_dir": str(output_path),
+            "markdown_files_written": len(md_files),
+            "entry_point": str(output_path / "index.md"),
+        },
+        indent=2,
+    )
 
 
 def main() -> None:

--- a/src/diogenes/prompts/sub-agents/self-auditor.md
+++ b/src/diogenes/prompts/sub-agents/self-auditor.md
@@ -58,8 +58,22 @@ Produce a prioritized reading list from the scored sources:
 - **Should read**: High reliability OR High relevance (not both)
 - **Reference**: Everything else
 
-For each source include: URL, one-sentence summary of its contribution,
-priority ranking, origin (search-discovered or researcher-provided).
+Each reading-list entry must stand alone as a complete article reference —
+downstream renderers should never need to join back against the scorecards
+to present an entry. Copy the following fields verbatim from the matching
+source scorecard: `title`, `authors`, `date`, and `content_summary`.
+If a scorecard field is missing or unknown, omit that field from the
+entry rather than inventing a value.
+
+Then add the following entry-specific fields:
+
+- `url` — the source URL
+- `reason` — a one-sentence explanation of why a reader should consult
+  this source for *this* research question. Distinct from
+  `content_summary`, which is neutral about the reader's purpose.
+- `items` — the IDs of the claims or queries this source supports
+- `priority` — must read / should read / reference
+- `origin` — search-discovered or researcher-provided
 
 ## Output
 

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -575,19 +575,19 @@ def _write_item_index(
     if has_summary:
         lines.extend(['<a id="sec-summary"></a>', "", "## Summary", ""])
 
-        # Claim / Query
+        # Claim / Query (single paragraph: label + text inline)
         if item_type == "axiom":
-            lines.extend(["**Axiom:**", "", original, ""])
+            lines.extend([f"**Axiom:** {original}", ""])
         else:
             label = "Claim" if item_type == "claim" else "Query"
-            lines.extend([f"**{label}:**", "", original or clarified, ""])
+            lines.extend([f"**{label}:** {original or clarified}", ""])
 
         # Bottom Line (BLUF) from report
         bluf = ""
         if isinstance(report, dict):
             bluf = report.get("verdict_summary") or report.get("answer_summary") or report.get("one_line") or ""
         if bluf:
-            lines.extend(["**Bottom Line:**", "", bluf, ""])
+            lines.extend([f"**Bottom Line:** {bluf}", ""])
 
         # Verdict / Confidence
         verdict = ""

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -278,17 +278,6 @@ def _write_run_index(
     claims = [i for i in input_items if i.get("type") == "claim"]
     queries = [i for i in input_items if i.get("type") == "query"]
 
-    # Meta table — only include rows with non-zero counts
-    meta_rows: list[str] = []
-    if axioms:
-        meta_rows.append(f"| **Axioms** | {len(axioms)} |")
-    if claims:
-        meta_rows.append(f"| **Claims** | {len(claims)} |")
-    if queries:
-        meta_rows.append(f"| **Queries** | {len(queries)} |")
-    if meta_rows:
-        lines.extend(["| | |", "|---|---|", *meta_rows, ""])
-
     # Slug lookup
     slug_by_id: dict[str, str] = {}
     for item in input_items:

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -391,9 +391,7 @@ def _write_run_index(
     slug_by_id: dict[str, str] = {}
     for item in input_items:
         item_id = item.get("id", "")
-        clarified = (
-            item.get("restated_for_testability") or item.get("clarified_text") or item.get("original_text", "")
-        )
+        clarified = item.get("restated_for_testability") or item.get("clarified_text") or item.get("original_text", "")
         if item_id:
             slug_by_id[item_id] = _item_slug(item_id, clarified)
 
@@ -484,18 +482,11 @@ def _write_run_index(
 
             # Claim / Query text
             text_label = "Claim" if item_type == "claim" else "Query"
-            item_text = (
-                original or clarified or report.get("original_query") or report.get("original_claim", "")
-            )
+            item_text = original or clarified or report.get("original_query") or report.get("original_claim", "")
             lines.extend([f"**{text_label}:** {item_text}", ""])
 
             # Answer / verdict summary
-            answer = (
-                report.get("verdict_summary")
-                or report.get("answer_summary")
-                or report.get("one_line")
-                or ""
-            )
+            answer = report.get("verdict_summary") or report.get("answer_summary") or report.get("one_line") or ""
             if answer:
                 answer_label = "Verdict" if item_type == "claim" else "Answer"
                 lines.extend([f"**{answer_label}:** {answer}", ""])
@@ -693,22 +684,21 @@ def _write_item_index(
             verdict_label = "Verdict" if item_type == "claim" else "Confidence"
             lines.extend([f"**{verdict_label}:** {verdict}", ""])
 
-    # --- Results section (the seven artifacts) -----------------------------
-    lines.extend(['<a id="sec-results"></a>', "", "## Results", "", "| Artifact | Description |", "|----------|-------------|"])
+    # --- Results section ---------------------------------------------------
+    # Artifact links only for pages unique to the Results view; hypotheses,
+    # searches, and sources are already surfaced in their own tables below
+    # with direct links to detail files, so no intermediate index is needed.
+    lines.extend(
+        ['<a id="sec-results"></a>', "", "## Results", "", "| Artifact | Description |", "|----------|-------------|"]
+    )
     if (item_dir / input_filename).exists():
         lines.append(f"| [Input]({input_filename}) | Original text, clarification, scope, vocabulary |")
-    if (item_dir / "hypotheses" / "index.md").exists():
-        lines.append("| [Hypotheses](hypotheses/index.md) | Competing hypotheses |")
     if (item_dir / "assessment.md").exists():
         lines.append("| [Assessment](assessment.md) | Evidence synthesis, probability assessment, gaps |")
     if (item_dir / "self-audit.md").exists():
         lines.append("| [Self-Audit](self-audit.md) | Process audit across 4 ROBIS domains |")
     if (item_dir / "reading-list.md").exists():
         lines.append("| [Reading List](reading-list.md) | Prioritized source list |")
-    if (item_dir / "searches" / "index.md").exists():
-        lines.append("| [Searches](searches/index.md) | Search plans and execution logs |")
-    if (item_dir / "sources" / "index.md").exists():
-        lines.append("| [Sources](sources/index.md) | Source scorecards |")
     lines.append("")
 
     # Hypothesis summary table (if hypotheses exist)
@@ -874,47 +864,30 @@ def _write_item_input(item_dir: Path, item: dict[str, Any], report: dict[str, An
     (item_dir / filename).write_text("\n".join(lines) + "\n")
 
 
-def _write_hypotheses(
-    item_dir: Path, data: dict[str, Any], report: dict[str, Any], synthesis: dict[str, Any]
-) -> None:
-    """Write hypotheses/ directory with per-hypothesis files and an index.
+def _write_hypotheses(item_dir: Path, data: dict[str, Any], report: dict[str, Any], synthesis: dict[str, Any]) -> None:
+    """Write hypotheses/ directory with per-hypothesis detail files.
 
     Creates:
         hypotheses/
-            index.md    — summary table of all hypotheses
             H1.md       — one file per hypothesis
             H2.md
             ...
+
+    The item-level index already carries the summary table with direct
+    links to these files, so no intermediate index is written here.
     """
     item_id = data.get("id", "?")
+    approach = data.get("approach", "hypotheses")
+
+    hyps = data.get("search_themes", []) if approach == "open-ended" else data.get("hypotheses", [])
+    if not hyps:
+        return
+
     hyps_dir = item_dir / "hypotheses"
     hyps_dir.mkdir(parents=True, exist_ok=True)
 
-    approach = data.get("approach", "hypotheses")
-    # Reconstruct a minimal item dict for title-building
-    item_for_title = {"id": item_id}
-
-    # Collect status string per hypothesis id (handles both CLI and plugin schemas)
-    ratings_by_hyp = _collect_hypothesis_ratings(report, synthesis)
-
     if approach == "open-ended":
-        # For open-ended queries there are no discrete hypotheses; write themes instead.
-        index_lines = [f"# {_subpage_title(item_for_title, report, 'Search Themes')}", ""]
-        rationale = data.get("rationale", "")
-        if rationale:
-            index_lines.extend([rationale, ""])
-
-        themes = data.get("search_themes", [])
-        if themes:
-            index_lines.extend(["| ID | Theme | Derived from |", "|----|-------|--------------|"])
-            for t in themes:
-                theme_id = t.get("id", "?")
-                theme = t.get("theme", "")
-                derived = t.get("derived_from", "")
-                index_lines.append(f"| [{theme_id}]({theme_id}.md) | {theme} | {derived} |")
-            index_lines.append("")
-
-        for t in themes:
+        for t in hyps:
             theme_id = t.get("id", "?")
             theme_lines = [f"# {item_id} — {theme_id}: {t.get('theme', '')}", ""]
             derived = t.get("derived_from", "")
@@ -932,45 +905,18 @@ def _write_hypotheses(
                 for p in perspectives:
                     theme_lines.append(f"- {p}")
                 theme_lines.append("")
-            theme_lines.append("[← Back to hypotheses index](index.md)")
+            theme_lines.append("[← Back to item overview](../index.md)")
             theme_lines = _add_toc(theme_lines)
             (hyps_dir / f"{theme_id}.md").write_text("\n".join(theme_lines) + "\n")
-    else:
-        hyps = data.get("hypotheses", [])
+        return
 
-        index_lines = [
-            f"# {_subpage_title(item_for_title, report, 'Hypotheses')}",
-            "",
-            "| ID | Label | Statement | Status |",
-            "|----|-------|-----------|--------|",
-        ]
-        for h in hyps:
-            hyp_id = h.get("id", "?")
-            # Support both "H1" and "C001-H1" ID styles; use short ID for filename
-            short_id = hyp_id.split("-")[-1] if "-" in hyp_id else hyp_id
-            label = h.get("label", "")
-            statement = (h.get("statement") or "")[:100]
-            status = ratings_by_hyp.get(hyp_id, "—")
-            index_lines.append(f"| [{short_id}]({short_id}.md) | {label} | {statement} | {status[:60]} |")
-        index_lines.append("")
-
-        # Discriminating questions in the index
-        disc = data.get("discriminating_questions", [])
-        if disc:
-            index_lines.extend(["## Discriminating Questions", ""])
-            for q in disc:
-                index_lines.append(f"- {q}")
-            index_lines.append("")
-
-        # Per-hypothesis file
-        for h in hyps:
-            hyp_id = h.get("id", "?")
-            short_id = hyp_id.split("-")[-1] if "-" in hyp_id else hyp_id
-            _write_hypothesis_file(hyps_dir / f"{short_id}.md", item_id, h, ratings_by_hyp.get(hyp_id, ""))
-
-    index_lines.append("[← Back to item overview](../index.md)")
-    index_lines = _add_toc(index_lines)
-    (hyps_dir / "index.md").write_text("\n".join(index_lines) + "\n")
+    # Discrete hypothesis mode
+    ratings_by_hyp = _collect_hypothesis_ratings(report, synthesis)
+    for h in hyps:
+        hyp_id = h.get("id", "?")
+        # Support both "H1" and "C001-H1" ID styles; use short ID for filename
+        short_id = hyp_id.split("-")[-1] if "-" in hyp_id else hyp_id
+        _write_hypothesis_file(hyps_dir / f"{short_id}.md", item_id, h, ratings_by_hyp.get(hyp_id, ""))
 
 
 def _write_hypothesis_file(path: Path, item_id: str, h: dict[str, Any], status: str) -> None:
@@ -1003,7 +949,7 @@ def _write_hypothesis_file(path: Path, item_id: str, h: dict[str, Any], status: 
             lines.append(f"- {e}")
         lines.append("")
 
-    lines.append("[← Back to hypotheses index](index.md)")
+    lines.append("[← Back to item overview](../index.md)")
     lines = _add_toc(lines)
     path.write_text("\n".join(lines) + "\n")
 
@@ -1232,11 +1178,36 @@ def _write_reading_list(
     scorecards: dict[str, Any],
     report: dict[str, Any],
 ) -> None:
-    """Write reading-list.md with prioritized sources."""
+    """Write reading-list.md with prioritized sources.
+
+    Reading-list entries are expected to be self-contained article references
+    — the self-audit step denormalizes title/authors/date/content_summary
+    from the source scorecards onto each entry, so this writer reads those
+    fields straight off the entry without any cross-artifact joining.
+    """
     item_for_title = {"id": item_id}
     lines = [f"# {_subpage_title(item_for_title, report, 'Reading List')}", ""]
 
     reading_list = audit.get("reading_list", []) if isinstance(audit, dict) else []
+
+    def _format_entry(entry: dict[str, Any]) -> list[str]:
+        url = entry.get("url", "")
+        title = entry.get("title") or url
+        authors = entry.get("authors", "")
+        date = entry.get("date", "")
+        content_summary = entry.get("content_summary", "")
+        # `summary` is the legacy field name; accept it as a fallback for reason.
+        reason = entry.get("reason") or entry.get("summary") or ""
+
+        out: list[str] = [f"- **[{title}]({url})**" if url else f"- **{title}**"]
+        meta_bits = [bit for bit in (authors, date) if bit]
+        if meta_bits:
+            out.append(f"  - {' · '.join(meta_bits)}")
+        if content_summary:
+            out.append(f"  - {content_summary}")
+        if reason:
+            out.append(f"  - _Why read:_ {reason}")
+        return out
 
     if reading_list:
         by_priority: dict[str, list[dict[str, Any]]] = {"must read": [], "should read": [], "reference": []}
@@ -1249,12 +1220,7 @@ def _write_reading_list(
             if entries:
                 lines.extend([f"## {priority_label.title()}", ""])
                 for e in entries:
-                    title = e.get("title") or e.get("url", "")
-                    summary = e.get("summary", "")
-                    url = e.get("url", "")
-                    lines.append(f"- **[{title}]({url})**")
-                    if summary:
-                        lines.append(f"  - {summary}")
+                    lines.extend(_format_entry(e))
                 lines.append("")
     else:
         # Fall back to scorecards directly
@@ -1298,25 +1264,24 @@ def _write_searches(
     item_id: str,
     item_plan: dict[str, Any],
     search_results: dict[str, Any],
-    report: dict[str, Any],
+    report: dict[str, Any],  # noqa: ARG001 - accepted for symmetry with other artifact writers
 ) -> None:
-    """Write searches/ subdirectory with per-search logs and an index."""
+    """Write searches/ subdirectory with per-search logs.
+
+    Per-search subdirectories contain a search-log.md plus a results/
+    subfolder with one file per hit. The item-level index already renders
+    a summary table that links directly into each search-log.md, so no
+    intermediate searches/index.md is produced.
+    """
     if not item_plan:
+        return
+    searches = item_plan.get("searches", [])
+    if not searches:
         return
     searches_dir = item_dir / "searches"
     searches_dir.mkdir(parents=True, exist_ok=True)
 
-    searches = item_plan.get("searches", [])
     execution_log = search_results.get("search_execution_log", []) if isinstance(search_results, dict) else []
-
-    # Write per-search logs and collect index entries
-    item_for_title = {"id": item_id}
-    index_lines = [
-        f"# {_subpage_title(item_for_title, report, 'Searches')}",
-        "",
-        "| ID | Target | Terms | Returned | Selected | Rejected |",
-        "|----|--------|-------|----------|----------|----------|",
-    ]
 
     for s in searches:
         search_id = s.get("id", "S??")
@@ -1429,20 +1394,9 @@ def _write_searches(
                     ]
                 )
 
-        lines.append("[← Back to searches index](../index.md)")
+        lines.append("[← Back to item overview](../../index.md)")
         lines = _add_toc(lines)
         (search_subdir / "search-log.md").write_text("\n".join(lines) + "\n")
-
-        # Add to index with counts
-        terms_short = ", ".join(f"`{t}`" for t in terms[:3])
-        index_lines.append(
-            f"| [{search_id}]({search_id}/search-log.md) | {theme[:60]} | {terms_short} | "
-            f"{total_returned} | {selected_count} | {rejected_count} |"
-        )
-
-    index_lines.extend(["", "[← Back to item overview](../index.md)"])
-    index_lines = _add_toc(index_lines)
-    (searches_dir / "index.md").write_text("\n".join(index_lines) + "\n")
 
 
 def _write_sources(
@@ -1450,23 +1404,19 @@ def _write_sources(
     item_id: str,
     scorecards: dict[str, Any],
     search_results: dict[str, Any],  # noqa: ARG001
-    report: dict[str, Any],
+    report: dict[str, Any],  # noqa: ARG001 - accepted for symmetry with other artifact writers
 ) -> None:
-    """Write sources/ subdirectory with per-source scorecards."""
+    """Write sources/ subdirectory with per-source scorecards.
+
+    The item-level index already renders a summary table linking directly
+    to each scorecard, so no intermediate sources/index.md is produced.
+    """
     sources = _extract_sources_for_item(scorecards, item_id)
     if not sources:
         return
 
     sources_dir = item_dir / "sources"
     sources_dir.mkdir(parents=True, exist_ok=True)
-
-    item_for_title = {"id": item_id}
-    index_lines = [
-        f"# {_subpage_title(item_for_title, report, 'Sources')}",
-        "",
-        "| ID | Title | Reliability | Relevance |",
-        "|----|-------|-------------|-----------|",
-    ]
 
     for i, s in enumerate(sources, 1):
         src_id = s.get("id") or f"SRC{i:03d}"
@@ -1481,7 +1431,6 @@ def _write_sources(
         relev_value = s.get("relevance", "")
         rel_str = rel_value.get("rating", "—") if isinstance(rel_value, dict) else (rel_value or "—")
         relev_str = relev_value.get("rating", "—") if isinstance(relev_value, dict) else (relev_value or "—")
-        index_lines.append(f"| [{src_id}]({src_id}/scorecard.md) | {title[:60]} | {rel_str} | {relev_str} |")
 
         # Per-source scorecard
         lines = [f"# {src_id} — {title}", ""]
@@ -1548,13 +1497,9 @@ def _write_sources(
                 lines.append(f"| {domain_label} | {rating} | {rationale} |")
             lines.append("")
 
-        lines.append("[← Back to sources index](../index.md)")
+        lines.append("[← Back to item overview](../../index.md)")
         lines = _add_toc(lines)
         (src_subdir / "scorecard.md").write_text("\n".join(lines) + "\n")
-
-    index_lines.extend(["", "[← Back to item overview](../index.md)"])
-    index_lines = _add_toc(index_lines)
-    (sources_dir / "index.md").write_text("\n".join(index_lines) + "\n")
 
 
 # ---------------------------------------------------------------------------

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -96,6 +96,19 @@ def _item_by_id(items: list[dict[str, Any]], item_id: str) -> dict[str, Any]:
     return {}
 
 
+def _card_heading_for(item: dict[str, Any], report: dict[str, Any]) -> str:
+    """Build '{id} — {topic} — {qualifier}' heading string used across pages."""
+    iid = item.get("id", "?")
+    topic = report.get("title", "").strip()
+    qualifier = (report.get("verdict") or report.get("confidence") or "").strip()
+    parts = [iid]
+    if topic:
+        parts.append(topic)
+    if qualifier:
+        parts.append(qualifier)
+    return " — ".join(parts)
+
+
 def _collect_hypothesis_ratings(report: dict[str, Any], synthesis: dict[str, Any]) -> dict[str, str]:
     """Collect hypothesis rating/disposition strings, keyed by hypothesis ID.
 
@@ -295,18 +308,6 @@ def _write_run_index(
     execution_log = search_results.get("search_execution_log", []) if isinstance(search_results, dict) else []
     reports_by_id: dict[str, dict[str, Any]] = {r.get("id", ""): r for r in reports}
 
-    def _card_heading(item: dict[str, Any], report: dict[str, Any]) -> str:
-        """Build a card-level heading like '{id} — {topic} — {qualifier}'."""
-        iid = item.get("id", "?")
-        topic = report.get("title", "").strip()
-        qualifier = (report.get("verdict") or report.get("confidence") or "").strip()
-        parts = [iid]
-        if topic:
-            parts.append(topic)
-        if qualifier:
-            parts.append(qualifier)
-        return " — ".join(parts)
-
     # Use explicit HTML anchors rather than relying on heading-text-derived anchors.
     # Different markdown renderers (GFM, MkDocs, VS Code preview) generate anchors
     # differently from the same heading text — em-dashes and parentheses cause
@@ -332,7 +333,7 @@ def _write_run_index(
         for item in section_items:
             iid = item.get("id", "?")
             report = reports_by_id.get(iid, {})
-            heading_text = _card_heading(item, report)
+            heading_text = _card_heading_for(item, report)
             sub_entries.append((f"card-{iid}", heading_text))
         toc_entries.append((section_anchor, section_label, sub_entries))
 
@@ -374,7 +375,7 @@ def _write_run_index(
                 [
                     f'<a id="card-{item_id}"></a>',
                     "",
-                    f"### {_card_heading(item, report)}",
+                    f"### {_card_heading_for(item, report)}",
                     "",
                 ]
             )
@@ -502,26 +503,102 @@ def _write_item_index(
     search_results: dict[str, Any],
     scorecards: dict[str, Any],
 ) -> None:
-    """Write the per-item index.md with BLUF, summary tables, and navigation."""
+    """Write the per-item index.md with Summary, Results table, and analytical tables.
+
+    Page structure:
+        # {id} — {topic} — {qualifier}          (title matches run-index card)
+        ## Contents                             (table of contents, TOC sentinels)
+        ## Summary                              (Claim/Query, Bottom Line, Verdict)
+        ## Results                              (links to the seven artifacts)
+        ## Hypotheses                           (summary table)
+        ## Searches                             (summary table)
+        ## Sources                              (summary table)
+        ## Evidence Snapshot
+        ## Revisit Triggers
+    """
     item_id = item.get("id", "?")
     item_type = item.get("type", "claim")
     input_filename = "claim.md" if item_type == "claim" else "query.md"
 
     clarified = item.get("restated_for_testability") or item.get("clarified_text") or item.get("original_text", "")
+    original = item.get("original_text", "") or clarified
 
-    lines = [f"# {item_id}", "", f"**{clarified}**", ""]
+    # Page title — same as the card heading in the run index
+    page_title = _card_heading_for(item, report) if report else f"{item_id} — {clarified[:80]}"
+    lines: list[str] = [f"# {page_title}", ""]
 
-    # BLUF from report
-    if report:
-        verdict = report.get("verdict", "")
-        summary = report.get("verdict_summary") or report.get("one_line") or ""
+    # --- Determine which sections will actually render -------------------
+    # (so we can build the TOC before writing the body)
+    has_summary = bool(report) or bool(clarified)
+    ratings_by_hyp = _collect_hypothesis_ratings(report, synthesis)
+    hyps_list = hypotheses.get("hypotheses", []) if isinstance(hypotheses, dict) else []
+    has_hypotheses_table = bool(hyps_list)
+
+    search_plan_searches = search_plan.get("searches", []) if isinstance(search_plan, dict) else []
+    has_searches_table = bool(search_plan_searches)
+
+    sources = _extract_sources_for_item(scorecards, item_id)
+    has_sources_table = bool(sources)
+
+    syn = synthesis.get("synthesis") or synthesis if isinstance(synthesis, dict) else {}
+    has_evidence_snapshot = bool(
+        isinstance(syn, dict)
+        and (syn.get("evidence_quality") or syn.get("source_agreement") or syn.get("ipcc_combined"))
+    )
+
+    triggers = report.get("revisit_triggers", []) if isinstance(report, dict) else []
+    has_triggers = bool(triggers)
+
+    # --- TOC ---------------------------------------------------------------
+    toc: list[tuple[str, str]] = []
+    if has_summary:
+        toc.append(("sec-summary", "Summary"))
+    toc.append(("sec-results", "Results"))
+    if has_hypotheses_table:
+        toc.append(("sec-hypotheses", "Hypotheses"))
+    if has_searches_table:
+        toc.append(("sec-searches", "Searches"))
+    if has_sources_table:
+        toc.append(("sec-sources", "Sources"))
+    if has_evidence_snapshot:
+        toc.append(("sec-evidence-snapshot", "Evidence Snapshot"))
+    if has_triggers:
+        toc.append(("sec-revisit-triggers", "Revisit Triggers"))
+
+    if len(toc) > 2:  # noqa: PLR2004 - Only include TOC when there is more than a trivial nav benefit
+        lines.extend(["<!-- TOC START -->", "## Contents", ""])
+        for anchor, label in toc:
+            lines.append(f"- [{label}](#{anchor})")
+        lines.extend(["", "<!-- TOC END -->", ""])
+
+    # --- Summary section ---------------------------------------------------
+    if has_summary:
+        lines.extend(['<a id="sec-summary"></a>', "", "## Summary", ""])
+
+        # Claim / Query
+        if item_type == "axiom":
+            lines.extend(["**Axiom:**", "", original, ""])
+        else:
+            label = "Claim" if item_type == "claim" else "Query"
+            lines.extend([f"**{label}:**", "", original or clarified, ""])
+
+        # Bottom Line (BLUF) from report
+        bluf = ""
+        if isinstance(report, dict):
+            bluf = report.get("verdict_summary") or report.get("answer_summary") or report.get("one_line") or ""
+        if bluf:
+            lines.extend(["**Bottom Line:**", "", bluf, ""])
+
+        # Verdict / Confidence
+        verdict = ""
+        if isinstance(report, dict):
+            verdict = report.get("verdict") or report.get("confidence") or ""
         if verdict:
-            lines.extend([f"**Verdict:** {verdict}", ""])
-        if summary:
-            lines.extend(["## Bottom Line", "", summary, ""])
+            verdict_label = "Verdict" if item_type == "claim" else "Confidence"
+            lines.extend([f"**{verdict_label}:** {verdict}", ""])
 
-    # Summary of what's in this directory — only link to files that exist
-    lines.extend(["## Contents", "", "| Section | Description |", "|---------|-------------|"])
+    # --- Results section (the seven artifacts) -----------------------------
+    lines.extend(['<a id="sec-results"></a>', "", "## Results", "", "| Artifact | Description |", "|----------|-------------|"])
     if (item_dir / input_filename).exists():
         lines.append(f"| [Input]({input_filename}) | Original text, clarification, scope, vocabulary |")
     if (item_dir / "hypotheses" / "index.md").exists():
@@ -539,18 +616,18 @@ def _write_item_index(
     lines.append("")
 
     # Hypothesis summary table (if hypotheses exist)
-    ratings_by_hyp = _collect_hypothesis_ratings(report, synthesis)
-
-    if hypotheses and hypotheses.get("hypotheses"):
+    if has_hypotheses_table:
         lines.extend(
             [
+                '<a id="sec-hypotheses"></a>',
+                "",
                 "## Hypotheses",
                 "",
                 "| ID | Label | Status |",
                 "|----|-------|--------|",
             ]
         )
-        for h in hypotheses["hypotheses"]:
+        for h in hyps_list:
             hyp_id = h.get("id", "?")
             short_id = hyp_id.split("-")[-1] if "-" in hyp_id else hyp_id
             label = h.get("label", "")
@@ -559,17 +636,19 @@ def _write_item_index(
         lines.append("")
 
     # Searches summary table
-    if search_plan and search_plan.get("searches"):
+    if has_searches_table:
         execution_log = search_results.get("search_execution_log", []) if isinstance(search_results, dict) else []
         lines.extend(
             [
+                '<a id="sec-searches"></a>',
+                "",
                 "## Searches",
                 "",
                 "| ID | Target | Returned | Selected |",
                 "|----|--------|----------|----------|",
             ]
         )
-        for s in search_plan["searches"]:
+        for s in search_plan_searches:
             search_id = s.get("id", "S??")
             theme = s.get("theme") or s.get("target_hypothesis") or ""
             exec_record = next(
@@ -589,10 +668,11 @@ def _write_item_index(
         lines.append("")
 
     # Sources summary table
-    sources = _extract_sources_for_item(scorecards, item_id)
-    if sources:
+    if has_sources_table:
         lines.extend(
             [
+                '<a id="sec-sources"></a>',
+                "",
                 "## Sources",
                 "",
                 "| ID | Title | Reliability | Relevance |",
@@ -610,8 +690,7 @@ def _write_item_index(
         lines.append("")
 
     # Evidence quality snapshot from synthesis
-    if synthesis:
-        syn = synthesis.get("synthesis") or synthesis
+    if has_evidence_snapshot:
         snapshot_rows: list[str] = []
         eq = syn.get("evidence_quality") if isinstance(syn, dict) else None
         sa = syn.get("source_agreement") if isinstance(syn, dict) else None
@@ -624,14 +703,23 @@ def _write_item_index(
             snapshot_rows.append(f"| IPCC assessment | {ipcc} |")
         if snapshot_rows:
             lines.extend(
-                ["## Evidence Snapshot", "", "| Dimension | Rating |", "|-----------|--------|", *snapshot_rows, ""]
+                [
+                    '<a id="sec-evidence-snapshot"></a>',
+                    "",
+                    "## Evidence Snapshot",
+                    "",
+                    "| Dimension | Rating |",
+                    "|-----------|--------|",
+                    *snapshot_rows,
+                    "",
+                ]
             )
 
     # Revisit triggers from report
     if report:
         triggers = report.get("revisit_triggers", [])
         if triggers:
-            lines.extend(["## Revisit Triggers", ""])
+            lines.extend(['<a id="sec-revisit-triggers"></a>', "", "## Revisit Triggers", ""])
             for t in triggers:
                 if isinstance(t, dict):
                     trigger_text = t.get("trigger", "")

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -96,6 +96,39 @@ def _item_by_id(items: list[dict[str, Any]], item_id: str) -> dict[str, Any]:
     return {}
 
 
+def _collect_hypothesis_ratings(report: dict[str, Any], synthesis: dict[str, Any]) -> dict[str, str]:
+    """Collect hypothesis rating/disposition strings, keyed by hypothesis ID.
+
+    Supports multiple source formats:
+    - CLI: report.assessment.hypothesis_ratings[] with probability_term/range
+    - Plugin: synthesis.assessment.hypothesis_disposition (id -> disposition string)
+    """
+    ratings: dict[str, str] = {}
+
+    # CLI format via report
+    if isinstance(report, dict):
+        assessment = report.get("assessment", {})
+        if isinstance(assessment, dict):
+            for r in assessment.get("hypothesis_ratings", []):
+                hyp_id = r.get("hypothesis_id", "")
+                if hyp_id:
+                    term = r.get("probability_term", "")
+                    rng = r.get("probability_range", "")
+                    ratings[hyp_id] = f"{term} ({rng})" if term else rng
+
+    # Plugin format via synthesis
+    if isinstance(synthesis, dict):
+        assessment = synthesis.get("assessment", {})
+        if isinstance(assessment, dict):
+            disposition = assessment.get("hypothesis_disposition", {})
+            if isinstance(disposition, dict):
+                for hyp_id, text in disposition.items():
+                    if hyp_id not in ratings:
+                        ratings[hyp_id] = str(text)
+
+    return ratings
+
+
 def render_run(run_dir: Path, output_dir: Path) -> None:
     """Render a single run's JSON output to a markdown tree.
 
@@ -150,7 +183,7 @@ def render_run(run_dir: Path, output_dir: Path) -> None:
         # Write all content files first
         _write_item_input(item_dir, item)
         if item_hypotheses:
-            _write_hypotheses(item_dir, item_hypotheses)
+            _write_hypotheses(item_dir, item_hypotheses, item_report, item_synthesis)
         if item_synthesis:
             _write_assessment(item_dir, item_synthesis, item_report)
         if audit_to_render:
@@ -161,7 +194,16 @@ def render_run(run_dir: Path, output_dir: Path) -> None:
         _write_reading_list(item_dir, audit_to_render, item_id, scorecards)
 
         # Write index LAST so existence checks see the actual files
-        _write_item_index(item_dir, item, item_report, item_synthesis)
+        _write_item_index(
+            item_dir,
+            item,
+            item_report,
+            item_synthesis,
+            item_hypotheses,
+            item_search_plan,
+            search_results,
+            scorecards,
+        )
 
 
 def render_run_group(group_dir: Path, output_dir: Path) -> None:
@@ -244,8 +286,12 @@ def _write_item_index(
     item: dict[str, Any],
     report: dict[str, Any],
     synthesis: dict[str, Any],
+    hypotheses: dict[str, Any],
+    search_plan: dict[str, Any],
+    search_results: dict[str, Any],
+    scorecards: dict[str, Any],
 ) -> None:
-    """Write the per-item index.md with BLUF and summary."""
+    """Write the per-item index.md with BLUF, summary tables, and navigation."""
     item_id = item.get("id", "?")
     item_type = item.get("type", "claim")
     input_filename = "claim.md" if item_type == "claim" else "query.md"
@@ -267,8 +313,8 @@ def _write_item_index(
     lines.extend(["## Contents", "", "| Section | Description |", "|---------|-------------|"])
     if (item_dir / input_filename).exists():
         lines.append(f"| [Input]({input_filename}) | Original text, clarification, scope, vocabulary |")
-    if (item_dir / "hypotheses.md").exists():
-        lines.append("| [Hypotheses](hypotheses.md) | Competing hypotheses |")
+    if (item_dir / "hypotheses" / "index.md").exists():
+        lines.append("| [Hypotheses](hypotheses/index.md) | Competing hypotheses |")
     if (item_dir / "assessment.md").exists():
         lines.append("| [Assessment](assessment.md) | Evidence synthesis, probability assessment, gaps |")
     if (item_dir / "self-audit.md").exists():
@@ -281,17 +327,110 @@ def _write_item_index(
         lines.append("| [Sources](sources/index.md) | Source scorecards |")
     lines.append("")
 
-    # Evidence quality snapshot
+    # Hypothesis summary table (if hypotheses exist)
+    ratings_by_hyp = _collect_hypothesis_ratings(report, synthesis)
+
+    if hypotheses and hypotheses.get("hypotheses"):
+        lines.extend(
+            [
+                "## Hypotheses",
+                "",
+                "| ID | Label | Status |",
+                "|----|-------|--------|",
+            ]
+        )
+        for h in hypotheses["hypotheses"]:
+            hyp_id = h.get("id", "?")
+            short_id = hyp_id.split("-")[-1] if "-" in hyp_id else hyp_id
+            label = h.get("label", "")
+            status = ratings_by_hyp.get(hyp_id, "—")
+            lines.append(f"| [{short_id}](hypotheses/{short_id}.md) | {label} | {status} |")
+        lines.append("")
+
+    # Searches summary table
+    if search_plan and search_plan.get("searches"):
+        execution_log = search_results.get("search_execution_log", []) if isinstance(search_results, dict) else []
+        lines.extend(
+            [
+                "## Searches",
+                "",
+                "| ID | Target | Returned | Selected |",
+                "|----|--------|----------|----------|",
+            ]
+        )
+        for s in search_plan["searches"]:
+            search_id = s.get("id", "S??")
+            theme = s.get("theme") or s.get("target_hypothesis") or ""
+            exec_record = next(
+                (e for e in execution_log if e.get("search_id") == search_id or e.get("id") == search_id),
+                None,
+            )
+            returned_str = "?"
+            selected_str = "?"
+            if exec_record:
+                results_list = exec_record.get("results", [])
+                returned_str = str(exec_record.get("total_returned") or len(results_list))
+                selected_str = str(sum(1 for r in results_list if r.get("disposition") == "selected"))
+            lines.append(
+                f"| [{search_id}](searches/{search_id}/search-log.md) | {theme[:60]} | "
+                f"{returned_str} | {selected_str} |"
+            )
+        lines.append("")
+
+    # Sources summary table
+    sources = _extract_sources_for_item(scorecards, item_id)
+    if sources:
+        lines.extend(
+            [
+                "## Sources",
+                "",
+                "| ID | Title | Reliability | Relevance |",
+                "|----|-------|-------------|-----------|",
+            ]
+        )
+        for i, s in enumerate(sources, 1):
+            src_id = s.get("id") or f"SRC{i:03d}"
+            title = (s.get("title") or s.get("url", ""))[:60]
+            rel_value = s.get("reliability", "")
+            relev_value = s.get("relevance", "")
+            rel_str = rel_value.get("rating", "—") if isinstance(rel_value, dict) else (rel_value or "—")
+            relev_str = relev_value.get("rating", "—") if isinstance(relev_value, dict) else (relev_value or "—")
+            lines.append(f"| [{src_id}](sources/{src_id}/scorecard.md) | {title} | {rel_str} | {relev_str} |")
+        lines.append("")
+
+    # Evidence quality snapshot from synthesis
     if synthesis:
         syn = synthesis.get("synthesis") or synthesis
-        evidence_quality = syn.get("evidence_quality", {})
-        source_agreement = syn.get("source_agreement", {})
-        if evidence_quality or source_agreement:
-            lines.extend(["## Evidence Snapshot", "", "| Dimension | Rating |", "|-----------|--------|"])
-            if isinstance(evidence_quality, dict) and evidence_quality.get("rating"):
-                lines.append(f"| Evidence quality | {evidence_quality.get('rating')} |")
-            if isinstance(source_agreement, dict) and source_agreement.get("rating"):
-                lines.append(f"| Source agreement | {source_agreement.get('rating')} |")
+        snapshot_rows: list[str] = []
+        eq = syn.get("evidence_quality") if isinstance(syn, dict) else None
+        sa = syn.get("source_agreement") if isinstance(syn, dict) else None
+        ipcc = syn.get("ipcc_combined") if isinstance(syn, dict) else None
+        if isinstance(eq, dict) and eq.get("rating"):
+            snapshot_rows.append(f"| Evidence quality | {eq['rating']} |")
+        if isinstance(sa, dict) and sa.get("rating"):
+            snapshot_rows.append(f"| Source agreement | {sa['rating']} |")
+        if ipcc:
+            snapshot_rows.append(f"| IPCC assessment | {ipcc} |")
+        if snapshot_rows:
+            lines.extend(
+                ["## Evidence Snapshot", "", "| Dimension | Rating |", "|-----------|--------|", *snapshot_rows, ""]
+            )
+
+    # Revisit triggers from report
+    if report:
+        triggers = report.get("revisit_triggers", [])
+        if triggers:
+            lines.extend(["## Revisit Triggers", ""])
+            for t in triggers:
+                if isinstance(t, dict):
+                    trigger_text = t.get("trigger", "")
+                    trigger_type = t.get("type", "")
+                    if trigger_type:
+                        lines.append(f"- **[{trigger_type}]** {trigger_text}")
+                    else:
+                        lines.append(f"- {trigger_text}")
+                else:
+                    lines.append(f"- {t}")
             lines.append("")
 
     lines.append("[← Back to run overview](../index.md)")
@@ -339,55 +478,133 @@ def _write_item_input(item_dir: Path, item: dict[str, Any]) -> None:
     (item_dir / filename).write_text("\n".join(lines) + "\n")
 
 
-def _write_hypotheses(item_dir: Path, data: dict[str, Any]) -> None:
-    """Write hypotheses.md with the competing hypotheses table."""
-    lines = [f"# {data.get('id', '?')} — Competing Hypotheses", ""]
+def _write_hypotheses(
+    item_dir: Path, data: dict[str, Any], report: dict[str, Any], synthesis: dict[str, Any]
+) -> None:
+    """Write hypotheses/ directory with per-hypothesis files and an index.
+
+    Creates:
+        hypotheses/
+            index.md    — summary table of all hypotheses
+            H1.md       — one file per hypothesis
+            H2.md
+            ...
+    """
+    item_id = data.get("id", "?")
+    hyps_dir = item_dir / "hypotheses"
+    hyps_dir.mkdir(parents=True, exist_ok=True)
 
     approach = data.get("approach", "hypotheses")
+
+    # Collect status string per hypothesis id (handles both CLI and plugin schemas)
+    ratings_by_hyp = _collect_hypothesis_ratings(report, synthesis)
+
     if approach == "open-ended":
+        # For open-ended queries there are no discrete hypotheses; write themes instead.
+        index_lines = [f"# {item_id} — Search Themes (open-ended)", ""]
         rationale = data.get("rationale", "")
+        if rationale:
+            index_lines.extend([rationale, ""])
+
         themes = data.get("search_themes", [])
-        lines.extend(["## Approach: Open-ended", "", rationale, "", "## Search Themes", ""])
+        if themes:
+            index_lines.extend(["| ID | Theme | Derived from |", "|----|-------|--------------|"])
+            for t in themes:
+                theme_id = t.get("id", "?")
+                theme = t.get("theme", "")
+                derived = t.get("derived_from", "")
+                index_lines.append(f"| [{theme_id}]({theme_id}.md) | {theme} | {derived} |")
+            index_lines.append("")
+
         for t in themes:
-            lines.append(f"### {t.get('id', '?')} — {t.get('theme', '')}")
-            lines.append("")
+            theme_id = t.get("id", "?")
+            theme_lines = [f"# {item_id} — {theme_id}: {t.get('theme', '')}", ""]
             derived = t.get("derived_from", "")
             if derived:
-                lines.append(f"**Derived from**: {derived}")
-                lines.append("")
+                theme_lines.extend([f"**Derived from**: {derived}", ""])
             look_for = t.get("look_for", [])
             if look_for:
-                lines.append("**Look for:**")
+                theme_lines.append("**Look for:**")
                 for lf in look_for:
-                    lines.append(f"- {lf}")
-                lines.append("")
+                    theme_lines.append(f"- {lf}")
+                theme_lines.append("")
+            perspectives = t.get("perspectives", [])
+            if perspectives:
+                theme_lines.append("**Perspectives:**")
+                for p in perspectives:
+                    theme_lines.append(f"- {p}")
+                theme_lines.append("")
+            theme_lines.append("[← Back to hypotheses index](index.md)")
+            (hyps_dir / f"{theme_id}.md").write_text("\n".join(theme_lines) + "\n")
     else:
         hyps = data.get("hypotheses", [])
-        for h in hyps:
-            lines.append(f"## {h.get('id', '?')} — {h.get('statement', '')}")
-            lines.append("")
-            supporting = h.get("supporting_evidence", [])
-            eliminating = h.get("eliminating_evidence", [])
-            if supporting:
-                lines.append("**Supporting evidence would show:**")
-                for s in supporting:
-                    lines.append(f"- {s}")
-                lines.append("")
-            if eliminating:
-                lines.append("**Eliminating evidence would show:**")
-                for e in eliminating:
-                    lines.append(f"- {e}")
-                lines.append("")
 
+        index_lines = [
+            f"# {item_id} — Competing Hypotheses",
+            "",
+            "| ID | Label | Statement | Status |",
+            "|----|-------|-----------|--------|",
+        ]
+        for h in hyps:
+            hyp_id = h.get("id", "?")
+            # Support both "H1" and "C001-H1" ID styles; use short ID for filename
+            short_id = hyp_id.split("-")[-1] if "-" in hyp_id else hyp_id
+            label = h.get("label", "")
+            statement = (h.get("statement") or "")[:100]
+            status = ratings_by_hyp.get(hyp_id, "—")
+            index_lines.append(f"| [{short_id}]({short_id}.md) | {label} | {statement} | {status[:60]} |")
+        index_lines.append("")
+
+        # Discriminating questions in the index
         disc = data.get("discriminating_questions", [])
         if disc:
-            lines.extend(["## Discriminating Questions", ""])
+            index_lines.extend(["## Discriminating Questions", ""])
             for q in disc:
-                lines.append(f"- {q}")
-            lines.append("")
+                index_lines.append(f"- {q}")
+            index_lines.append("")
 
-    lines.append("[← Back to item overview](index.md)")
-    (item_dir / "hypotheses.md").write_text("\n".join(lines) + "\n")
+        # Per-hypothesis file
+        for h in hyps:
+            hyp_id = h.get("id", "?")
+            short_id = hyp_id.split("-")[-1] if "-" in hyp_id else hyp_id
+            _write_hypothesis_file(hyps_dir / f"{short_id}.md", item_id, h, ratings_by_hyp.get(hyp_id, ""))
+
+    index_lines.append("[← Back to item overview](../index.md)")
+    (hyps_dir / "index.md").write_text("\n".join(index_lines) + "\n")
+
+
+def _write_hypothesis_file(path: Path, item_id: str, h: dict[str, Any], status: str) -> None:
+    """Write a single hypothesis detail file."""
+    hyp_id = h.get("id", "?")
+    short_id = hyp_id.split("-")[-1] if "-" in hyp_id else hyp_id
+    label = h.get("label", "")
+    statement = h.get("statement", "")
+
+    lines = [f"# {item_id} — {short_id}: {label}", "", f"**Statement**: {statement}", ""]
+
+    if status:
+        lines.extend(["## Status", "", status, ""])
+
+    falsification = h.get("falsification_target")
+    if falsification:
+        lines.extend(["## Falsification Target", "", falsification, ""])
+
+    supporting = h.get("supporting_evidence", [])
+    if supporting:
+        lines.extend(["## Supporting Evidence Would Show", ""])
+        for s in supporting:
+            lines.append(f"- {s}")
+        lines.append("")
+
+    eliminating = h.get("eliminating_evidence", [])
+    if eliminating:
+        lines.extend(["## Eliminating Evidence Would Show", ""])
+        for e in eliminating:
+            lines.append(f"- {e}")
+        lines.append("")
+
+    lines.append("[← Back to hypotheses index](index.md)")
+    path.write_text("\n".join(lines) + "\n")
 
 
 def _write_assessment(item_dir: Path, synthesis: dict[str, Any], report: dict[str, Any]) -> None:
@@ -684,7 +901,12 @@ def _write_searches(
     execution_log = search_results.get("search_execution_log", []) if isinstance(search_results, dict) else []
 
     # Write per-search logs and collect index entries
-    index_lines = [f"# {item_id} — Searches", "", "| ID | Target | Terms |", "|----|--------|-------|"]
+    index_lines = [
+        f"# {item_id} — Searches",
+        "",
+        "| ID | Target | Terms | Returned | Selected | Rejected |",
+        "|----|--------|-------|----------|----------|----------|",
+    ]
 
     for s in searches:
         search_id = s.get("id", "S??")
@@ -710,22 +932,102 @@ def _write_searches(
             (e for e in execution_log if e.get("search_id") == search_id or e.get("id") == search_id),
             None,
         )
+        # Write per-result files and build selected/rejected tables
+        selected_count = 0
+        rejected_count = 0
+        total_returned = 0
         if exec_record:
-            lines.extend(["## Execution", ""])
-            results = exec_record.get("results_returned") or exec_record.get("results_found", 0)
-            selected = exec_record.get("results_selected", 0)
-            rejected = exec_record.get("results_rejected", 0)
-            lines.append(f"- Results returned: {results}")
-            lines.append(f"- Selected: {selected}")
-            lines.append(f"- Rejected: {rejected}")
-            lines.append("")
+            query_str = exec_record.get("query", "")
+            if query_str:
+                lines.extend([f"**Query**: `{query_str}`", ""])
 
-        lines.append("[← Back to item overview](../../index.md)")
+            results_list = exec_record.get("results", [])
+            total_returned = exec_record.get("total_returned") or len(results_list)
+            selected_count = sum(1 for r in results_list if r.get("disposition") == "selected")
+            rejected_count = sum(1 for r in results_list if r.get("disposition") != "selected")
+
+            lines.extend(
+                [
+                    "## Execution Summary",
+                    "",
+                    f"- Results returned: {total_returned}",
+                    f"- Selected: {selected_count}",
+                    f"- Rejected: {rejected_count}",
+                    "",
+                ]
+            )
+
+            # Per-result files + tables
+            results_subdir = search_subdir / "results"
+            if results_list:
+                results_subdir.mkdir(parents=True, exist_ok=True)
+
+            selected_rows: list[str] = []
+            rejected_rows: list[str] = []
+            for idx, r in enumerate(results_list, 1):
+                result_id = f"R{idx:02d}"
+                disposition = r.get("disposition", "rejected")
+                title = r.get("title") or r.get("url", "")
+                url = r.get("url", "")
+                score = r.get("relevance_score", "?")
+                reason = r.get("reason", "")
+
+                # Write detail file
+                rlines = [
+                    f"# {search_id} — {result_id}",
+                    "",
+                    f"**Title**: {title}",
+                    "",
+                    f"**URL**: <{url}>",
+                    "",
+                    f"**Relevance score**: {score}",
+                    "",
+                    f"**Disposition**: {disposition}",
+                    "",
+                ]
+                if reason:
+                    rlines.extend([f"**Rationale**: {reason}", ""])
+                rlines.append("[← Back to search log](../search-log.md)")
+                (results_subdir / f"{result_id}.md").write_text("\n".join(rlines) + "\n")
+
+                row = f"| [{result_id}](results/{result_id}.md) | {title[:60]} | {score} | {reason[:80]} |"
+                if disposition == "selected":
+                    selected_rows.append(row)
+                else:
+                    rejected_rows.append(row)
+
+            if selected_rows:
+                lines.extend(
+                    [
+                        "## Selected Results",
+                        "",
+                        "| ID | Title | Score | Rationale |",
+                        "|----|-------|-------|-----------|",
+                        *selected_rows,
+                        "",
+                    ]
+                )
+            if rejected_rows:
+                lines.extend(
+                    [
+                        "## Rejected Results",
+                        "",
+                        "| ID | Title | Score | Rationale |",
+                        "|----|-------|-------|-----------|",
+                        *rejected_rows,
+                        "",
+                    ]
+                )
+
+        lines.append("[← Back to searches index](../index.md)")
         (search_subdir / "search-log.md").write_text("\n".join(lines) + "\n")
 
-        # Add to index
+        # Add to index with counts
         terms_short = ", ".join(f"`{t}`" for t in terms[:3])
-        index_lines.append(f"| [{search_id}]({search_id}/search-log.md) | {theme[:60]} | {terms_short} |")
+        index_lines.append(
+            f"| [{search_id}]({search_id}/search-log.md) | {theme[:60]} | {terms_short} | "
+            f"{total_returned} | {selected_count} | {rejected_count} |"
+        )
 
     index_lines.extend(["", "[← Back to item overview](../index.md)"])
     (searches_dir / "index.md").write_text("\n".join(index_lines) + "\n")
@@ -760,41 +1062,79 @@ def _write_sources(
         url = s.get("url", "")
         title = s.get("title") or url
 
-        # Index entry
-        rel_rating = s.get("reliability", {})
-        relev_rating = s.get("relevance", {})
-        rel_str = rel_rating.get("rating", "—") if isinstance(rel_rating, dict) else str(rel_rating)
-        relev_str = relev_rating.get("rating", "—") if isinstance(relev_rating, dict) else str(relev_rating)
+        # Handle both CLI-style (rated object) and plugin-style (simple string) ratings
+        rel_value = s.get("reliability", "")
+        relev_value = s.get("relevance", "")
+        rel_str = rel_value.get("rating", "—") if isinstance(rel_value, dict) else (rel_value or "—")
+        relev_str = relev_value.get("rating", "—") if isinstance(relev_value, dict) else (relev_value or "—")
         index_lines.append(f"| [{src_id}]({src_id}/scorecard.md) | {title[:60]} | {rel_str} | {relev_str} |")
 
+        # Per-source scorecard
         lines = [f"# {src_id} — {title}", ""]
+
+        # Metadata table
+        meta_rows: list[str] = []
         if url:
-            lines.append(f"URL: <{url}>")
+            meta_rows.append(f"| URL | <{url}> |")
+        if s.get("authors"):
+            meta_rows.append(f"| Authors | {s['authors']} |")
+        if s.get("date"):
+            meta_rows.append(f"| Date | {s['date']} |")
+        if s.get("items"):
+            items_refs = ", ".join(str(i) for i in s["items"])
+            meta_rows.append(f"| Referenced by | {items_refs} |")
+        if meta_rows:
+            lines.extend(["## Metadata", "", "| Field | Value |", "|-------|-------|", *meta_rows, ""])
+
+        # Content summary
+        if s.get("content_summary"):
+            lines.extend(["## Content Summary", "", s["content_summary"], ""])
+
+        # Reliability
+        if rel_str and rel_str != "—":
+            lines.append(f"## Reliability: {rel_str}")
             lines.append("")
+            rationale = (
+                rel_value.get("rationale") if isinstance(rel_value, dict) else s.get("reliability_rationale", "")
+            )
+            if rationale:
+                lines.extend([rationale, ""])
 
-        for field in ("reliability", "relevance"):
-            val = s.get(field, {})
-            if isinstance(val, dict):
-                rating = val.get("rating", "—")
-                rationale = val.get("rationale", "")
-                lines.append(f"**{field.capitalize()}**: {rating}")
-                if rationale:
-                    lines.append(f"- {rationale}")
-                lines.append("")
+        # Relevance
+        if relev_str and relev_str != "—":
+            lines.append(f"## Relevance: {relev_str}")
+            lines.append("")
+            rationale = (
+                relev_value.get("rationale") if isinstance(relev_value, dict) else s.get("relevance_rationale", "")
+            )
+            if rationale:
+                lines.extend([rationale, ""])
 
+        # Bias assessment
         bias = s.get("bias_assessment", {})
         if isinstance(bias, dict) and bias:
             lines.extend(
                 ["## Bias Assessment", "", "| Domain | Rating | Rationale |", "|--------|--------|-----------|"]
             )
             for domain, d in bias.items():
+                domain_label = domain.replace("_", " ").title()
+                # Plugin format: value is a string like "Low risk — rationale"
+                # CLI format: value is a dict with rating + rationale
                 if isinstance(d, dict):
                     rating = d.get("rating", "—")
-                    rationale = (d.get("rationale") or "")[:150]
-                    lines.append(f"| {domain.replace('_', ' ').title()} | {rating} | {rationale} |")
+                    rationale = (d.get("rationale") or "")[:200]
+                elif isinstance(d, str):
+                    # Try to split "Rating — rationale"
+                    parts = d.split("—", 1) if "—" in d else d.split("-", 1) if " - " in d else [d, ""]
+                    rating = parts[0].strip()
+                    rationale = parts[1].strip()[:200] if len(parts) > 1 else ""
+                else:
+                    rating = str(d)
+                    rationale = ""
+                lines.append(f"| {domain_label} | {rating} | {rationale} |")
             lines.append("")
 
-        lines.append("[← Back to item overview](../../index.md)")
+        lines.append("[← Back to sources index](../index.md)")
         (src_subdir / "scorecard.md").write_text("\n".join(lines) + "\n")
 
     index_lines.extend(["", "[← Back to item overview](../index.md)"])

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -327,10 +327,16 @@ def _write_run_index(
         item_synthesis = _item_by_id(synthesis_items, item_id)
         item_search_plan = _item_by_id(search_plan_items, item_id)
 
-        # Verdict for claims, confidence for queries
-        verdict = report.get("verdict") or report.get("confidence") or ""
-        heading = f"### {item_id} — {verdict}" if verdict else f"### {item_id}"
-        lines.extend([heading, ""])
+        # Heading: {id} — {topic title} — {verdict or confidence qualifier}
+        topic = report.get("title", "").strip()
+        qualifier = (report.get("verdict") or report.get("confidence") or "").strip()
+
+        heading_parts = [item_id]
+        if topic:
+            heading_parts.append(topic)
+        if qualifier:
+            heading_parts.append(qualifier)
+        lines.extend([f"### {' — '.join(heading_parts)}", ""])
 
         # Claim / Query text
         text_label = "Claim" if item_type == "claim" else "Query"

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -273,22 +273,21 @@ def _write_run_index(
     """
     lines: list[str] = ["# Run Overview", ""]
 
-    # Meta table
+    # Separate items by type, in display order: axioms → claims → queries
+    axioms = [i for i in input_items if i.get("type") == "axiom"]
     claims = [i for i in input_items if i.get("type") == "claim"]
     queries = [i for i in input_items if i.get("type") == "query"]
-    axioms = [i for i in input_items if i.get("type") == "axiom"]
 
-    lines.extend(
-        [
-            "| | |",
-            "|---|---|",
-            f"| **Items** | {len(input_items)} |",
-            f"| **Claims** | {len(claims)} |",
-            f"| **Queries** | {len(queries)} |",
-            f"| **Axioms** | {len(axioms)} |",
-            "",
-        ]
-    )
+    # Meta table — only include rows with non-zero counts
+    meta_rows: list[str] = []
+    if axioms:
+        meta_rows.append(f"| **Axioms** | {len(axioms)} |")
+    if claims:
+        meta_rows.append(f"| **Claims** | {len(claims)} |")
+    if queries:
+        meta_rows.append(f"| **Queries** | {len(queries)} |")
+    if meta_rows:
+        lines.extend(["| | |", "|---|---|", *meta_rows, ""])
 
     # Slug lookup
     slug_by_id: dict[str, str] = {}
@@ -307,83 +306,137 @@ def _write_run_index(
     execution_log = search_results.get("search_execution_log", []) if isinstance(search_results, dict) else []
     reports_by_id: dict[str, dict[str, Any]] = {r.get("id", ""): r for r in reports}
 
-    # Section heading
-    section_label = "Claims & Queries" if (claims and queries) else ("Claims" if claims else "Queries")
-    lines.extend([f"## {section_label}", ""])
-
-    # Per-item cards
-    for item in input_items:
-        item_id = item.get("id", "")
-        if not item_id:
-            continue
-        item_type = item.get("type", "claim")
-        slug = slug_by_id.get(item_id, "")
-
-        original = item.get("original_text", "")
-        clarified = item.get("restated_for_testability") or item.get("clarified_text") or original
-
-        report = reports_by_id.get(item_id, {})
-        item_hypotheses = _item_by_id(hypotheses_items, item_id)
-        item_synthesis = _item_by_id(synthesis_items, item_id)
-        item_search_plan = _item_by_id(search_plan_items, item_id)
-
-        # Heading: {id} — {topic title} — {verdict or confidence qualifier}
+    # Reports lookup by id (may differ from input items when plugin uses report.title)
+    def _card_heading(item: dict[str, Any], report: dict[str, Any]) -> str:
+        """Build a card-level heading like '{id} — {topic} — {qualifier}'."""
+        iid = item.get("id", "?")
         topic = report.get("title", "").strip()
         qualifier = (report.get("verdict") or report.get("confidence") or "").strip()
-
-        heading_parts = [item_id]
+        parts = [iid]
         if topic:
-            heading_parts.append(topic)
+            parts.append(topic)
         if qualifier:
-            heading_parts.append(qualifier)
-        lines.extend([f"### {' — '.join(heading_parts)}", ""])
+            parts.append(qualifier)
+        return " — ".join(parts)
 
-        # Claim / Query text
-        text_label = "Claim" if item_type == "claim" else "Query"
-        item_text = original or clarified or report.get("original_query") or report.get("original_claim", "")
-        lines.extend([f"**{text_label}:** {item_text}", ""])
+    # Build ToC entries as we go so we can insert the TOC after the meta table
+    toc_entries: list[tuple[str, str, list[tuple[str, str]]]] = []
+    # list of (section_anchor, section_label, [(subheading_anchor, subheading_label), ...])
 
-        # Answer / verdict summary
-        answer = (
-            report.get("verdict_summary")
-            or report.get("answer_summary")
-            or report.get("one_line")
-            or ""
-        )
-        if answer:
-            answer_label = "Verdict" if item_type == "claim" else "Answer"
-            lines.extend([f"**{answer_label}:** {answer}", ""])
+    # Collect card info so we can write the TOC, then render cards after
+    def _card_anchor(heading_text: str) -> str:
+        """GitHub-style anchor: lowercase, dashes, strip punctuation."""
+        # Keep alphanumerics, spaces, and dashes. Replace spaces with dashes.
+        normalized = re.sub(r"[^a-z0-9\s\-]", "", heading_text.lower())
+        return re.sub(r"\s+", "-", normalized.strip())
 
-        # Hypothesis status table
-        hyp_ratings = _collect_hypothesis_ratings(report, item_synthesis)
-        hyps_list = item_hypotheses.get("hypotheses", []) if isinstance(item_hypotheses, dict) else []
-        if hyps_list:
-            lines.extend(["| Hypothesis | Status |", "|------------|--------|"])
-            for h in hyps_list:
-                hid = h.get("id", "?")
-                short_id = hid.split("-")[-1] if "-" in hid else hid
-                label_text = h.get("label", "")
-                status = (hyp_ratings.get(hid, "—") or "—")[:80]
-                lines.append(f"| {short_id}: *{label_text}* | {status} |")
+    card_sections: list[tuple[str, list[dict[str, Any]]]] = []
+    if axioms:
+        card_sections.append(("Axioms", axioms))
+    if claims:
+        card_sections.append(("Claims", claims))
+    if queries:
+        card_sections.append(("Queries", queries))
+
+    for section_label, section_items in card_sections:
+        sub_entries: list[tuple[str, str]] = []
+        for item in section_items:
+            report = reports_by_id.get(item.get("id", ""), {})
+            h = _card_heading(item, report)
+            sub_entries.append((_card_anchor(h), h))
+        toc_entries.append((_card_anchor(section_label), section_label, sub_entries))
+
+    # Collection Analysis ToC entry (we always render at least statistics)
+    collection_subs: list[tuple[str, str]] = [("collection-statistics", "Collection Statistics")]
+    robis = audit.get("robis_audit", {}) if isinstance(audit, dict) else {}
+    if isinstance(robis, dict) and robis:
+        collection_subs.append(("collection-self-audit", "Collection Self-Audit"))
+    toc_entries.append(("collection-analysis", "Collection Analysis", collection_subs))
+
+    # Render the TOC
+    if toc_entries:
+        lines.extend(["<!-- TOC START -->", "## Contents", ""])
+        for anchor, label, subs in toc_entries:
+            lines.append(f"- [{label}](#{anchor})")
+            for sub_anchor, sub_label in subs:
+                lines.append(f"    - [{sub_label}](#{sub_anchor})")
+        lines.extend(["", "<!-- TOC END -->", ""])
+
+    # Render card sections
+    for section_label, section_items in card_sections:
+        lines.extend([f"## {section_label}", ""])
+
+        for item in section_items:
+            item_id = item.get("id", "")
+            if not item_id:
+                continue
+            item_type = item.get("type", "claim")
+            slug = slug_by_id.get(item_id, "")
+
+            original = item.get("original_text", "")
+            clarified = item.get("restated_for_testability") or item.get("clarified_text") or original
+
+            report = reports_by_id.get(item_id, {})
+            item_hypotheses = _item_by_id(hypotheses_items, item_id)
+            item_synthesis = _item_by_id(synthesis_items, item_id)
+            item_search_plan = _item_by_id(search_plan_items, item_id)
+
+            lines.extend([f"### {_card_heading(item, report)}", ""])
+
+            # Axioms don't have hypotheses, sources, etc. — just the text
+            if item_type == "axiom":
+                axiom_text = original or clarified or item.get("text", "")
+                lines.extend([axiom_text, ""])
+                continue
+
+            # Claim / Query text
+            text_label = "Claim" if item_type == "claim" else "Query"
+            item_text = (
+                original or clarified or report.get("original_query") or report.get("original_claim", "")
+            )
+            lines.extend([f"**{text_label}:** {item_text}", ""])
+
+            # Answer / verdict summary
+            answer = (
+                report.get("verdict_summary")
+                or report.get("answer_summary")
+                or report.get("one_line")
+                or ""
+            )
+            if answer:
+                answer_label = "Verdict" if item_type == "claim" else "Answer"
+                lines.extend([f"**{answer_label}:** {answer}", ""])
+
+            # Hypothesis status table
+            hyp_ratings = _collect_hypothesis_ratings(report, item_synthesis)
+            hyps_list = item_hypotheses.get("hypotheses", []) if isinstance(item_hypotheses, dict) else []
+            if hyps_list:
+                lines.extend(["| Hypothesis | Status |", "|------------|--------|"])
+                for h in hyps_list:
+                    hid = h.get("id", "?")
+                    short_id = hid.split("-")[-1] if "-" in hid else hid
+                    label_text = h.get("label", "")
+                    status = (hyp_ratings.get(hid, "—") or "—")[:80]
+                    lines.append(f"| {short_id}: *{label_text}* | {status} |")
+                lines.append("")
+
+            # Confidence · Sources · Searches metadata line
+            source_count = len(_extract_sources_for_item(scorecards, item_id))
+            search_count = len(item_search_plan.get("searches", [])) if isinstance(item_search_plan, dict) else 0
+            confidence = ""
+            if isinstance(item_synthesis, dict):
+                assessment = item_synthesis.get("assessment", {})
+                if isinstance(assessment, dict):
+                    confidence = assessment.get("probability_label") or assessment.get("confidence", "")
+            meta_parts: list[str] = []
+            if confidence:
+                meta_parts.append(f"**Confidence:** {confidence}")
+            meta_parts.extend([f"**Sources:** {source_count}", f"**Searches:** {search_count}"])
+            lines.append(" · ".join(meta_parts))
             lines.append("")
 
-        # Confidence · Sources · Searches metadata line
-        source_count = len(_extract_sources_for_item(scorecards, item_id))
-        search_count = len(item_search_plan.get("searches", [])) if isinstance(item_search_plan, dict) else 0
-        confidence = ""
-        if isinstance(item_synthesis, dict):
-            assessment = item_synthesis.get("assessment", {})
-            if isinstance(assessment, dict):
-                confidence = assessment.get("probability_label") or assessment.get("confidence", "")
-        meta_parts: list[str] = []
-        if confidence:
-            meta_parts.append(f"**Confidence:** {confidence}")
-        meta_parts.extend([f"**Sources:** {source_count}", f"**Searches:** {search_count}"])
-        lines.append(" · ".join(meta_parts))
-        lines.append("")
-
-        if slug:
-            lines.extend([f"[Full analysis]({slug}/index.md)", ""])
+            if slug:
+                lines.extend([f"[Full analysis]({slug}/index.md)", ""])
 
     # Collection Analysis
     lines.extend(["---", "", "## Collection Analysis", ""])

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -109,6 +109,87 @@ def _card_heading_for(item: dict[str, Any], report: dict[str, Any]) -> str:
     return " — ".join(parts)
 
 
+def _add_toc(lines: list[str], min_sections: int = 2) -> list[str]:
+    """Insert a table of contents after the page title.
+
+    Scans the lines list for H2 headings (## ...), auto-generates
+    anchor IDs if not already present, and prepends a TOC block
+    right after the top-level # title. Returns the modified list.
+
+    The TOC is only added if the page has at least ``min_sections``
+    H2 headings — tiny pages skip the TOC.
+
+    Idempotent: if a TOC is already present (detected by
+    '<!-- TOC START -->' sentinel), returns lines unchanged.
+    """
+    # Already has a TOC — leave as-is
+    if any("<!-- TOC START -->" in line for line in lines):
+        return lines
+
+    # Find the title line (first line starting with "# ")
+    title_idx = -1
+    for i, line in enumerate(lines):
+        if line.startswith("# "):
+            title_idx = i
+            break
+    if title_idx < 0:
+        return lines
+
+    # Scan for H2 headings and the anchor (if any) immediately preceding them.
+    # A heading is preceded by its anchor if the line before (skipping blanks)
+    # is an <a id="..."></a> tag.
+    toc_entries: list[tuple[str, str]] = []  # (anchor_id, label)
+    pending_inserts: list[tuple[int, str]] = []  # (line_index, anchor_line_to_insert)
+
+    for i, line in enumerate(lines):
+        if i <= title_idx:
+            continue
+        if not line.startswith("## "):
+            continue
+        label = line[3:].strip()
+
+        # Look backwards for existing <a id="..."></a>
+        anchor_id: str | None = None
+        for j in range(i - 1, max(title_idx, i - 3) - 1, -1):
+            stripped = lines[j].strip()
+            if not stripped:
+                continue
+            m = re.match(r'<a id="([^"]+)"></a>', stripped)
+            if m:
+                anchor_id = m.group(1)
+                break
+            break  # hit a non-anchor, non-blank line — stop looking back
+
+        if anchor_id is None:
+            # Generate one from the label
+            anchor_id = "sec-" + re.sub(r"[^a-z0-9]+", "-", label.lower()).strip("-")
+            pending_inserts.append((i, f'<a id="{anchor_id}"></a>'))
+
+        toc_entries.append((anchor_id, label))
+
+    if len(toc_entries) < min_sections:
+        return lines
+
+    # Insert pending anchors in reverse so indices remain valid
+    result = list(lines)
+    for idx, anchor_line in reversed(pending_inserts):
+        result.insert(idx, "")
+        result.insert(idx, anchor_line)
+
+    # Build the TOC block
+    toc_block: list[str] = ["<!-- TOC START -->", "## Contents", ""]
+    for anchor_id, label in toc_entries:
+        toc_block.append(f"- [{label}](#{anchor_id})")
+    toc_block.extend(["", "<!-- TOC END -->", ""])
+
+    # Insert TOC after the title (and any blank line following it)
+    insert_at = title_idx + 1
+    if insert_at < len(result) and not result[insert_at].strip():
+        insert_at += 1
+
+    return [*result[:insert_at], *toc_block, *result[insert_at:]]
+
+
 def _subpage_title(item: dict[str, Any], report: dict[str, Any], artifact: str) -> str:
     """Build a sub-page title like '{id} — {topic} — {artifact}'.
 
@@ -789,6 +870,7 @@ def _write_item_input(item_dir: Path, item: dict[str, Any], report: dict[str, An
                 lines.append("")
 
     lines.append("[← Back to item overview](index.md)")
+    lines = _add_toc(lines)
     (item_dir / filename).write_text("\n".join(lines) + "\n")
 
 
@@ -851,6 +933,7 @@ def _write_hypotheses(
                     theme_lines.append(f"- {p}")
                 theme_lines.append("")
             theme_lines.append("[← Back to hypotheses index](index.md)")
+            theme_lines = _add_toc(theme_lines)
             (hyps_dir / f"{theme_id}.md").write_text("\n".join(theme_lines) + "\n")
     else:
         hyps = data.get("hypotheses", [])
@@ -886,6 +969,7 @@ def _write_hypotheses(
             _write_hypothesis_file(hyps_dir / f"{short_id}.md", item_id, h, ratings_by_hyp.get(hyp_id, ""))
 
     index_lines.append("[← Back to item overview](../index.md)")
+    index_lines = _add_toc(index_lines)
     (hyps_dir / "index.md").write_text("\n".join(index_lines) + "\n")
 
 
@@ -920,6 +1004,7 @@ def _write_hypothesis_file(path: Path, item_id: str, h: dict[str, Any], status: 
         lines.append("")
 
     lines.append("[← Back to hypotheses index](index.md)")
+    lines = _add_toc(lines)
     path.write_text("\n".join(lines) + "\n")
 
 
@@ -1038,6 +1123,7 @@ def _write_assessment(item_dir: Path, synthesis: dict[str, Any], report: dict[st
                 lines.append("")
 
     lines.append("[← Back to item overview](index.md)")
+    lines = _add_toc(lines)
     (item_dir / "assessment.md").write_text("\n".join(lines) + "\n")
 
 
@@ -1135,6 +1221,7 @@ def _write_self_audit(item_dir: Path, audit: dict[str, Any], report: dict[str, A
             lines.append("")
 
     lines.append("[← Back to item overview](index.md)")
+    lines = _add_toc(lines)
     (item_dir / "self-audit.md").write_text("\n".join(lines) + "\n")
 
 
@@ -1187,6 +1274,7 @@ def _write_reading_list(
             lines.append("")
 
     lines.append("[← Back to item overview](index.md)")
+    lines = _add_toc(lines)
     (item_dir / "reading-list.md").write_text("\n".join(lines) + "\n")
 
 
@@ -1342,6 +1430,7 @@ def _write_searches(
                 )
 
         lines.append("[← Back to searches index](../index.md)")
+        lines = _add_toc(lines)
         (search_subdir / "search-log.md").write_text("\n".join(lines) + "\n")
 
         # Add to index with counts
@@ -1352,6 +1441,7 @@ def _write_searches(
         )
 
     index_lines.extend(["", "[← Back to item overview](../index.md)"])
+    index_lines = _add_toc(index_lines)
     (searches_dir / "index.md").write_text("\n".join(index_lines) + "\n")
 
 
@@ -1459,9 +1549,11 @@ def _write_sources(
             lines.append("")
 
         lines.append("[← Back to sources index](../index.md)")
+        lines = _add_toc(lines)
         (src_subdir / "scorecard.md").write_text("\n".join(lines) + "\n")
 
     index_lines.extend(["", "[← Back to item overview](../index.md)"])
+    index_lines = _add_toc(index_lines)
     (sources_dir / "index.md").write_text("\n".join(index_lines) + "\n")
 
 
@@ -1498,6 +1590,7 @@ def _write_group_index(
             lines.append(f"- [{label}]({filename})")
         lines.append("")
 
+    lines = _add_toc(lines)
     (output_dir / "index.md").write_text("\n".join(lines) + "\n")
 
 
@@ -1537,6 +1630,7 @@ def _write_group_synthesis(output_dir: Path, data: dict[str, Any]) -> None:
                 lines.append("")
 
     lines.append("[← Back to group overview](index.md)")
+    lines = _add_toc(lines)
     (output_dir / "synthesis.md").write_text("\n".join(lines) + "\n")
 
 
@@ -1565,6 +1659,7 @@ def _write_group_consistency(output_dir: Path, data: dict[str, Any]) -> None:
         lines.extend(["## Diagnostic", "", diagnostic, ""])
 
     lines.append("[← Back to group overview](index.md)")
+    lines = _add_toc(lines)
     (output_dir / "consistency.md").write_text("\n".join(lines) + "\n")
 
 
@@ -1607,4 +1702,5 @@ def _write_group_reading_list(output_dir: Path, data: dict[str, Any]) -> None:
         lines.append("")
 
     lines.append("[← Back to group overview](index.md)")
+    lines = _add_toc(lines)
     (output_dir / "reading-list.md").write_text("\n".join(lines) + "\n")

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -153,10 +153,7 @@ def render_run(run_dir: Path, output_dir: Path) -> None:
     input_items = _unwrap_items(research_input)
     report_items = _unwrap_items(reports, key="reports")
 
-    # Write run index
-    _write_run_index(output_dir, input_items, report_items)
-
-    # Write per-item content
+    # Write per-item content first (so run index can count sources etc.)
     for item in input_items:
         item_id = item.get("id", "")
         if not item_id:
@@ -174,13 +171,10 @@ def render_run(run_dir: Path, output_dir: Path) -> None:
         item_report = _item_by_id(report_items, item_id)
 
         # Plugin format has a single global audit (not per-item).
-        # Use it when no per-item audit exists.
         audit_to_render = item_audit or audit
-        # Tag with item id so the writer's heading is correct
         if audit_to_render and not audit_to_render.get("id"):
             audit_to_render = {**audit_to_render, "id": item_id}
 
-        # Write all content files first
         _write_item_input(item_dir, item)
         if item_hypotheses:
             _write_hypotheses(item_dir, item_hypotheses, item_report, item_synthesis)
@@ -193,7 +187,6 @@ def render_run(run_dir: Path, output_dir: Path) -> None:
         _write_sources(item_dir, item_id, scorecards, search_results)
         _write_reading_list(item_dir, audit_to_render, item_id, scorecards)
 
-        # Write index LAST so existence checks see the actual files
         _write_item_index(
             item_dir,
             item,
@@ -204,6 +197,19 @@ def render_run(run_dir: Path, output_dir: Path) -> None:
             search_results,
             scorecards,
         )
+
+    # Write run index LAST, with full context for cards + collection analysis
+    _write_run_index(
+        output_dir,
+        input_items,
+        report_items,
+        hypotheses,
+        search_plans,
+        search_results,
+        scorecards,
+        synthesis,
+        audit,
+    )
 
 
 def render_run_group(group_dir: Path, output_dir: Path) -> None:
@@ -244,39 +250,186 @@ def render_run_group(group_dir: Path, output_dir: Path) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _write_run_index(output_dir: Path, input_items: list[dict[str, Any]], reports: list[dict[str, Any]]) -> None:
-    """Write the run-level index.md with a verdict summary table."""
-    lines: list[str] = ["# Run Overview", ""]
-    lines.append(f"Items investigated: {len(input_items)}")
-    lines.append("")
+def _write_run_index(
+    output_dir: Path,
+    input_items: list[dict[str, Any]],
+    reports: list[dict[str, Any]],
+    hypotheses: dict[str, Any],
+    search_plans: dict[str, Any],
+    search_results: dict[str, Any],
+    scorecards: dict[str, Any],
+    synthesis: dict[str, Any],
+    audit: dict[str, Any],
+) -> None:
+    """Write the run-level index.md.
 
-    # Build a lookup from item ID to the slug used by input items (for consistent links)
+    Structure modeled on past research runs (see
+    docs/site/docs/research/R0044-*/2026-04-01/index.md as canonical):
+
+    1. Meta table (item counts)
+    2. Per-item cards — claim/query text, answer/verdict, hypothesis
+       status table, sources/searches counts, Full analysis link
+    3. Collection analysis — statistics table and self-audit summary
+    """
+    lines: list[str] = ["# Run Overview", ""]
+
+    # Meta table
+    claims = [i for i in input_items if i.get("type") == "claim"]
+    queries = [i for i in input_items if i.get("type") == "query"]
+    axioms = [i for i in input_items if i.get("type") == "axiom"]
+
+    lines.extend(
+        [
+            "| | |",
+            "|---|---|",
+            f"| **Items** | {len(input_items)} |",
+            f"| **Claims** | {len(claims)} |",
+            f"| **Queries** | {len(queries)} |",
+            f"| **Axioms** | {len(axioms)} |",
+            "",
+        ]
+    )
+
+    # Slug lookup
     slug_by_id: dict[str, str] = {}
     for item in input_items:
         item_id = item.get("id", "")
-        clarified = item.get("restated_for_testability") or item.get("clarified_text") or item.get("original_text", "")
+        clarified = (
+            item.get("restated_for_testability") or item.get("clarified_text") or item.get("original_text", "")
+        )
         if item_id:
             slug_by_id[item_id] = _item_slug(item_id, clarified)
 
-    if reports:
-        lines.extend(
-            ["## Verdict Summary", "", "| ID | Type | Verdict | Summary |", "|----|------|---------|---------|"]
+    # Unwrap step outputs once
+    hypotheses_items = _unwrap_items(hypotheses)
+    synthesis_items = _unwrap_items(synthesis)
+    search_plan_items = _unwrap_items(search_plans)
+    execution_log = search_results.get("search_execution_log", []) if isinstance(search_results, dict) else []
+    reports_by_id: dict[str, dict[str, Any]] = {r.get("id", ""): r for r in reports}
+
+    # Section heading
+    section_label = "Claims & Queries" if (claims and queries) else ("Claims" if claims else "Queries")
+    lines.extend([f"## {section_label}", ""])
+
+    # Per-item cards
+    for item in input_items:
+        item_id = item.get("id", "")
+        if not item_id:
+            continue
+        item_type = item.get("type", "claim")
+        slug = slug_by_id.get(item_id, "")
+
+        original = item.get("original_text", "")
+        clarified = item.get("restated_for_testability") or item.get("clarified_text") or original
+
+        report = reports_by_id.get(item_id, {})
+        item_hypotheses = _item_by_id(hypotheses_items, item_id)
+        item_synthesis = _item_by_id(synthesis_items, item_id)
+        item_search_plan = _item_by_id(search_plan_items, item_id)
+
+        # Verdict for claims, confidence for queries
+        verdict = report.get("verdict") or report.get("confidence") or ""
+        heading = f"### {item_id} — {verdict}" if verdict else f"### {item_id}"
+        lines.extend([heading, ""])
+
+        # Claim / Query text
+        text_label = "Claim" if item_type == "claim" else "Query"
+        item_text = original or clarified or report.get("original_query") or report.get("original_claim", "")
+        lines.extend([f"**{text_label}:** {item_text}", ""])
+
+        # Answer / verdict summary
+        answer = (
+            report.get("verdict_summary")
+            or report.get("answer_summary")
+            or report.get("one_line")
+            or ""
         )
-        for report in reports:
-            item_id = report.get("id", "?")
-            item_type = report.get("type", "?")
-            verdict = report.get("verdict", "—")
-            summary = (report.get("verdict_summary") or report.get("one_line") or "")[:120]
-            slug = slug_by_id.get(item_id) or _item_slug(item_id, report.get("title", ""))
-            lines.append(f"| [{item_id}]({slug}/index.md) | {item_type} | {verdict} | {summary} |")
+        if answer:
+            answer_label = "Verdict" if item_type == "claim" else "Answer"
+            lines.extend([f"**{answer_label}:** {answer}", ""])
+
+        # Hypothesis status table
+        hyp_ratings = _collect_hypothesis_ratings(report, item_synthesis)
+        hyps_list = item_hypotheses.get("hypotheses", []) if isinstance(item_hypotheses, dict) else []
+        if hyps_list:
+            lines.extend(["| Hypothesis | Status |", "|------------|--------|"])
+            for h in hyps_list:
+                hid = h.get("id", "?")
+                short_id = hid.split("-")[-1] if "-" in hid else hid
+                label_text = h.get("label", "")
+                status = (hyp_ratings.get(hid, "—") or "—")[:80]
+                lines.append(f"| {short_id}: *{label_text}* | {status} |")
+            lines.append("")
+
+        # Confidence · Sources · Searches metadata line
+        source_count = len(_extract_sources_for_item(scorecards, item_id))
+        search_count = len(item_search_plan.get("searches", [])) if isinstance(item_search_plan, dict) else 0
+        confidence = ""
+        if isinstance(item_synthesis, dict):
+            assessment = item_synthesis.get("assessment", {})
+            if isinstance(assessment, dict):
+                confidence = assessment.get("probability_label") or assessment.get("confidence", "")
+        meta_parts: list[str] = []
+        if confidence:
+            meta_parts.append(f"**Confidence:** {confidence}")
+        meta_parts.extend([f"**Sources:** {source_count}", f"**Searches:** {search_count}"])
+        lines.append(" · ".join(meta_parts))
         lines.append("")
 
-    lines.extend(["## Items", ""])
-    for item in input_items:
-        item_id = item.get("id", "?")
-        clarified = item.get("restated_for_testability") or item.get("clarified_text") or item.get("original_text", "")
-        slug = _item_slug(item_id, clarified)
-        lines.append(f"- [{item_id} — {clarified[:100]}]({slug}/index.md)")
+        if slug:
+            lines.extend([f"[Full analysis]({slug}/index.md)", ""])
+
+    # Collection Analysis
+    lines.extend(["---", "", "## Collection Analysis", ""])
+
+    # Collection Statistics
+    total_sources = len(scorecards.get("sources", [])) if isinstance(scorecards, dict) else 0
+    total_searches = len(execution_log)
+    total_results = sum(e.get("total_returned", 0) or len(e.get("results", [])) for e in execution_log)
+    total_selected = sum(
+        sum(1 for r in e.get("results", []) if r.get("disposition") == "selected") for e in execution_log
+    )
+
+    lines.extend(
+        [
+            "### Collection Statistics",
+            "",
+            "| Metric | Value |",
+            "|--------|-------|",
+            f"| Items investigated | {len(input_items)} |",
+        ]
+    )
+    if total_sources:
+        lines.append(f"| Sources scored | {total_sources} |")
+    if total_searches:
+        lines.append(f"| Searches executed | {total_searches} |")
+    if total_results:
+        rejected = total_results - total_selected
+        lines.append(
+            f"| Results dispositioned | {total_selected} selected + {rejected} rejected = {total_results} total |"
+        )
+    lines.append("")
+
+    # Collection Self-Audit (plugin format: global robis_audit)
+    robis = audit.get("robis_audit", {}) if isinstance(audit, dict) else {}
+    if isinstance(robis, dict) and robis:
+        lines.extend(
+            [
+                "### Collection Self-Audit",
+                "",
+                "| Domain | Rating |",
+                "|--------|--------|",
+            ]
+        )
+        for key in sorted(k for k in robis if k.startswith("domain_")):
+            d = robis[key]
+            if isinstance(d, dict):
+                rating = d.get("risk", "—")
+                label_text = key.replace("domain_", "Domain ").replace("_", " ").title()
+                lines.append(f"| {label_text} | {rating} |")
+        lines.append("")
+        if robis.get("overall_risk_of_bias"):
+            lines.extend([f"**Overall risk of bias:** {robis['overall_risk_of_bias']}", ""])
 
     (output_dir / "index.md").write_text("\n".join(lines) + "\n")
 

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -109,6 +109,21 @@ def _card_heading_for(item: dict[str, Any], report: dict[str, Any]) -> str:
     return " — ".join(parts)
 
 
+def _subpage_title(item: dict[str, Any], report: dict[str, Any], artifact: str) -> str:
+    """Build a sub-page title like '{id} — {topic} — {artifact}'.
+
+    E.g., 'C001 — RLHF and Sycophantic Behavior in Language Models — Input'.
+    Falls back gracefully if there's no report/topic available.
+    """
+    iid = item.get("id", "?")
+    topic = (report.get("title") or "").strip() if isinstance(report, dict) else ""
+    parts = [iid]
+    if topic:
+        parts.append(topic)
+    parts.append(artifact)
+    return " — ".join(parts)
+
+
 def _collect_hypothesis_ratings(report: dict[str, Any], synthesis: dict[str, Any]) -> dict[str, str]:
     """Collect hypothesis rating/disposition strings, keyed by hypothesis ID.
 
@@ -188,17 +203,17 @@ def render_run(run_dir: Path, output_dir: Path) -> None:
         if audit_to_render and not audit_to_render.get("id"):
             audit_to_render = {**audit_to_render, "id": item_id}
 
-        _write_item_input(item_dir, item)
+        _write_item_input(item_dir, item, item_report)
         if item_hypotheses:
             _write_hypotheses(item_dir, item_hypotheses, item_report, item_synthesis)
         if item_synthesis:
             _write_assessment(item_dir, item_synthesis, item_report)
         if audit_to_render:
-            _write_self_audit(item_dir, audit_to_render)
+            _write_self_audit(item_dir, audit_to_render, item_report)
 
-        _write_searches(item_dir, item_id, item_search_plan, search_results)
-        _write_sources(item_dir, item_id, scorecards, search_results)
-        _write_reading_list(item_dir, audit_to_render, item_id, scorecards)
+        _write_searches(item_dir, item_id, item_search_plan, search_results, item_report)
+        _write_sources(item_dir, item_id, scorecards, search_results, item_report)
+        _write_reading_list(item_dir, audit_to_render, item_id, scorecards, item_report)
 
         _write_item_index(
             item_dir,
@@ -736,12 +751,12 @@ def _write_item_index(
     (item_dir / "index.md").write_text("\n".join(lines) + "\n")
 
 
-def _write_item_input(item_dir: Path, item: dict[str, Any]) -> None:
+def _write_item_input(item_dir: Path, item: dict[str, Any], report: dict[str, Any]) -> None:
     """Write claim.md or query.md with input details."""
     item_type = item.get("type", "claim")
     filename = "claim.md" if item_type == "claim" else "query.md"
 
-    lines = [f"# {item.get('id', '?')} — Input", ""]
+    lines = [f"# {_subpage_title(item, report, 'Input')}", ""]
 
     original = item.get("original_text", "")
     clarified = item.get("restated_for_testability") or item.get("clarified_text", "")
@@ -794,13 +809,15 @@ def _write_hypotheses(
     hyps_dir.mkdir(parents=True, exist_ok=True)
 
     approach = data.get("approach", "hypotheses")
+    # Reconstruct a minimal item dict for title-building
+    item_for_title = {"id": item_id}
 
     # Collect status string per hypothesis id (handles both CLI and plugin schemas)
     ratings_by_hyp = _collect_hypothesis_ratings(report, synthesis)
 
     if approach == "open-ended":
         # For open-ended queries there are no discrete hypotheses; write themes instead.
-        index_lines = [f"# {item_id} — Search Themes (open-ended)", ""]
+        index_lines = [f"# {_subpage_title(item_for_title, report, 'Search Themes')}", ""]
         rationale = data.get("rationale", "")
         if rationale:
             index_lines.extend([rationale, ""])
@@ -839,7 +856,7 @@ def _write_hypotheses(
         hyps = data.get("hypotheses", [])
 
         index_lines = [
-            f"# {item_id} — Competing Hypotheses",
+            f"# {_subpage_title(item_for_title, report, 'Hypotheses')}",
             "",
             "| ID | Label | Statement | Status |",
             "|----|-------|-----------|--------|",
@@ -908,7 +925,8 @@ def _write_hypothesis_file(path: Path, item_id: str, h: dict[str, Any], status: 
 
 def _write_assessment(item_dir: Path, synthesis: dict[str, Any], report: dict[str, Any]) -> None:
     """Write assessment.md with evidence synthesis, probability assessment, gaps."""
-    lines = [f"# {synthesis.get('id', '?')} — Assessment", ""]
+    item_for_title = {"id": synthesis.get("id", "?")}
+    lines = [f"# {_subpage_title(item_for_title, report, 'Assessment')}", ""]
 
     # Verdict from report
     if report:
@@ -1023,13 +1041,14 @@ def _write_assessment(item_dir: Path, synthesis: dict[str, Any], report: dict[st
     (item_dir / "assessment.md").write_text("\n".join(lines) + "\n")
 
 
-def _write_self_audit(item_dir: Path, audit: dict[str, Any]) -> None:
+def _write_self_audit(item_dir: Path, audit: dict[str, Any], report: dict[str, Any]) -> None:
     """Write self-audit.md with ROBIS 4-domain audit + source verification.
 
     Handles both per-item audit (CLI format with 'process_audit') and
     per-run global audit (plugin format with 'robis_audit' at top level).
     """
-    lines = [f"# {audit.get('id', '?')} — Self-Audit", ""]
+    item_for_title = {"id": audit.get("id", "?")}
+    lines = [f"# {_subpage_title(item_for_title, report, 'Self-Audit')}", ""]
 
     # CLI format: process_audit with named domains
     process = audit.get("process_audit", {})
@@ -1124,9 +1143,11 @@ def _write_reading_list(
     audit: dict[str, Any],
     item_id: str,
     scorecards: dict[str, Any],
+    report: dict[str, Any],
 ) -> None:
     """Write reading-list.md with prioritized sources."""
-    lines = [f"# {item_id} — Reading List", ""]
+    item_for_title = {"id": item_id}
+    lines = [f"# {_subpage_title(item_for_title, report, 'Reading List')}", ""]
 
     reading_list = audit.get("reading_list", []) if isinstance(audit, dict) else []
 
@@ -1189,6 +1210,7 @@ def _write_searches(
     item_id: str,
     item_plan: dict[str, Any],
     search_results: dict[str, Any],
+    report: dict[str, Any],
 ) -> None:
     """Write searches/ subdirectory with per-search logs and an index."""
     if not item_plan:
@@ -1200,8 +1222,9 @@ def _write_searches(
     execution_log = search_results.get("search_execution_log", []) if isinstance(search_results, dict) else []
 
     # Write per-search logs and collect index entries
+    item_for_title = {"id": item_id}
     index_lines = [
-        f"# {item_id} — Searches",
+        f"# {_subpage_title(item_for_title, report, 'Searches')}",
         "",
         "| ID | Target | Terms | Returned | Selected | Rejected |",
         "|----|--------|-------|----------|----------|----------|",
@@ -1337,6 +1360,7 @@ def _write_sources(
     item_id: str,
     scorecards: dict[str, Any],
     search_results: dict[str, Any],  # noqa: ARG001
+    report: dict[str, Any],
 ) -> None:
     """Write sources/ subdirectory with per-source scorecards."""
     sources = _extract_sources_for_item(scorecards, item_id)
@@ -1346,8 +1370,9 @@ def _write_sources(
     sources_dir = item_dir / "sources"
     sources_dir.mkdir(parents=True, exist_ok=True)
 
+    item_for_title = {"id": item_id}
     index_lines = [
-        f"# {item_id} — Sources",
+        f"# {_subpage_title(item_for_title, report, 'Sources')}",
         "",
         "| ID | Title | Reliability | Relevance |",
         "|----|-------|-------------|-----------|",

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -306,7 +306,6 @@ def _write_run_index(
     execution_log = search_results.get("search_execution_log", []) if isinstance(search_results, dict) else []
     reports_by_id: dict[str, dict[str, Any]] = {r.get("id", ""): r for r in reports}
 
-    # Reports lookup by id (may differ from input items when plugin uses report.title)
     def _card_heading(item: dict[str, Any], report: dict[str, Any]) -> str:
         """Build a card-level heading like '{id} — {topic} — {qualifier}'."""
         iid = item.get("id", "?")
@@ -319,41 +318,42 @@ def _write_run_index(
             parts.append(qualifier)
         return " — ".join(parts)
 
-    # Build ToC entries as we go so we can insert the TOC after the meta table
-    toc_entries: list[tuple[str, str, list[tuple[str, str]]]] = []
-    # list of (section_anchor, section_label, [(subheading_anchor, subheading_label), ...])
-
-    # Collect card info so we can write the TOC, then render cards after
-    def _card_anchor(heading_text: str) -> str:
-        """GitHub-style anchor: lowercase, dashes, strip punctuation."""
-        # Keep alphanumerics, spaces, and dashes. Replace spaces with dashes.
-        normalized = re.sub(r"[^a-z0-9\s\-]", "", heading_text.lower())
-        return re.sub(r"\s+", "-", normalized.strip())
-
-    card_sections: list[tuple[str, list[dict[str, Any]]]] = []
+    # Use explicit HTML anchors rather than relying on heading-text-derived anchors.
+    # Different markdown renderers (GFM, MkDocs, VS Code preview) generate anchors
+    # differently from the same heading text — em-dashes and parentheses cause
+    # mismatches. Explicit <a id="..."></a> tags work identically everywhere.
+    #
+    # Anchor scheme:
+    #   sec-axioms, sec-claims, sec-queries, sec-collection-analysis
+    #   card-{item_id}   e.g. card-C001
+    #   sub-collection-statistics, sub-collection-self-audit
+    # Each tuple is (section_anchor, section_label, items)
+    card_sections: list[tuple[str, str, list[dict[str, Any]]]] = []
     if axioms:
-        card_sections.append(("Axioms", axioms))
+        card_sections.append(("sec-axioms", "Axioms", axioms))
     if claims:
-        card_sections.append(("Claims", claims))
+        card_sections.append(("sec-claims", "Claims", claims))
     if queries:
-        card_sections.append(("Queries", queries))
+        card_sections.append(("sec-queries", "Queries", queries))
 
-    for section_label, section_items in card_sections:
+    # Build TOC
+    toc_entries: list[tuple[str, str, list[tuple[str, str]]]] = []
+    for section_anchor, section_label, section_items in card_sections:
         sub_entries: list[tuple[str, str]] = []
         for item in section_items:
-            report = reports_by_id.get(item.get("id", ""), {})
-            h = _card_heading(item, report)
-            sub_entries.append((_card_anchor(h), h))
-        toc_entries.append((_card_anchor(section_label), section_label, sub_entries))
+            iid = item.get("id", "?")
+            report = reports_by_id.get(iid, {})
+            heading_text = _card_heading(item, report)
+            sub_entries.append((f"card-{iid}", heading_text))
+        toc_entries.append((section_anchor, section_label, sub_entries))
 
-    # Collection Analysis ToC entry (we always render at least statistics)
-    collection_subs: list[tuple[str, str]] = [("collection-statistics", "Collection Statistics")]
+    collection_subs: list[tuple[str, str]] = [("sub-collection-statistics", "Collection Statistics")]
     robis = audit.get("robis_audit", {}) if isinstance(audit, dict) else {}
     if isinstance(robis, dict) and robis:
-        collection_subs.append(("collection-self-audit", "Collection Self-Audit"))
-    toc_entries.append(("collection-analysis", "Collection Analysis", collection_subs))
+        collection_subs.append(("sub-collection-self-audit", "Collection Self-Audit"))
+    toc_entries.append(("sec-collection-analysis", "Collection Analysis", collection_subs))
 
-    # Render the TOC
+    # Render TOC
     if toc_entries:
         lines.extend(["<!-- TOC START -->", "## Contents", ""])
         for anchor, label, subs in toc_entries:
@@ -362,9 +362,9 @@ def _write_run_index(
                 lines.append(f"    - [{sub_label}](#{sub_anchor})")
         lines.extend(["", "<!-- TOC END -->", ""])
 
-    # Render card sections
-    for section_label, section_items in card_sections:
-        lines.extend([f"## {section_label}", ""])
+    # Render card sections with explicit anchors
+    for section_anchor, section_label, section_items in card_sections:
+        lines.extend([f'<a id="{section_anchor}"></a>', "", f"## {section_label}", ""])
 
         for item in section_items:
             item_id = item.get("id", "")
@@ -381,7 +381,14 @@ def _write_run_index(
             item_synthesis = _item_by_id(synthesis_items, item_id)
             item_search_plan = _item_by_id(search_plan_items, item_id)
 
-            lines.extend([f"### {_card_heading(item, report)}", ""])
+            lines.extend(
+                [
+                    f'<a id="card-{item_id}"></a>',
+                    "",
+                    f"### {_card_heading(item, report)}",
+                    "",
+                ]
+            )
 
             # Axioms don't have hypotheses, sources, etc. — just the text
             if item_type == "axiom":
@@ -438,8 +445,8 @@ def _write_run_index(
             if slug:
                 lines.extend([f"[Full analysis]({slug}/index.md)", ""])
 
-    # Collection Analysis
-    lines.extend(["---", "", "## Collection Analysis", ""])
+    # Collection Analysis (with explicit anchor)
+    lines.extend(["---", "", '<a id="sec-collection-analysis"></a>', "", "## Collection Analysis", ""])
 
     # Collection Statistics
     total_sources = len(scorecards.get("sources", [])) if isinstance(scorecards, dict) else 0
@@ -451,6 +458,8 @@ def _write_run_index(
 
     lines.extend(
         [
+            '<a id="sub-collection-statistics"></a>',
+            "",
             "### Collection Statistics",
             "",
             "| Metric | Value |",
@@ -470,10 +479,11 @@ def _write_run_index(
     lines.append("")
 
     # Collection Self-Audit (plugin format: global robis_audit)
-    robis = audit.get("robis_audit", {}) if isinstance(audit, dict) else {}
     if isinstance(robis, dict) and robis:
         lines.extend(
             [
+                '<a id="sub-collection-self-audit"></a>',
+                "",
                 "### Collection Self-Audit",
                 "",
                 "| Domain | Rating |",

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -140,18 +140,28 @@ def render_run(run_dir: Path, output_dir: Path) -> None:
         item_audit = _item_by_id(_unwrap_items(audit), item_id)
         item_report = _item_by_id(report_items, item_id)
 
-        _write_item_index(item_dir, item, item_report, item_synthesis)
+        # Plugin format has a single global audit (not per-item).
+        # Use it when no per-item audit exists.
+        audit_to_render = item_audit or audit
+        # Tag with item id so the writer's heading is correct
+        if audit_to_render and not audit_to_render.get("id"):
+            audit_to_render = {**audit_to_render, "id": item_id}
+
+        # Write all content files first
         _write_item_input(item_dir, item)
         if item_hypotheses:
             _write_hypotheses(item_dir, item_hypotheses)
         if item_synthesis:
             _write_assessment(item_dir, item_synthesis, item_report)
-        if item_audit:
-            _write_self_audit(item_dir, item_audit)
+        if audit_to_render:
+            _write_self_audit(item_dir, audit_to_render)
 
         _write_searches(item_dir, item_id, item_search_plan, search_results)
         _write_sources(item_dir, item_id, scorecards, search_results)
-        _write_reading_list(item_dir, item_audit, item_id, scorecards)
+        _write_reading_list(item_dir, audit_to_render, item_id, scorecards)
+
+        # Write index LAST so existence checks see the actual files
+        _write_item_index(item_dir, item, item_report, item_synthesis)
 
 
 def render_run_group(group_dir: Path, output_dir: Path) -> None:
@@ -176,14 +186,15 @@ def render_run_group(group_dir: Path, output_dir: Path) -> None:
     group_consistency = _load_json(group_dir / "group-consistency.json")
     group_reading_list = _load_json(group_dir / "group-reading-list.json")
 
-    _write_group_index(output_dir, run_dirs, group_synthesis)
-
     if group_synthesis:
         _write_group_synthesis(output_dir, group_synthesis)
     if group_consistency:
         _write_group_consistency(output_dir, group_consistency)
     if group_reading_list:
         _write_group_reading_list(output_dir, group_reading_list)
+
+    # Write index LAST so existence checks see the actual files
+    _write_group_index(output_dir, run_dirs, group_synthesis)
 
 
 # ---------------------------------------------------------------------------
@@ -252,15 +263,22 @@ def _write_item_index(
         if summary:
             lines.extend(["## Bottom Line", "", summary, ""])
 
-    # Summary of what's in this directory
+    # Summary of what's in this directory — only link to files that exist
     lines.extend(["## Contents", "", "| Section | Description |", "|---------|-------------|"])
-    lines.append(f"| [Input]({input_filename}) | Original text, clarification, scope, vocabulary |")
-    lines.append("| [Hypotheses](hypotheses.md) | Competing hypotheses |")
-    lines.append("| [Assessment](assessment.md) | Evidence synthesis, probability assessment, gaps |")
-    lines.append("| [Self-Audit](self-audit.md) | Process audit across 4 ROBIS domains |")
-    lines.append("| [Reading List](reading-list.md) | Prioritized source list |")
-    lines.append("| [Searches](searches/) | Search plans and execution logs |")
-    lines.append("| [Sources](sources/) | Source scorecards |")
+    if (item_dir / input_filename).exists():
+        lines.append(f"| [Input]({input_filename}) | Original text, clarification, scope, vocabulary |")
+    if (item_dir / "hypotheses.md").exists():
+        lines.append("| [Hypotheses](hypotheses.md) | Competing hypotheses |")
+    if (item_dir / "assessment.md").exists():
+        lines.append("| [Assessment](assessment.md) | Evidence synthesis, probability assessment, gaps |")
+    if (item_dir / "self-audit.md").exists():
+        lines.append("| [Self-Audit](self-audit.md) | Process audit across 4 ROBIS domains |")
+    if (item_dir / "reading-list.md").exists():
+        lines.append("| [Reading List](reading-list.md) | Prioritized source list |")
+    if (item_dir / "searches" / "index.md").exists():
+        lines.append("| [Searches](searches/index.md) | Search plans and execution logs |")
+    if (item_dir / "sources" / "index.md").exists():
+        lines.append("| [Sources](sources/index.md) | Source scorecards |")
     lines.append("")
 
     # Evidence quality snapshot
@@ -490,9 +508,14 @@ def _write_assessment(item_dir: Path, synthesis: dict[str, Any], report: dict[st
 
 
 def _write_self_audit(item_dir: Path, audit: dict[str, Any]) -> None:
-    """Write self-audit.md with ROBIS 4-domain audit + source verification."""
+    """Write self-audit.md with ROBIS 4-domain audit + source verification.
+
+    Handles both per-item audit (CLI format with 'process_audit') and
+    per-run global audit (plugin format with 'robis_audit' at top level).
+    """
     lines = [f"# {audit.get('id', '?')} — Self-Audit", ""]
 
+    # CLI format: process_audit with named domains
     process = audit.get("process_audit", {})
     if isinstance(process, dict) and process:
         lines.extend(
@@ -516,6 +539,35 @@ def _write_self_audit(item_dir: Path, audit: dict[str, Any]) -> None:
                 lines.append(f"| {domain_key.replace('_', ' ').title()} | {rating} | {rationale} |")
         lines.append("")
 
+    # Plugin format: robis_audit with domain_N_* keys (global, not per-item)
+    robis = audit.get("robis_audit", {})
+    if isinstance(robis, dict) and robis:
+        lines.extend(
+            [
+                "## ROBIS Audit (4 Domains)",
+                "",
+                "| Domain | Risk | Assessment |",
+                "|--------|------|------------|",
+            ]
+        )
+        for key in sorted(k for k in robis if k.startswith("domain_")):
+            d = robis[key]
+            if isinstance(d, dict):
+                risk = d.get("risk", "—")
+                assessment_text = (d.get("assessment") or "")[:300]
+                domain_label = key.replace("_", " ").replace("domain ", "Domain ").title()
+                lines.append(f"| {domain_label} | {risk} | {assessment_text} |")
+        lines.append("")
+        if robis.get("overall_risk_of_bias"):
+            lines.append(f"**Overall risk of bias**: {robis['overall_risk_of_bias']}")
+            lines.append("")
+        if robis.get("overall_assessment"):
+            lines.append("### Overall Assessment")
+            lines.append("")
+            lines.append(robis["overall_assessment"])
+            lines.append("")
+
+    # Source-back verification (CLI format)
     verification = audit.get("source_verification", {})
     if isinstance(verification, dict) and verification:
         count = verification.get("sources_verified", 0)
@@ -531,6 +583,20 @@ def _write_self_audit(item_dir: Path, audit: dict[str, Any]) -> None:
             lines.append("")
         else:
             lines.append("No discrepancies found.")
+            lines.append("")
+
+    # Plugin format: source_interpretation_verification (different field name)
+    plugin_verification = audit.get("source_interpretation_verification", {})
+    if isinstance(plugin_verification, dict) and plugin_verification:
+        lines.extend(["## Source Interpretation Verification", ""])
+        if plugin_verification.get("sources_checked"):
+            lines.append(f"Sources checked: {plugin_verification['sources_checked']}")
+            lines.append("")
+        if plugin_verification.get("findings"):
+            lines.append(plugin_verification["findings"])
+            lines.append("")
+        if plugin_verification.get("assessment"):
+            lines.append(plugin_verification["assessment"])
             lines.append("")
 
     lines.append("[← Back to item overview](index.md)")
@@ -608,7 +674,7 @@ def _write_searches(
     item_plan: dict[str, Any],
     search_results: dict[str, Any],
 ) -> None:
-    """Write searches/ subdirectory with per-search logs."""
+    """Write searches/ subdirectory with per-search logs and an index."""
     if not item_plan:
         return
     searches_dir = item_dir / "searches"
@@ -616,6 +682,9 @@ def _write_searches(
 
     searches = item_plan.get("searches", [])
     execution_log = search_results.get("search_execution_log", []) if isinstance(search_results, dict) else []
+
+    # Write per-search logs and collect index entries
+    index_lines = [f"# {item_id} — Searches", "", "| ID | Target | Terms |", "|----|--------|-------|"]
 
     for s in searches:
         search_id = s.get("id", "S??")
@@ -654,6 +723,13 @@ def _write_searches(
         lines.append("[← Back to item overview](../../index.md)")
         (search_subdir / "search-log.md").write_text("\n".join(lines) + "\n")
 
+        # Add to index
+        terms_short = ", ".join(f"`{t}`" for t in terms[:3])
+        index_lines.append(f"| [{search_id}]({search_id}/search-log.md) | {theme[:60]} | {terms_short} |")
+
+    index_lines.extend(["", "[← Back to item overview](../index.md)"])
+    (searches_dir / "index.md").write_text("\n".join(index_lines) + "\n")
+
 
 def _write_sources(
     item_dir: Path,
@@ -669,6 +745,13 @@ def _write_sources(
     sources_dir = item_dir / "sources"
     sources_dir.mkdir(parents=True, exist_ok=True)
 
+    index_lines = [
+        f"# {item_id} — Sources",
+        "",
+        "| ID | Title | Reliability | Relevance |",
+        "|----|-------|-------------|-----------|",
+    ]
+
     for i, s in enumerate(sources, 1):
         src_id = s.get("id") or f"SRC{i:03d}"
         src_subdir = sources_dir / src_id
@@ -676,6 +759,13 @@ def _write_sources(
 
         url = s.get("url", "")
         title = s.get("title") or url
+
+        # Index entry
+        rel_rating = s.get("reliability", {})
+        relev_rating = s.get("relevance", {})
+        rel_str = rel_rating.get("rating", "—") if isinstance(rel_rating, dict) else str(rel_rating)
+        relev_str = relev_rating.get("rating", "—") if isinstance(relev_rating, dict) else str(relev_rating)
+        index_lines.append(f"| [{src_id}]({src_id}/scorecard.md) | {title[:60]} | {rel_str} | {relev_str} |")
 
         lines = [f"# {src_id} — {title}", ""]
         if url:
@@ -707,6 +797,9 @@ def _write_sources(
         lines.append("[← Back to item overview](../../index.md)")
         (src_subdir / "scorecard.md").write_text("\n".join(lines) + "\n")
 
+    index_lines.extend(["", "[← Back to item overview](../index.md)"])
+    (sources_dir / "index.md").write_text("\n".join(index_lines) + "\n")
+
 
 # ---------------------------------------------------------------------------
 # Group-level writers
@@ -729,15 +822,17 @@ def _write_group_index(
             lines.append(f"- [{rd.name}]({rd.name}/index.md)")
         lines.append("")
 
-    lines.extend(["## Group-Level Reports", ""])
-    for filename, label in [
+    group_links = [
         ("synthesis.md", "Cross-run synthesis"),
         ("consistency.md", "Cross-run consistency metrics"),
         ("reading-list.md", "Consolidated reading list"),
-    ]:
-        if (output_dir / filename).exists() or True:
+    ]
+    existing_links = [(f, lab) for f, lab in group_links if (output_dir / f).exists()]
+    if existing_links:
+        lines.extend(["## Group-Level Reports", ""])
+        for filename, label in existing_links:
             lines.append(f"- [{label}]({filename})")
-    lines.append("")
+        lines.append("")
 
     (output_dir / "index.md").write_text("\n".join(lines) + "\n")
 
@@ -745,19 +840,107 @@ def _write_group_index(
 def _write_group_synthesis(output_dir: Path, data: dict[str, Any]) -> None:
     """Write group-level synthesis.md."""
     lines = ["# Cross-Run Synthesis", ""]
-    lines.append(json.dumps(data, indent=2))
+
+    total_runs = data.get("total_runs", 0)
+    if total_runs:
+        lines.append(f"**Total runs**: {total_runs}")
+        lines.append("")
+    note = data.get("note")
+    if note:
+        lines.extend([f"> {note}", ""])
+
+    items = data.get("items", [])
+    if items:
+        lines.extend(["## Consensus Per Item", ""])
+        for item in items:
+            item_id = item.get("id", "?")
+            verdict = item.get("consensus_verdict", "—")
+            summary = item.get("summary", "")
+            lines.append(f"### {item_id} — {verdict}")
+            lines.append("")
+            if summary:
+                lines.append(summary)
+                lines.append("")
+            divergences = item.get("divergences", [])
+            if divergences:
+                lines.append("**Divergences across runs:**")
+                for d in divergences:
+                    lines.append(f"- {d}")
+                lines.append("")
+            sources_count = item.get("sources_union_count")
+            if sources_count is not None:
+                lines.append(f"Sources (union across runs): {sources_count}")
+                lines.append("")
+
+    lines.append("[← Back to group overview](index.md)")
     (output_dir / "synthesis.md").write_text("\n".join(lines) + "\n")
 
 
 def _write_group_consistency(output_dir: Path, data: dict[str, Any]) -> None:
     """Write group-level consistency.md."""
     lines = ["# Cross-Run Consistency Metrics", ""]
-    lines.append(json.dumps(data, indent=2))
+
+    total_runs = data.get("total_runs", 0)
+    if total_runs:
+        lines.append(f"**Total runs**: {total_runs}")
+        lines.append("")
+    note = data.get("note")
+    if note:
+        lines.extend([f"> {note}", ""])
+
+    metrics = data.get("metrics", {})
+    if isinstance(metrics, dict) and metrics:
+        lines.extend(["## Metrics", "", "| Metric | Value |", "|--------|-------|"])
+        for k, v in metrics.items():
+            label = k.replace("_", " ").title()
+            lines.append(f"| {label} | {v} |")
+        lines.append("")
+
+    diagnostic = data.get("diagnostic")
+    if diagnostic:
+        lines.extend(["## Diagnostic", "", diagnostic, ""])
+
+    lines.append("[← Back to group overview](index.md)")
     (output_dir / "consistency.md").write_text("\n".join(lines) + "\n")
 
 
 def _write_group_reading_list(output_dir: Path, data: dict[str, Any]) -> None:
     """Write group-level reading-list.md."""
     lines = ["# Consolidated Reading List", ""]
-    lines.append(json.dumps(data, indent=2))
+
+    reading_list = data.get("reading_list", [])
+    if not reading_list:
+        lines.append("No sources recorded.")
+        lines.append("")
+        (output_dir / "reading-list.md").write_text("\n".join(lines) + "\n")
+        return
+
+    # Group by priority
+    by_priority: dict[str, list[dict[str, Any]]] = {"must read": [], "should read": [], "reference": []}
+    for entry in reading_list:
+        priority = entry.get("priority", "reference")
+        if priority in by_priority:
+            by_priority[priority].append(entry)
+
+    for priority_label in ("must read", "should read", "reference"):
+        entries = by_priority[priority_label]
+        if not entries:
+            continue
+        lines.extend([f"## {priority_label.title()}", ""])
+        for e in entries:
+            title = e.get("title") or e.get("url", "")
+            url = e.get("url", "")
+            summary = e.get("summary", "")
+            items_refs = e.get("items", [])
+            runs_found = e.get("found_in_runs", [])
+            lines.append(f"- **[{title}]({url})**")
+            if summary:
+                lines.append(f"  - {summary}")
+            if items_refs:
+                lines.append(f"  - Referenced by: {', '.join(items_refs)}")
+            if runs_found:
+                lines.append(f"  - Found in runs: {', '.join(runs_found)}")
+        lines.append("")
+
+    lines.append("[← Back to group overview](index.md)")
     (output_dir / "reading-list.md").write_text("\n".join(lines) + "\n")

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -1,0 +1,763 @@
+"""JSON-to-Markdown renderer for Diogenes research output.
+
+Reads the JSON files produced by the pipeline and writes a directory tree
+of linked markdown files. Pure Python, zero LLM tokens. Produces generic
+markdown with relative links — no CSS classes, admonitions, or
+framework-specific markup.
+
+Output structure (per run):
+
+    run-N/
+    ├── index.md                  (run overview + verdict summary)
+    └── C001-<slug>/
+        ├── index.md              (item overview, BLUF, summary)
+        ├── claim.md or query.md  (input details, vocabulary)
+        ├── hypotheses.md         (competing hypotheses)
+        ├── assessment.md         (full assessment with reasoning)
+        ├── self-audit.md         (process audit domains)
+        ├── reading-list.md       (prioritized sources)
+        ├── searches/
+        │   └── S01/search-log.md
+        └── sources/
+            └── SRC001/scorecard.md
+
+Group-level (run group directory):
+
+    <run-group>/
+    ├── index.md                  (group overview)
+    ├── synthesis.md              (cross-run synthesis, if multi-run)
+    ├── consistency.md            (cross-run metrics, if multi-run)
+    └── reading-list.md           (consolidated sources)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any
+
+_SLUG_MAX_LEN = 50
+
+
+def _slugify(text: str, max_len: int = _SLUG_MAX_LEN) -> str:
+    """Convert text to a filesystem-safe slug."""
+    # Lowercase, replace non-alphanum with dashes, collapse, trim
+    slug = re.sub(r"[^a-z0-9]+", "-", text.lower())
+    slug = slug.strip("-")
+    if len(slug) > max_len:
+        slug = slug[:max_len].rstrip("-")
+    return slug or "unnamed"
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    """Load a JSON file, returning empty dict if missing."""
+    if not path.exists():
+        return {}
+    try:
+        data: dict[str, Any] = json.loads(path.read_text())
+    except json.JSONDecodeError:
+        return {}
+    return data
+
+
+def _item_slug(item_id: str, text: str) -> str:
+    """Generate a directory slug for an item (e.g. C001-rlhf-sycophancy)."""
+    return f"{item_id}-{_slugify(text, max_len=40)}"
+
+
+def _unwrap_items(data: dict[str, Any], key: str = "items") -> list[dict[str, Any]]:
+    """Extract item list from a pipeline output file.
+
+    Handles both CLI format (dict keyed by item ID) and plugin format
+    (wrapped with pipeline_step metadata, items under a key).
+    """
+    if not data:
+        return []
+    # Plugin format: metadata wrapper with items list
+    if key in data and isinstance(data[key], list):
+        items: list[dict[str, Any]] = data[key]
+        return items
+    # Alternative plugin key
+    if "reports" in data and isinstance(data["reports"], list):
+        reports: list[dict[str, Any]] = data["reports"]
+        return reports
+    # CLI format: dict keyed by item ID
+    if all(k.startswith(("C", "Q")) for k in data if k not in {"pipeline_step", "step_name", "timestamp"}):
+        return [v for k, v in data.items() if k.startswith(("C", "Q")) and isinstance(v, dict)]
+    return []
+
+
+def _item_by_id(items: list[dict[str, Any]], item_id: str) -> dict[str, Any]:
+    """Find an item by its ID in a list."""
+    for item in items:
+        if item.get("id") == item_id:
+            return item
+    return {}
+
+
+def render_run(run_dir: Path, output_dir: Path) -> None:
+    """Render a single run's JSON output to a markdown tree.
+
+    Args:
+        run_dir: Directory containing the JSON step outputs.
+        output_dir: Where to write the markdown tree.
+
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Load all pipeline outputs
+    research_input = _load_json(run_dir / "research-input.json")
+    hypotheses = _load_json(run_dir / "hypotheses.json")
+    search_plans = _load_json(run_dir / "search-plans.json")
+    search_results = _load_json(run_dir / "search-results.json")
+    scorecards = _load_json(run_dir / "source-scorecards.json")
+    synthesis = _load_json(run_dir / "synthesis.json")
+    audit = _load_json(run_dir / "self-audit.json")
+    reports = _load_json(run_dir / "reports.json")
+
+    # Extract items
+    input_items = _unwrap_items(research_input)
+    report_items = _unwrap_items(reports, key="reports")
+
+    # Write run index
+    _write_run_index(output_dir, input_items, report_items)
+
+    # Write per-item content
+    for item in input_items:
+        item_id = item.get("id", "")
+        if not item_id:
+            continue
+
+        clarified = item.get("restated_for_testability") or item.get("clarified_text") or item.get("original_text", "")
+        slug = _item_slug(item_id, clarified)
+        item_dir = output_dir / slug
+        item_dir.mkdir(parents=True, exist_ok=True)
+
+        item_hypotheses = _item_by_id(_unwrap_items(hypotheses), item_id)
+        item_search_plan = _item_by_id(_unwrap_items(search_plans), item_id)
+        item_synthesis = _item_by_id(_unwrap_items(synthesis), item_id)
+        item_audit = _item_by_id(_unwrap_items(audit), item_id)
+        item_report = _item_by_id(report_items, item_id)
+
+        _write_item_index(item_dir, item, item_report, item_synthesis)
+        _write_item_input(item_dir, item)
+        if item_hypotheses:
+            _write_hypotheses(item_dir, item_hypotheses)
+        if item_synthesis:
+            _write_assessment(item_dir, item_synthesis, item_report)
+        if item_audit:
+            _write_self_audit(item_dir, item_audit)
+
+        _write_searches(item_dir, item_id, item_search_plan, search_results)
+        _write_sources(item_dir, item_id, scorecards, search_results)
+        _write_reading_list(item_dir, item_audit, item_id, scorecards)
+
+
+def render_run_group(group_dir: Path, output_dir: Path) -> None:
+    """Render an entire run group (possibly multiple runs) to markdown.
+
+    Args:
+        group_dir: Run group directory containing run-N/ subdirs and
+            optionally group-level JSON files.
+        output_dir: Where to write the rendered markdown tree.
+
+    """
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    # Render each run
+    run_dirs = sorted(d for d in group_dir.iterdir() if d.is_dir() and d.name.startswith("run-"))
+    for run_dir in run_dirs:
+        run_output = output_dir / run_dir.name
+        render_run(run_dir, run_output)
+
+    # Render group-level content if present
+    group_synthesis = _load_json(group_dir / "group-synthesis.json")
+    group_consistency = _load_json(group_dir / "group-consistency.json")
+    group_reading_list = _load_json(group_dir / "group-reading-list.json")
+
+    _write_group_index(output_dir, run_dirs, group_synthesis)
+
+    if group_synthesis:
+        _write_group_synthesis(output_dir, group_synthesis)
+    if group_consistency:
+        _write_group_consistency(output_dir, group_consistency)
+    if group_reading_list:
+        _write_group_reading_list(output_dir, group_reading_list)
+
+
+# ---------------------------------------------------------------------------
+# Writers for individual markdown files
+# ---------------------------------------------------------------------------
+
+
+def _write_run_index(output_dir: Path, input_items: list[dict[str, Any]], reports: list[dict[str, Any]]) -> None:
+    """Write the run-level index.md with a verdict summary table."""
+    lines: list[str] = ["# Run Overview", ""]
+    lines.append(f"Items investigated: {len(input_items)}")
+    lines.append("")
+
+    # Build a lookup from item ID to the slug used by input items (for consistent links)
+    slug_by_id: dict[str, str] = {}
+    for item in input_items:
+        item_id = item.get("id", "")
+        clarified = item.get("restated_for_testability") or item.get("clarified_text") or item.get("original_text", "")
+        if item_id:
+            slug_by_id[item_id] = _item_slug(item_id, clarified)
+
+    if reports:
+        lines.extend(
+            ["## Verdict Summary", "", "| ID | Type | Verdict | Summary |", "|----|------|---------|---------|"]
+        )
+        for report in reports:
+            item_id = report.get("id", "?")
+            item_type = report.get("type", "?")
+            verdict = report.get("verdict", "—")
+            summary = (report.get("verdict_summary") or report.get("one_line") or "")[:120]
+            slug = slug_by_id.get(item_id) or _item_slug(item_id, report.get("title", ""))
+            lines.append(f"| [{item_id}]({slug}/index.md) | {item_type} | {verdict} | {summary} |")
+        lines.append("")
+
+    lines.extend(["## Items", ""])
+    for item in input_items:
+        item_id = item.get("id", "?")
+        clarified = item.get("restated_for_testability") or item.get("clarified_text") or item.get("original_text", "")
+        slug = _item_slug(item_id, clarified)
+        lines.append(f"- [{item_id} — {clarified[:100]}]({slug}/index.md)")
+
+    (output_dir / "index.md").write_text("\n".join(lines) + "\n")
+
+
+def _write_item_index(
+    item_dir: Path,
+    item: dict[str, Any],
+    report: dict[str, Any],
+    synthesis: dict[str, Any],
+) -> None:
+    """Write the per-item index.md with BLUF and summary."""
+    item_id = item.get("id", "?")
+    item_type = item.get("type", "claim")
+    input_filename = "claim.md" if item_type == "claim" else "query.md"
+
+    clarified = item.get("restated_for_testability") or item.get("clarified_text") or item.get("original_text", "")
+
+    lines = [f"# {item_id}", "", f"**{clarified}**", ""]
+
+    # BLUF from report
+    if report:
+        verdict = report.get("verdict", "")
+        summary = report.get("verdict_summary") or report.get("one_line") or ""
+        if verdict:
+            lines.extend([f"**Verdict:** {verdict}", ""])
+        if summary:
+            lines.extend(["## Bottom Line", "", summary, ""])
+
+    # Summary of what's in this directory
+    lines.extend(["## Contents", "", "| Section | Description |", "|---------|-------------|"])
+    lines.append(f"| [Input]({input_filename}) | Original text, clarification, scope, vocabulary |")
+    lines.append("| [Hypotheses](hypotheses.md) | Competing hypotheses |")
+    lines.append("| [Assessment](assessment.md) | Evidence synthesis, probability assessment, gaps |")
+    lines.append("| [Self-Audit](self-audit.md) | Process audit across 4 ROBIS domains |")
+    lines.append("| [Reading List](reading-list.md) | Prioritized source list |")
+    lines.append("| [Searches](searches/) | Search plans and execution logs |")
+    lines.append("| [Sources](sources/) | Source scorecards |")
+    lines.append("")
+
+    # Evidence quality snapshot
+    if synthesis:
+        syn = synthesis.get("synthesis") or synthesis
+        evidence_quality = syn.get("evidence_quality", {})
+        source_agreement = syn.get("source_agreement", {})
+        if evidence_quality or source_agreement:
+            lines.extend(["## Evidence Snapshot", "", "| Dimension | Rating |", "|-----------|--------|"])
+            if isinstance(evidence_quality, dict) and evidence_quality.get("rating"):
+                lines.append(f"| Evidence quality | {evidence_quality.get('rating')} |")
+            if isinstance(source_agreement, dict) and source_agreement.get("rating"):
+                lines.append(f"| Source agreement | {source_agreement.get('rating')} |")
+            lines.append("")
+
+    lines.append("[← Back to run overview](../index.md)")
+    (item_dir / "index.md").write_text("\n".join(lines) + "\n")
+
+
+def _write_item_input(item_dir: Path, item: dict[str, Any]) -> None:
+    """Write claim.md or query.md with input details."""
+    item_type = item.get("type", "claim")
+    filename = "claim.md" if item_type == "claim" else "query.md"
+
+    lines = [f"# {item.get('id', '?')} — Input", ""]
+
+    original = item.get("original_text", "")
+    clarified = item.get("restated_for_testability") or item.get("clarified_text", "")
+
+    if original:
+        lines.extend(["## Original Text", "", original, ""])
+    if clarified and clarified != original:
+        lines.extend(["## Clarified for Testability", "", clarified, ""])
+
+    assumptions = item.get("embedded_assumptions") or item.get("assumptions_surfaced", [])
+    if assumptions:
+        lines.extend(["## Embedded Assumptions Surfaced", ""])
+        for a in assumptions:
+            lines.append(f"- {a}")
+        lines.append("")
+
+    scope = item.get("scope", {})
+    if isinstance(scope, dict) and scope:
+        lines.extend(["## Scope", "", "| Dimension | Value |", "|-----------|-------|"])
+        for k, v in scope.items():
+            lines.append(f"| {k.capitalize()} | {v} |")
+        lines.append("")
+
+    vocab = item.get("vocabulary_map") or item.get("vocabulary", {})
+    if isinstance(vocab, dict) and vocab:
+        lines.extend(["## Vocabulary Map", ""])
+        for section, terms in vocab.items():
+            if isinstance(terms, list) and terms:
+                lines.append(f"**{section.replace('_', ' ').title()}**: " + ", ".join(str(t) for t in terms))
+                lines.append("")
+
+    lines.append("[← Back to item overview](index.md)")
+    (item_dir / filename).write_text("\n".join(lines) + "\n")
+
+
+def _write_hypotheses(item_dir: Path, data: dict[str, Any]) -> None:
+    """Write hypotheses.md with the competing hypotheses table."""
+    lines = [f"# {data.get('id', '?')} — Competing Hypotheses", ""]
+
+    approach = data.get("approach", "hypotheses")
+    if approach == "open-ended":
+        rationale = data.get("rationale", "")
+        themes = data.get("search_themes", [])
+        lines.extend(["## Approach: Open-ended", "", rationale, "", "## Search Themes", ""])
+        for t in themes:
+            lines.append(f"### {t.get('id', '?')} — {t.get('theme', '')}")
+            lines.append("")
+            derived = t.get("derived_from", "")
+            if derived:
+                lines.append(f"**Derived from**: {derived}")
+                lines.append("")
+            look_for = t.get("look_for", [])
+            if look_for:
+                lines.append("**Look for:**")
+                for lf in look_for:
+                    lines.append(f"- {lf}")
+                lines.append("")
+    else:
+        hyps = data.get("hypotheses", [])
+        for h in hyps:
+            lines.append(f"## {h.get('id', '?')} — {h.get('statement', '')}")
+            lines.append("")
+            supporting = h.get("supporting_evidence", [])
+            eliminating = h.get("eliminating_evidence", [])
+            if supporting:
+                lines.append("**Supporting evidence would show:**")
+                for s in supporting:
+                    lines.append(f"- {s}")
+                lines.append("")
+            if eliminating:
+                lines.append("**Eliminating evidence would show:**")
+                for e in eliminating:
+                    lines.append(f"- {e}")
+                lines.append("")
+
+        disc = data.get("discriminating_questions", [])
+        if disc:
+            lines.extend(["## Discriminating Questions", ""])
+            for q in disc:
+                lines.append(f"- {q}")
+            lines.append("")
+
+    lines.append("[← Back to item overview](index.md)")
+    (item_dir / "hypotheses.md").write_text("\n".join(lines) + "\n")
+
+
+def _write_assessment(item_dir: Path, synthesis: dict[str, Any], report: dict[str, Any]) -> None:
+    """Write assessment.md with evidence synthesis, probability assessment, gaps."""
+    lines = [f"# {synthesis.get('id', '?')} — Assessment", ""]
+
+    # Verdict from report
+    if report:
+        verdict = report.get("verdict", "")
+        summary = report.get("verdict_summary") or report.get("one_line") or ""
+        if verdict:
+            lines.extend([f"**Verdict:** {verdict}", ""])
+        if summary:
+            lines.extend([summary, ""])
+        reasoning = report.get("reasoning") or report.get("reasoning_chain", "")
+        if reasoning:
+            lines.extend(["## Reasoning", "", reasoning, ""])
+
+    # Synthesis section
+    syn = synthesis.get("synthesis") or synthesis
+    if isinstance(syn, dict):
+        lines.extend(["## Evidence Synthesis", ""])
+
+        # Plugin format: evidence_summary text + IPCC axes
+        if syn.get("evidence_summary"):
+            lines.append(syn["evidence_summary"])
+            lines.append("")
+        if syn.get("ipcc_combined"):
+            lines.append(f"**IPCC assessment**: {syn['ipcc_combined']}")
+            lines.append("")
+        if syn.get("ipcc_agreement_axis"):
+            lines.append(f"- **Agreement**: {syn['ipcc_agreement_axis']}")
+        if syn.get("ipcc_evidence_axis"):
+            lines.append(f"- **Evidence**: {syn['ipcc_evidence_axis']}")
+        lines.append("")
+
+        # CLI format: rated fields with rationale
+        eq = syn.get("evidence_quality", {})
+        sa = syn.get("source_agreement", {})
+        if isinstance(eq, dict) and eq.get("rating"):
+            lines.append(f"**Evidence quality**: {eq.get('rating')} — {eq.get('rationale', '')}")
+            lines.append("")
+        if isinstance(sa, dict) and sa.get("rating"):
+            lines.append(f"**Source agreement**: {sa.get('rating')} — {sa.get('rationale', '')}")
+            lines.append("")
+        indep = syn.get("independence", {})
+        if isinstance(indep, dict) and indep.get("assessment"):
+            lines.append(f"**Independence**: {indep.get('assessment')}")
+            lines.append("")
+        outliers = syn.get("outliers", [])
+        if outliers:
+            lines.extend(["### Outliers", ""])
+            for o in outliers:
+                lines.append(f"- **{o.get('source_url', '')}**: {o.get('divergence', '')} — {o.get('explanation', '')}")
+            lines.append("")
+
+    # Assessment section (probability/confidence)
+    assessment = synthesis.get("assessment", {})
+    if isinstance(assessment, dict) and assessment:
+        lines.extend(["## Probability Assessment", ""])
+
+        # Plugin format
+        if assessment.get("scale"):
+            lines.append(f"**Scale**: {assessment['scale']}")
+        if assessment.get("probability_label"):
+            lines.append(
+                f"**Probability**: {assessment['probability_label']} ({assessment.get('probability_range', '')})"
+            )
+        if assessment.get("rationale"):
+            lines.append("")
+            lines.append(assessment["rationale"])
+        lines.append("")
+
+        # CLI format: per-hypothesis ratings
+        ratings = assessment.get("hypothesis_ratings", [])
+        for r in ratings:
+            lines.append(
+                f"- **{r.get('hypothesis_id', '?')}**: {r.get('probability_term', '')} ({r.get('probability_range', '')})"
+            )
+            if r.get("reasoning"):
+                lines.append(f"  - {r.get('reasoning')}")
+        if assessment.get("verdict"):
+            lines.append(f"**Verdict**: {assessment['verdict']}")
+        if assessment.get("confidence"):
+            lines.append(f"**Confidence**: {assessment['confidence']}")
+        lines.append("")
+
+    # Gaps
+    gaps = synthesis.get("gaps")
+    if gaps:
+        lines.extend(["## Evidence Gaps", ""])
+        # Plugin format: flat list of strings
+        if isinstance(gaps, list):
+            for g in gaps:
+                lines.append(f"- {g}")
+            lines.append("")
+        # CLI format: structured dict
+        elif isinstance(gaps, dict):
+            expected = gaps.get("expected_not_found", [])
+            if expected:
+                lines.append("**Expected but not found:**")
+                for e in expected:
+                    lines.append(f"- {e}")
+                lines.append("")
+            unanswered = gaps.get("unanswered_questions", [])
+            if unanswered:
+                lines.append("**Unanswered questions:**")
+                for u in unanswered:
+                    lines.append(f"- {u}")
+                lines.append("")
+            impact = gaps.get("impact_on_confidence", "")
+            if impact:
+                lines.append(f"**Impact on confidence**: {impact}")
+                lines.append("")
+
+    lines.append("[← Back to item overview](index.md)")
+    (item_dir / "assessment.md").write_text("\n".join(lines) + "\n")
+
+
+def _write_self_audit(item_dir: Path, audit: dict[str, Any]) -> None:
+    """Write self-audit.md with ROBIS 4-domain audit + source verification."""
+    lines = [f"# {audit.get('id', '?')} — Self-Audit", ""]
+
+    process = audit.get("process_audit", {})
+    if isinstance(process, dict) and process:
+        lines.extend(
+            [
+                "## Process Audit (ROBIS 4 Domains)",
+                "",
+                "| Domain | Rating | Rationale |",
+                "|--------|--------|-----------|",
+            ]
+        )
+        for domain_key in (
+            "eligibility_criteria",
+            "search_comprehensiveness",
+            "evaluation_consistency",
+            "synthesis_fairness",
+        ):
+            d = process.get(domain_key, {})
+            if isinstance(d, dict):
+                rating = d.get("rating", "—")
+                rationale = (d.get("rationale") or "")[:200]
+                lines.append(f"| {domain_key.replace('_', ' ').title()} | {rating} | {rationale} |")
+        lines.append("")
+
+    verification = audit.get("source_verification", {})
+    if isinstance(verification, dict) and verification:
+        count = verification.get("sources_verified", 0)
+        discrepancies = verification.get("discrepancies", [])
+        lines.extend(["## Source-Back Verification", "", f"Sources verified: {count}", ""])
+        if discrepancies:
+            lines.append("### Discrepancies")
+            lines.append("")
+            for d in discrepancies:
+                lines.append(f"- **{d.get('severity', '?')}** at {d.get('source_url', '')}")
+                lines.append(f"  - Assessment claims: {d.get('claim_in_assessment', '')}")
+                lines.append(f"  - Source actually says: {d.get('actual_source_says', '')}")
+            lines.append("")
+        else:
+            lines.append("No discrepancies found.")
+            lines.append("")
+
+    lines.append("[← Back to item overview](index.md)")
+    (item_dir / "self-audit.md").write_text("\n".join(lines) + "\n")
+
+
+def _write_reading_list(
+    item_dir: Path,
+    audit: dict[str, Any],
+    item_id: str,
+    scorecards: dict[str, Any],
+) -> None:
+    """Write reading-list.md with prioritized sources."""
+    lines = [f"# {item_id} — Reading List", ""]
+
+    reading_list = audit.get("reading_list", []) if isinstance(audit, dict) else []
+
+    if reading_list:
+        by_priority: dict[str, list[dict[str, Any]]] = {"must read": [], "should read": [], "reference": []}
+        for entry in reading_list:
+            priority = entry.get("priority", "reference")
+            if priority in by_priority:
+                by_priority[priority].append(entry)
+        for priority_label in ("must read", "should read", "reference"):
+            entries = by_priority[priority_label]
+            if entries:
+                lines.extend([f"## {priority_label.title()}", ""])
+                for e in entries:
+                    title = e.get("title") or e.get("url", "")
+                    summary = e.get("summary", "")
+                    url = e.get("url", "")
+                    lines.append(f"- **[{title}]({url})**")
+                    if summary:
+                        lines.append(f"  - {summary}")
+                lines.append("")
+    else:
+        # Fall back to scorecards directly
+        sources = _extract_sources_for_item(scorecards, item_id)
+        if sources:
+            lines.extend(
+                ["## Sources", "", "| Source | Reliability | Relevance |", "|--------|-------------|-----------|"]
+            )
+            for s in sources:
+                url = s.get("url", "")
+                title = s.get("title") or url
+                rel = s.get("reliability", {})
+                relev = s.get("relevance", {})
+                rel_rating = rel.get("rating", "?") if isinstance(rel, dict) else str(rel)
+                relev_rating = relev.get("rating", "?") if isinstance(relev, dict) else str(relev)
+                lines.append(f"| [{title}]({url}) | {rel_rating} | {relev_rating} |")
+            lines.append("")
+
+    lines.append("[← Back to item overview](index.md)")
+    (item_dir / "reading-list.md").write_text("\n".join(lines) + "\n")
+
+
+def _extract_sources_for_item(scorecards: dict[str, Any], item_id: str) -> list[dict[str, Any]]:
+    """Pull out scorecards relevant to a specific item ID."""
+    sources_list = scorecards.get("sources", []) if isinstance(scorecards, dict) else []
+    if isinstance(sources_list, list):
+        matching = [s for s in sources_list if s.get("item_id") == item_id or not s.get("item_id")]
+        if matching:
+            return matching
+    # CLI style: dict keyed by item ID
+    item_data = scorecards.get(item_id, {})
+    if isinstance(item_data, dict):
+        scores: list[dict[str, Any]] = item_data.get("scorecards", [])
+        return scores
+    return []
+
+
+def _write_searches(
+    item_dir: Path,
+    item_id: str,
+    item_plan: dict[str, Any],
+    search_results: dict[str, Any],
+) -> None:
+    """Write searches/ subdirectory with per-search logs."""
+    if not item_plan:
+        return
+    searches_dir = item_dir / "searches"
+    searches_dir.mkdir(parents=True, exist_ok=True)
+
+    searches = item_plan.get("searches", [])
+    execution_log = search_results.get("search_execution_log", []) if isinstance(search_results, dict) else []
+
+    for s in searches:
+        search_id = s.get("id", "S??")
+        search_subdir = searches_dir / search_id
+        search_subdir.mkdir(parents=True, exist_ok=True)
+
+        lines = [f"# {item_id} — {search_id}", ""]
+        theme = s.get("theme") or s.get("target_hypothesis") or ""
+        if theme:
+            lines.append(f"**Target**: {theme}")
+            lines.append("")
+        terms = s.get("terms", [])
+        if terms:
+            lines.append("**Terms**: " + ", ".join(f"`{t}`" for t in terms))
+            lines.append("")
+        sources_planned = s.get("sources", [])
+        if sources_planned:
+            lines.append("**Planned sources**: " + ", ".join(sources_planned))
+            lines.append("")
+
+        # Match execution record
+        exec_record = next(
+            (e for e in execution_log if e.get("search_id") == search_id or e.get("id") == search_id),
+            None,
+        )
+        if exec_record:
+            lines.extend(["## Execution", ""])
+            results = exec_record.get("results_returned") or exec_record.get("results_found", 0)
+            selected = exec_record.get("results_selected", 0)
+            rejected = exec_record.get("results_rejected", 0)
+            lines.append(f"- Results returned: {results}")
+            lines.append(f"- Selected: {selected}")
+            lines.append(f"- Rejected: {rejected}")
+            lines.append("")
+
+        lines.append("[← Back to item overview](../../index.md)")
+        (search_subdir / "search-log.md").write_text("\n".join(lines) + "\n")
+
+
+def _write_sources(
+    item_dir: Path,
+    item_id: str,
+    scorecards: dict[str, Any],
+    search_results: dict[str, Any],  # noqa: ARG001
+) -> None:
+    """Write sources/ subdirectory with per-source scorecards."""
+    sources = _extract_sources_for_item(scorecards, item_id)
+    if not sources:
+        return
+
+    sources_dir = item_dir / "sources"
+    sources_dir.mkdir(parents=True, exist_ok=True)
+
+    for i, s in enumerate(sources, 1):
+        src_id = s.get("id") or f"SRC{i:03d}"
+        src_subdir = sources_dir / src_id
+        src_subdir.mkdir(parents=True, exist_ok=True)
+
+        url = s.get("url", "")
+        title = s.get("title") or url
+
+        lines = [f"# {src_id} — {title}", ""]
+        if url:
+            lines.append(f"URL: <{url}>")
+            lines.append("")
+
+        for field in ("reliability", "relevance"):
+            val = s.get(field, {})
+            if isinstance(val, dict):
+                rating = val.get("rating", "—")
+                rationale = val.get("rationale", "")
+                lines.append(f"**{field.capitalize()}**: {rating}")
+                if rationale:
+                    lines.append(f"- {rationale}")
+                lines.append("")
+
+        bias = s.get("bias_assessment", {})
+        if isinstance(bias, dict) and bias:
+            lines.extend(
+                ["## Bias Assessment", "", "| Domain | Rating | Rationale |", "|--------|--------|-----------|"]
+            )
+            for domain, d in bias.items():
+                if isinstance(d, dict):
+                    rating = d.get("rating", "—")
+                    rationale = (d.get("rationale") or "")[:150]
+                    lines.append(f"| {domain.replace('_', ' ').title()} | {rating} | {rationale} |")
+            lines.append("")
+
+        lines.append("[← Back to item overview](../../index.md)")
+        (src_subdir / "scorecard.md").write_text("\n".join(lines) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# Group-level writers
+# ---------------------------------------------------------------------------
+
+
+def _write_group_index(
+    output_dir: Path,
+    run_dirs: list[Path],
+    group_synthesis: dict[str, Any],  # noqa: ARG001
+) -> None:
+    """Write the run group index.md."""
+    lines = ["# Research Run Group", ""]
+    lines.append(f"Runs: {len(run_dirs)}")
+    lines.append("")
+
+    if run_dirs:
+        lines.extend(["## Runs", ""])
+        for rd in run_dirs:
+            lines.append(f"- [{rd.name}]({rd.name}/index.md)")
+        lines.append("")
+
+    lines.extend(["## Group-Level Reports", ""])
+    for filename, label in [
+        ("synthesis.md", "Cross-run synthesis"),
+        ("consistency.md", "Cross-run consistency metrics"),
+        ("reading-list.md", "Consolidated reading list"),
+    ]:
+        if (output_dir / filename).exists() or True:
+            lines.append(f"- [{label}]({filename})")
+    lines.append("")
+
+    (output_dir / "index.md").write_text("\n".join(lines) + "\n")
+
+
+def _write_group_synthesis(output_dir: Path, data: dict[str, Any]) -> None:
+    """Write group-level synthesis.md."""
+    lines = ["# Cross-Run Synthesis", ""]
+    lines.append(json.dumps(data, indent=2))
+    (output_dir / "synthesis.md").write_text("\n".join(lines) + "\n")
+
+
+def _write_group_consistency(output_dir: Path, data: dict[str, Any]) -> None:
+    """Write group-level consistency.md."""
+    lines = ["# Cross-Run Consistency Metrics", ""]
+    lines.append(json.dumps(data, indent=2))
+    (output_dir / "consistency.md").write_text("\n".join(lines) + "\n")
+
+
+def _write_group_reading_list(output_dir: Path, data: dict[str, Any]) -> None:
+    """Write group-level reading-list.md."""
+    lines = ["# Consolidated Reading List", ""]
+    lines.append(json.dumps(data, indent=2))
+    (output_dir / "reading-list.md").write_text("\n".join(lines) + "\n")

--- a/src/diogenes/schemas/self-audit.schema.json
+++ b/src/diogenes/schemas/self-audit.schema.json
@@ -80,13 +80,34 @@
     },
     "reading_list_entry": {
       "type": "object",
-      "required": ["url", "summary", "priority"],
+      "description": "Stands alone as a rich article reference — all metadata needed to cite and describe the source is denormalized onto the entry so downstream renderers do not need to join back against the source scorecards.",
+      "required": ["url", "title", "reason", "priority"],
       "properties": {
         "url": { "type": "string" },
-        "title": { "type": "string" },
-        "summary": {
+        "title": {
           "type": "string",
-          "description": "One-sentence summary of what this source contributes."
+          "description": "Title of the source, copied from the matching scorecard."
+        },
+        "authors": {
+          "type": "string",
+          "description": "Author line (names, institutions, or publisher as appropriate) copied from the scorecard."
+        },
+        "date": {
+          "type": "string",
+          "description": "Publication or last-updated date copied from the scorecard."
+        },
+        "content_summary": {
+          "type": "string",
+          "description": "Short neutral description of what the source says, copied from the scorecard."
+        },
+        "reason": {
+          "type": "string",
+          "description": "Why this entry is on the reading list — how it advances the research question. Distinct from content_summary, which is neutral about the reader's purpose."
+        },
+        "items": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "IDs of claims or queries this source speaks to."
         },
         "priority": {
           "type": "string",


### PR DESCRIPTION
## Summary

- Adds `dio render`: a pure-Python, zero-LLM-token JSON-to-markdown renderer that turns a Diogenes run directory into a linked set of generic GitHub-Flavored Markdown pages (CLI + MCP tool).
- Iterates to match the R0044 reference structure: run-level index with per-item cards and hypothesis status tables, per-item index with Summary / Results / Hypotheses / Searches / Sources / Evidence Snapshot sections, per-hypothesis / per-search / per-source detail pages.
- Universal table of contents on every rendered page (sentinel-wrapped for downstream stripping) with explicit HTML anchors for cross-renderer compatibility.
- Denormalizes reading-list entries so each entry stands alone as a complete article reference — title, authors, date, content summary, and a "why read" reason all travel on the entry itself. Self-auditor prompt now copies these fields verbatim from the matching scorecard; renderer reads them straight off the entry with no join logic.
- Drops the redundant intermediate `hypotheses/index.md`, `searches/index.md`, and `sources/index.md` pages — the item-level index already carries summary tables that link directly to detail files.

## Test plan

- [x] `dio render` run against a known JSON directory produces the expected structure (claims, queries, group-level reports, per-item artifacts).
- [x] Cross-renderer anchor compatibility verified via explicit `<a id="..."></a>` tags.
- [x] Reading-list entries render with title (linked), authors · date, content summary, and _Why read:_ reason — no scorecard lookup needed.
- [x] `ruff check`, `ruff format --check`, `mypy src/`, `pytest` all green.
- [ ] End-to-end: regenerate JSON from a fresh research run once the evidence-extraction work in #94 lands, re-render, verify no regressions.

Ref #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
