### PR TITLE
feat: record PID in pipeline-state.json for crash correlation (#123)

### DIFF
--- a/src/diogenes/state_machine.py
+++ b/src/diogenes/state_machine.py
@@ -20,6 +20,7 @@ provides explicit step-completion tracking with timestamps and diagnostics.
 from __future__ import annotations
 
 import json
+import os
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path  # noqa: TC003 — needed at runtime for file operations
@@ -260,11 +261,17 @@ class PipelineState:
                 elapsed = round((now - created).total_seconds(), 1)
             except ValueError:
                 pass
+        # Capture the PID of the process that wrote this state snapshot.
+        # If the process crashes, the macOS crash report's PID can be
+        # matched against this field to identify exactly which run died.
+        # Captured on every save (not just init) so the value always
+        # reflects the process currently driving the pipeline.
         data = {
             "created_at": self._created_at,
             "updated_at": now_str,
             "completed_at": now_str if self.all_complete() else None,
             "elapsed_seconds": elapsed,
+            "pid": os.getpid(),
             "steps": [
                 {
                     "name": s.name,

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -185,6 +185,22 @@ class TestPipelineState:
         assert data["elapsed_seconds"] is not None
         assert data["elapsed_seconds"] >= 0
 
+    def test_pid_captured_on_save(self, tmp_path: pytest.TempPathFactory) -> None:
+        """pipeline-state.json includes the PID of the writing process.
+
+        Used to correlate OS-level crash reports (e.g., macOS SIGABRT)
+        with a specific research run. Captured on every save so the value
+        always reflects the currently-executing process.
+        """
+        import os
+
+        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir.mkdir()
+        state = PipelineState(run_dir)
+        state.mark_complete("step_01_research_input_clarified")
+        data = json.loads((run_dir / "pipeline-state.json").read_text())
+        assert data["pid"] == os.getpid()
+
     def test_completed_at_set_when_all_done(self, tmp_path: pytest.TempPathFactory) -> None:
         run_dir = tmp_path / "run-1"  # type: ignore[operator]
         run_dir.mkdir()


### PR DESCRIPTION
## Summary

Closes #123.

When the Python process crashes (SIGABRT from lxml/trafilatura, segfault, OOM kill, etc.), macOS crash reports contain only a PID — no pointer to the research run that died. Previously, matching a crash to a specific run required manual timestamp correlation across system logs and run directories.

This adds a `pid` field to `pipeline-state.json` alongside `created_at` and `updated_at`. Captured via `os.getpid()` on every state save, not just init, so the value always reflects the currently-executing process.

## Behavior

- **Mid-run crash**: last persisted state carries the PID of the crashed process — direct correlation with the crash report.
- **Resumed run**: subsequent saves overwrite with the new PID — correct, since that new process is the one whose crash now matters.

## Diff

```
src/diogenes/state_machine.py: +7 lines (import os, save pid on every _save())
tests/test_state_machine.py:   +16 lines (new test_pid_captured_on_save)
```

## Test plan
- [x] 462 tests pass, 100% line + branch coverage maintained
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run mypy src/` passes

Ref #123
Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)