### PR TITLE
feat: add model identifier to run outputs (#109)

### DIFF
--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -312,6 +312,11 @@ class APIClient:
 
         self.usage = UsageAccumulator()
 
+    @property
+    def model(self) -> str:
+        """The model ID configured for this client."""
+        return self._model
+
     def _compose_system_prompt(
         self,
         agent_prompt: str,

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -236,7 +236,12 @@ def execute(input_file: str, output: str, runs: int) -> int:
         # find it when rendering a single run (not just via run-group).
         write_step_output(run_dir, "research-input.json", research_input)
 
-        event_logger = EventLogger(run_id=run_dir.name, output_dir=run_dir)
+        event_logger = EventLogger(
+            run_id=run_dir.name,
+            output_dir=run_dir,
+            model=client.model,
+            execution_path="cli",
+        )
 
         # Step 2: Generate competing hypotheses
         print("Step 2: Generating competing hypotheses...")
@@ -363,6 +368,11 @@ def execute(input_file: str, output: str, runs: int) -> int:
         # Step 11: Archive for temporal revisitation
         print("Step 11: Archiving...")
         all_outputs = {
+            "run_metadata": {
+                "model": client.model,
+                "execution_path": "cli",
+                "run_id": run_dir.name,
+            },
             "research_input": research_input,
             "hypotheses": hypotheses,
             "search_plans": search_plans,

--- a/src/diogenes/events.py
+++ b/src/diogenes/events.py
@@ -24,9 +24,17 @@ from typing import Any
 class EventLogger:
     """Append-only structured event log for a single research run."""
 
-    def __init__(self, run_id: str, output_dir: Path | None = None) -> None:  # noqa: D107
+    def __init__(  # noqa: D107
+        self,
+        run_id: str,
+        output_dir: Path | None = None,
+        model: str | None = None,
+        execution_path: str = "cli",
+    ) -> None:
         self.run_id = run_id
         self.output_dir = output_dir
+        self.model = model
+        self.execution_path = execution_path
         self._events: list[dict[str, Any]] = []
         self._coverage: dict[str, Any] = {}
 
@@ -86,11 +94,16 @@ class EventLogger:
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the full event log for JSON persistence."""
-        return {
+        result: dict[str, Any] = {
             "run_id": self.run_id,
+            "run_metadata": {
+                "model": self.model,
+                "execution_path": self.execution_path,
+            },
             "events": self._events,
             "summary": self.summary(),
         }
+        return result
 
     def write(self, path: Path | None = None) -> Path:
         """Write the event log to disk.

--- a/src/diogenes/schemas/pipeline-events.schema.json
+++ b/src/diogenes/schemas/pipeline-events.schema.json
@@ -10,6 +10,22 @@
       "type": "string",
       "description": "Run identifier (e.g., 'run-1')."
     },
+    "run_metadata": {
+      "type": "object",
+      "description": "Identifies the model and execution path that produced this run. Critical for longitudinal comparisons across model versions.",
+      "properties": {
+        "model": {
+          "type": ["string", "null"],
+          "description": "Model ID used for sub-agent calls (e.g., 'claude-sonnet-4-20250514'). Null if unknown (e.g., skill path before #110 state machine)."
+        },
+        "execution_path": {
+          "type": "string",
+          "enum": ["cli", "skill"],
+          "description": "Whether this run was produced by the Python CLI or the Claude Code skill."
+        }
+      },
+      "additionalProperties": false
+    },
     "events": {
       "type": "array",
       "items": { "$ref": "#/$defs/pipeline_event" }


### PR DESCRIPTION
## Summary

- Adds `run_metadata` block (model ID + execution path) to `pipeline-events.json` and `archive.json`
- `EventLogger` now accepts `model` and `execution_path` parameters
- `APIClient` exposes `.model` property for the configured model ID
- Schema updated: `pipeline-events.schema.json` includes `run_metadata` definition

This ensures every run's output self-documents which model produced it and via which path (CLI vs skill), enabling controlled longitudinal comparisons across model versions.

## Test plan

- [x] `st-validate-local-python` — clean
- [x] Local unit test: EventLogger serializes model metadata correctly
- [x] ruff + mypy + pytest all pass

## Example output

```json
{
  "run_id": "run-1",
  "run_metadata": {
    "model": "claude-sonnet-4-20250514",
    "execution_path": "cli"
  },
  "events": [...],
  "summary": {...}
}
```

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)
