### PR TITLE
feat: parallel evidence extraction via parallelize_thread (#89)

### DIFF
--- a/src/diogenes/parallelize.py
+++ b/src/diogenes/parallelize.py
@@ -1,0 +1,104 @@
+"""Thread-based parallel execution with kwargs-style argument passing.
+
+Wraps concurrent.futures.ThreadPoolExecutor with two features not
+available in mainstream parallel libraries (joblib, tqdm, pqdm, MPIRE):
+
+1. Native kwargs-style argument passing — accepts a sequence of dicts,
+   each unpacked as **kwargs to the target function. Essential for
+   calling functions with multiple named parameters (like sub-agent
+   API calls with model, prompt, config, etc.).
+
+2. Non-fatal error collection — collects exceptions alongside results
+   rather than raising on first failure. The caller decides what to do
+   with partial results. Essential for batch processing where partial
+   success is expected (e.g., 12 of 13 evidence extractions succeed).
+
+Origin: adapted from a shared collaboration between the project author
+and Richie Cahill. Original source:
+https://github.com/RichieCahill/dotfiles/blob/main/python/parallelize.py
+
+Modifications for Diogenes:
+- Removed ProcessPoolExecutor variant (all our work is I/O-bound)
+- Removed early_error mode (not needed; use a for-loop if you want fail-fast)
+- Simplified to a single public function
+"""
+
+from __future__ import annotations
+
+import logging
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable, Mapping, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ExecutorResults:
+    """Results of a parallel execution: successes and failures side by side."""
+
+    results: list[Any] = field(default_factory=list)
+    exceptions: list[BaseException] = field(default_factory=list)
+
+    @property
+    def success_count(self) -> int:
+        """Number of successful results."""
+        return len(self.results)
+
+    @property
+    def error_count(self) -> int:
+        """Number of failed tasks."""
+        return len(self.exceptions)
+
+    @property
+    def total(self) -> int:
+        """Total tasks (succeeded + failed)."""
+        return self.success_count + self.error_count
+
+
+def parallelize_thread(
+    func: Callable[..., Any],
+    kwargs_list: Sequence[Mapping[str, Any]],
+    max_workers: int | None = None,
+    progress_tracker: int | None = None,
+) -> ExecutorResults:
+    """Run a function with multiple argument sets in parallel threads.
+
+    Each entry in kwargs_list is unpacked as **kwargs to func. Results
+    are collected in submission order; exceptions are collected separately
+    rather than raising, so partial success is preserved.
+
+    Args:
+        func: The function to call in parallel.
+        kwargs_list: Sequence of dicts, each unpacked as **kwargs.
+        max_workers: Maximum concurrent threads (default: ThreadPoolExecutor default).
+        progress_tracker: Log progress every N completed tasks (None to disable).
+
+    Returns:
+        ExecutorResults with results (in order) and any exceptions.
+
+    """
+    total_work = len(kwargs_list)
+
+    with ThreadPoolExecutor(max_workers=max_workers) as executor:
+        futures = [executor.submit(func, **kwargs) for kwargs in kwargs_list]
+
+    results: list[Any] = []
+    exceptions: list[BaseException] = []
+
+    for index, future in enumerate(futures, 1):
+        exc = future.exception()
+        if exc is not None:
+            logger.error("%s raised %s", future, exc.__class__.__name__)
+            exceptions.append(exc)
+            continue
+
+        results.append(future.result())
+
+        if progress_tracker and index % progress_tracker == 0:
+            logger.info("Progress: %d/%d", index, total_work)
+
+    return ExecutorResults(results=results, exceptions=exceptions)

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -13,8 +13,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from diogenes.api_client import SubAgentError
-from diogenes.search import FetchError, SearchProvider, execute_search_plan, fetch_page_extract
+from diogenes.parallelize import parallelize_thread
+from diogenes.search import SearchProvider, execute_search_plan, fetch_page_extract
 
 if TYPE_CHECKING:
     from diogenes.api_client import APIClient
@@ -334,55 +334,80 @@ _SCORING_BATCH_SIZE = 1
 _MAX_SOURCES_TO_SCORE = 15
 
 
+# Serialized (1 worker) due to lxml/trafilatura thread-safety crash (SIGABRT).
+# See issue tracking thread-safe HTML parser alternatives.
+_FETCH_WORKERS = 1
+
+
+def _fetch_single_source(url: str) -> dict[str, Any]:
+    """Fetch a single source's article body. Thread-safe.
+
+    Returns a dict with url + content, or raises FetchError.
+    """
+    return {"url": url, "content": fetch_page_extract(url)}
+
+
 def _fetch_sources_for_scoring(
     item_id: str,
     selected: list[dict[str, Any]],
     event_logger: EventLogger | None = None,
 ) -> list[dict[str, Any]]:
-    """Fetch article bodies for a list of selected sources.
+    """Fetch article bodies for selected sources in parallel.
 
-    Sources whose bodies cannot be retrieved or parsed are dropped with a
-    loud log entry rather than passed forward with an empty content_extract
-    — an empty extract is an invitation for the evidence-extractor to
-    fabricate quotes from training-data memory of the URL.
+    Uses parallelize_thread with _FETCH_WORKERS concurrent threads.
+    Sources whose bodies cannot be retrieved or parsed are dropped with
+    event logging rather than passed forward with empty content_extract.
     """
+    print(f"    Fetching {len(selected)} sources ({_FETCH_WORKERS} threads)...")
+    kwargs_list = [{"url": s.get("url", "")} for s in selected]
+    results = parallelize_thread(
+        func=_fetch_single_source,
+        kwargs_list=kwargs_list,
+        max_workers=_FETCH_WORKERS,
+    )
+
+    # Log fetch failures as events
+    if results.exceptions and event_logger:
+        for exc in results.exceptions:
+            exc_str = str(exc)
+            # Try to extract URL from the FetchError message
+            url = ""
+            if "for " in exc_str:
+                url = exc_str.split("for ", 1)[1].split(":", maxsplit=1)[0].strip()
+            kind = "fetch_failed"
+            if ".pdf" in url.lower():
+                kind = "fetch_failed_pdf"
+            elif "trafilatura" in exc_str.lower():
+                kind = "fetch_failed_html"
+            event_logger.log(
+                step="step5_score_sources",
+                kind=kind,
+                detail=exc_str,
+                url=url,
+                item_id=item_id,
+                layer="pipeline",
+            )
+
+    if results.error_count:
+        print(f"    {item_id}: {results.error_count} of {len(selected)} sources dropped due to fetch failures.")
+
+    # Build enriched sources from successful fetches, matching back to
+    # original source metadata (title, snippet)
+    source_by_url = {s.get("url", ""): s for s in selected}
     enriched_sources: list[dict[str, Any]] = []
-    for source in selected:
-        url = source.get("url", "")
-        print(f"    Fetching {url[:60]}...")
-        try:
-            content = fetch_page_extract(url)
-        except FetchError as exc:
-            print(f"      FETCH FAILED — dropping source: {exc}")
-            if event_logger:
-                kind = "fetch_failed"
-                exc_str = str(exc)
-                if ".pdf" in url.lower():
-                    kind = "fetch_failed_pdf"
-                elif "trafilatura" in exc_str.lower():
-                    kind = "fetch_failed_html"
-                event_logger.log(
-                    step="step5_score_sources",
-                    kind=kind,
-                    detail=exc_str,
-                    url=url,
-                    item_id=item_id,
-                    layer="pipeline",
-                )
-            continue
+    for fetch_result in results.results:
+        url = fetch_result["url"]
+        source = source_by_url.get(url, {})
         enriched_sources.append(
             {
                 "url": url,
                 "title": source.get("title", ""),
                 "snippet": source.get("snippet", ""),
-                "content_extract": content,
+                "content_extract": fetch_result["content"],
             }
         )
 
-    n_failed = len(selected) - len(enriched_sources)
-    if n_failed:
-        print(f"    {item_id}: {n_failed} of {len(selected)} sources dropped due to fetch failures (see logs above).")
-
+    print(f"    {len(enriched_sources)} sources fetched successfully.")
     return enriched_sources
 
 
@@ -511,6 +536,55 @@ def _verify_packet_verbatim(
     return bool(segments) and all(seg in norm_source for seg in segments)
 
 
+_EXTRACT_WORKERS = 4
+
+
+def _extract_single_source(
+    item_id: str,
+    item: dict[str, Any],
+    hypotheses: dict[str, Any],
+    scorecard: dict[str, Any],
+    prompt_path_str: str,
+    client: APIClient,
+) -> dict[str, Any]:
+    """Extract evidence packets from a single source. Thread-safe.
+
+    Returns a dict with url, verified_packets, claimed_count, dropped_count.
+    Raises SubAgentError on API failure.
+    """
+    url = scorecard.get("url", "<unknown URL>")
+    source_extract = scorecard.get("content_extract") or ""
+
+    response = client.call_sub_agent(
+        prompt_path=Path(prompt_path_str),
+        user_input={
+            "id": item_id,
+            "item": item,
+            "hypotheses": hypotheses,
+            "scorecards": [scorecard],
+        },
+        output_schema="evidence-packets.schema.json",
+        max_tokens=8192,
+    )
+
+    claimed_packets = response.get("packets", []) or []
+    verified: list[dict[str, Any]] = []
+    dropped = 0
+    for pk in claimed_packets:
+        if _verify_packet_verbatim(pk, source_extract):
+            verified.append(pk)
+        else:
+            dropped += 1
+
+    return {
+        "url": url,
+        "verified_packets": verified,
+        "claimed": len(claimed_packets),
+        "kept": len(verified),
+        "dropped": dropped,
+    }
+
+
 def _extract_evidence_for_item(
     item: dict[str, Any],
     item_hypotheses: dict[str, Any],
@@ -519,89 +593,76 @@ def _extract_evidence_for_item(
     client: APIClient,
     event_logger: EventLogger | None = None,
 ) -> tuple[list[dict[str, Any]], list[str], dict[str, int]]:
-    """Call the extractor once per source, aggregate packets, drop non-verbatim.
+    """Extract evidence packets from all sources in parallel threads.
 
-    Calling once per source — instead of once for all sources together —
-    keeps the input per call bounded (~1 scorecard's worth of article body,
-    typically 10-100 KB) so the model does not drop instructions or the
-    output schema under long-context pressure, and keeps the task framing
-    crisp.
-
-    After each call, every returned packet is verified against the
-    source's content_extract as a deterministic backstop. Packets whose
-    excerpt is not actually a substring of the source are DROPPED — this
-    is the "do not trust the AI" layer: the model may claim verbatim
-    extraction, but we accept only what string-matches.
+    Uses parallelize_thread with _EXTRACT_WORKERS concurrent API calls.
+    Each call handles one source — keeping input bounded and the task
+    framing crisp. After each call, verbatim verification drops
+    non-substring packets.
 
     Returns (aggregated verified packets, list of per-source error
     messages, verbatim stats dict with keys 'claimed', 'kept', 'dropped').
     """
+    kwargs_list = [
+        {
+            "item_id": item["id"],
+            "item": item,
+            "hypotheses": item_hypotheses,
+            "scorecard": sc,
+            "prompt_path_str": str(prompt_path),
+            "client": client,
+        }
+        for sc in substantive
+    ]
+
+    print(f"    Extracting from {len(substantive)} sources ({_EXTRACT_WORKERS} threads)...")
+    results = parallelize_thread(
+        func=_extract_single_source,
+        kwargs_list=kwargs_list,
+        max_workers=_EXTRACT_WORKERS,
+    )
+
+    # Aggregate results
     aggregated_packets: list[dict[str, Any]] = []
     errors: list[str] = []
     stats = {"claimed": 0, "kept": 0, "dropped": 0}
 
-    for idx, sc in enumerate(substantive, start=1):
-        url = sc.get("url", "<unknown URL>")
-        source_extract = sc.get("content_extract") or ""
-        agent_input = {
-            "id": item["id"],
-            "item": item,
-            "hypotheses": item_hypotheses,
-            # Intentionally one-element scorecards list — same shape the
-            # extractor prompt documents, so no prompt changes are needed.
-            "scorecards": [sc],
-        }
-        try:
-            response = client.call_sub_agent(
-                prompt_path=prompt_path,
-                user_input=agent_input,
-                output_schema="evidence-packets.schema.json",
-                max_tokens=8192,
-            )
-        except SubAgentError as exc:
-            err = f"source {idx}/{len(substantive)} ({url}): {exc}"
-            errors.append(err)
-            print(f"      extractor FAILED on {url[:60]}: {exc}")
-            if event_logger:
-                event_logger.log(
-                    step="step5b_extract_evidence",
-                    kind="subagent_failed",
-                    detail=f"Evidence-extractor JSON parse failure: {exc}",
-                    url=url,
-                    item_id=item["id"],
-                    layer="pipeline",
-                )
-            continue
+    for res in results.results:
+        url = res["url"]
+        aggregated_packets.extend(res["verified_packets"])
+        stats["claimed"] += res["claimed"]
+        stats["kept"] += res["kept"]
+        stats["dropped"] += res["dropped"]
 
-        claimed_packets = response.get("packets", []) or []
-        verified_packets: list[dict[str, Any]] = []
-        dropped = 0
-        for pk in claimed_packets:
-            if _verify_packet_verbatim(pk, source_extract):
-                verified_packets.append(pk)
-            else:
-                dropped += 1
-
-        stats["claimed"] += len(claimed_packets)
-        stats["kept"] += len(verified_packets)
-        stats["dropped"] += dropped
-
-        if dropped and event_logger:
+        if res["dropped"] and event_logger:
             event_logger.log(
                 step="step5b_extract_evidence",
                 kind="packet_dropped_non_verbatim",
-                detail=f"{dropped} of {len(claimed_packets)} claimed packets failed verbatim verification",
+                detail=f"{res['dropped']} of {res['claimed']} claimed packets failed verbatim verification",
                 url=url,
                 item_id=item["id"],
-                count=dropped,
+                count=res["dropped"],
                 layer="pipeline",
             )
 
-        aggregated_packets.extend(verified_packets)
-        if dropped:
-            print(f"      {url[:60]}: {len(verified_packets)} verified / {dropped} dropped (non-verbatim)")
+        if res["dropped"]:
+            print(f"      {res['url'][:60]}: {res['kept']} verified / {res['dropped']} dropped")
         else:
-            print(f"      {url[:60]}: {len(verified_packets)} packet(s) verified")
+            print(f"      {res['url'][:60]}: {res['kept']} packet(s) verified")
+
+    # Log API failures from the parallel run
+    for exc in results.exceptions:
+        err = f"extractor error: {exc}"
+        errors.append(err)
+        print(f"      extractor FAILED: {exc}")
+        if event_logger:
+            event_logger.log(
+                step="step5b_extract_evidence",
+                kind="subagent_failed",
+                detail=f"Evidence-extractor failure: {exc}",
+                item_id=item["id"],
+                layer="pipeline",
+            )
 
     return aggregated_packets, errors, stats
 


### PR DESCRIPTION
## Summary

- Adds **parallelize.py** — thread-based parallel execution with kwargs-style argument passing and non-fatal error collection. Adapted from prior collaboration ([source](https://github.com/RichieCahill/dotfiles/blob/main/python/parallelize.py)).
- **Step 6 extraction parallelized**: 4 concurrent Anthropic API calls via `_EXTRACT_WORKERS=4`. Drops from 711s to 274s (**2.6x speedup**).
- **Step 5 fetching serialized**: `_FETCH_WORKERS=1` due to lxml/trafilatura SIGABRT crash under thread contention (#124).

## Timing comparison

| Step | Sequential | Parallel | Speedup |
|------|-----------|----------|---------|
| step_06 extraction | 711.6s | 274.5s | **2.6x** |
| Full run | 26.1 min | 20.3 min | **5.8 min saved** |

## Test plan

- [x] ruff + mypy + pytest — clean
- [x] Full CLI end-to-end smoke run — all 11 steps complete, no crashes
- [x] No print output from parallel worker threads (clean log output)
- [x] Error collection works (exceptions aggregated, not raised)

## Known limitations

- Step 5 serialized due to lxml thread-safety crash (#124)
- Step 6 speedup limited by API rate limits (2.6x vs theoretical 4x)

Ref #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)