### PR TITLE
feat: replace prompt-snapshot.md with version metadata in pipeline-state.json (#127)

### DIFF
--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -318,12 +318,11 @@ def _run_pipeline(parent_dir: Path, input_path: Path) -> int:
     clarified_path = write_step_output(instance_dir, "research-input-clarified.json", research_input)
     print(f"  Wrote: {clarified_path}")
 
-    # Save methodology snapshot (common guidelines from the package)
-    guidelines_src = _PACKAGE_DIR / "prompts" / "common-guidelines.md"
-    if guidelines_src.exists():
-        snapshot_dest = instance_dir / "prompt-snapshot.md"
-        snapshot_dest.write_text(guidelines_src.read_text())
-        print("  Saved: prompt-snapshot.md")
+    # Methodology provenance now lives in pipeline-state.json's 'version'
+    # block (package_version + git commit/branch/dirty). The previous
+    # prompt-snapshot.md copy of common-guidelines.md is redundant — the
+    # prompts are in the git repo, and the version stamp identifies which
+    # revision produced this run.
 
     # --- Pipeline execution (state-machine-driven) ---
     print()

--- a/src/diogenes/state_machine.py
+++ b/src/diogenes/state_machine.py
@@ -21,10 +21,67 @@ from __future__ import annotations
 
 import json
 import os
+import subprocess
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
-from pathlib import Path  # noqa: TC003 — needed at runtime for file operations
+from pathlib import Path
 from typing import Any
+
+import diogenes
+
+# Resolve against the package directory so git queries run inside the
+# Diogenes source tree, not wherever the pipeline happens to be writing.
+_PACKAGE_DIR = Path(__file__).parent
+
+
+def _git_metadata() -> dict[str, Any] | None:
+    """Collect git commit/branch/dirty for the Diogenes source tree.
+
+    Returns None when the package is installed from a wheel or the git
+    CLI is otherwise unavailable — version metadata gracefully degrades
+    to just the package_version in that case.
+    """
+    # S603/S607: we deliberately invoke git by name (not an absolute path)
+    # so it resolves from PATH — the standard way of calling git across
+    # macOS/Linux/CI images. Arguments are constant, no user input.
+    try:
+        commit = subprocess.check_output(
+            ["git", "rev-parse", "HEAD"],  # noqa: S607
+            cwd=_PACKAGE_DIR,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        branch = subprocess.check_output(
+            ["git", "rev-parse", "--abbrev-ref", "HEAD"],  # noqa: S607
+            cwd=_PACKAGE_DIR,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        dirty_output = subprocess.check_output(
+            ["git", "status", "--porcelain"],  # noqa: S607
+            cwd=_PACKAGE_DIR,
+            stderr=subprocess.DEVNULL,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    return {"commit": commit, "branch": branch, "dirty": bool(dirty_output.strip())}
+
+
+def _compute_version() -> dict[str, Any]:
+    """Version stamp for a run — the code that produced the outputs.
+
+    Always includes ``package_version``. Adds ``git_commit``,
+    ``git_branch``, and ``git_dirty`` when available (i.e., running
+    from a source checkout).
+    """
+    meta: dict[str, Any] = {"package_version": diogenes.__version__}
+    git = _git_metadata()
+    if git is not None:
+        meta["git_commit"] = git["commit"]
+        meta["git_branch"] = git["branch"]
+        meta["git_dirty"] = git["dirty"]
+    return meta
 
 
 @dataclass
@@ -236,15 +293,22 @@ class PipelineState:
         self._state_file = run_dir / "pipeline-state.json"
         self._completed: dict[str, StepStatus] = {}
         self._created_at: str | None = None
+        # Version is captured at run *start* — it identifies which code
+        # produced the outputs. On reload (resume), we preserve the
+        # original version rather than overwrite, so the field always
+        # points back to the source commit that kicked the run off.
+        self._version: dict[str, Any] | None = None
         if self._state_file.exists():
             self._load()
         else:
             self._created_at = datetime.now(tz=UTC).strftime("%Y-%m-%dT%H:%M:%SZ")
+            self._version = _compute_version()
 
     def _load(self) -> None:
         """Load state from disk."""
         data = json.loads(self._state_file.read_text())
         self._created_at = data.get("created_at")
+        self._version = data.get("version")
         for entry in data.get("steps", []):
             self._completed[entry["name"]] = StepStatus(**entry)
 
@@ -272,6 +336,7 @@ class PipelineState:
             "completed_at": now_str if self.all_complete() else None,
             "elapsed_seconds": elapsed,
             "pid": os.getpid(),
+            "version": self._version,
             "steps": [
                 {
                     "name": s.name,

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -566,16 +566,18 @@ class TestExecute:
     @patch("diogenes.commands.run._parse_and_clarify")
     @patch("diogenes.commands.run._create_search_provider")
     @patch("diogenes.commands.run.APIClient")
-    def test_pipeline_no_guidelines_file(
+    def test_pipeline_does_not_write_prompt_snapshot(
         self,
         mock_api_cls: MagicMock,
         mock_sp: MagicMock,
         mock_parse: MagicMock,
         mock_dispatch: MagicMock,
         tmp_path: pytest.TempPathFactory,
-        monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """Guidelines file missing → skip snapshot write."""
+        """Regression guard: prompt-snapshot.md is never written.
+
+        Replaced by the version block in pipeline-state.json (#127).
+        """
         mock_client = MagicMock(model="m")
         mock_client.usage.to_dict.return_value = self._usage_stub()
         mock_api_cls.return_value = mock_client
@@ -588,10 +590,6 @@ class TestExecute:
             return {"result": "ok"}
 
         mock_dispatch.side_effect = dispatch_side_effect
-
-        empty_pkg_dir = tmp_path / "empty_pkg"  # type: ignore[operator]
-        empty_pkg_dir.mkdir()
-        monkeypatch.setattr("diogenes.commands.run._PACKAGE_DIR", empty_pkg_dir)
 
         input_path = self._make_input_file(tmp_path)  # type: ignore[arg-type]
         output_dir = tmp_path / "output"  # type: ignore[operator]

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -1,10 +1,18 @@
 """Tests for state_machine module."""
 
 import json
+import subprocess
 
 import pytest
 
-from diogenes.state_machine import PIPELINE_STEPS, PipelineState, StepDefinition, StepStatus
+from diogenes.state_machine import (
+    PIPELINE_STEPS,
+    PipelineState,
+    StepDefinition,
+    StepStatus,
+    _compute_version,
+    _git_metadata,
+)
 
 
 class TestStepDefinition:
@@ -316,3 +324,94 @@ class TestPipelineState:
         step = data["steps"][0]
         assert step["status"] == "failed"
         assert step["elapsed_seconds"] is None
+
+
+class TestGitMetadata:
+    """Tests for _git_metadata helper."""
+
+    def test_returns_dict_in_git_checkout(self) -> None:
+        """Return real commit/branch/dirty when run inside the source checkout."""
+        meta = _git_metadata()
+        assert meta is not None
+        assert isinstance(meta["commit"], str)
+        # Commit is 40-char SHA
+        assert len(meta["commit"]) == 40
+        assert isinstance(meta["branch"], str)
+        assert isinstance(meta["dirty"], bool)
+
+    def test_returns_none_when_git_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If the git CLI is missing (e.g., installed from a wheel), fall back cleanly."""
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise FileNotFoundError
+
+        monkeypatch.setattr("diogenes.state_machine.subprocess.check_output", boom)
+        assert _git_metadata() is None
+
+    def test_returns_none_when_git_exits_nonzero(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """If git returns non-zero (e.g., run outside a repo), fall back cleanly."""
+
+        def boom(*_args: object, **_kwargs: object) -> None:
+            raise subprocess.CalledProcessError(128, "git")
+
+        monkeypatch.setattr("diogenes.state_machine.subprocess.check_output", boom)
+        assert _git_metadata() is None
+
+
+class TestComputeVersion:
+    """Tests for _compute_version."""
+
+    def test_always_includes_package_version(self) -> None:
+        version = _compute_version()
+        assert "package_version" in version
+
+    def test_includes_git_fields_when_available(self) -> None:
+        version = _compute_version()
+        # When run in the source checkout (normal test environment), git fields
+        # are present
+        assert "git_commit" in version
+        assert "git_branch" in version
+        assert "git_dirty" in version
+
+    def test_omits_git_fields_when_unavailable(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("diogenes.state_machine._git_metadata", lambda: None)
+        version = _compute_version()
+        assert set(version.keys()) == {"package_version"}
+
+
+class TestVersionInPipelineState:
+    """Version metadata persisted in pipeline-state.json."""
+
+    def test_version_written_on_fresh_state(self, tmp_path: pytest.TempPathFactory) -> None:
+        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir.mkdir()
+        state = PipelineState(run_dir)
+        state.mark_complete("step_01_research_input_clarified")
+        data = json.loads((run_dir / "pipeline-state.json").read_text())
+        assert "version" in data
+        assert "package_version" in data["version"]
+
+    def test_version_preserved_across_reload(self, tmp_path: pytest.TempPathFactory) -> None:
+        """Resuming a run keeps the version from when the run was created.
+
+        The version stamp identifies which code produced the outputs, not
+        which process most recently touched the state. Preserving it on
+        reload means resuming on a different commit doesn't overwrite the
+        provenance trail.
+        """
+        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir.mkdir()
+        # Pre-populate with a specific version block that differs from
+        # whatever _compute_version would produce here
+        preload = {
+            "created_at": "2026-01-01T00:00:00Z",
+            "version": {"package_version": "0.0.1-pinned", "git_commit": "abc123"},
+            "steps": [],
+        }
+        (run_dir / "pipeline-state.json").write_text(json.dumps(preload))
+
+        state = PipelineState(run_dir)
+        state.mark_complete("step_01_research_input_clarified")
+        data = json.loads((run_dir / "pipeline-state.json").read_text())
+        assert data["version"]["package_version"] == "0.0.1-pinned"
+        assert data["version"]["git_commit"] == "abc123"


### PR DESCRIPTION
## Summary

Closes #127.

The per-run `prompt-snapshot.md` was a 40KB copy of `common-guidelines.md` written to every run's output directory. It was a leftover from early development when the skill path needed to record what prompts were in effect. With the state machine (#110) and CLI orchestration, the prompts live in the git repo — what matters is **which revision** of the code produced the run, not a prose copy of its content.

## Changes

1. Add `version` block to `pipeline-state.json`, captured on fresh state and preserved across reload/resume:

```json
"version": {
  "package_version": "0.1.0",
  "git_commit": "a1b2c3d…",
  "git_branch": "develop",
  "git_dirty": false
}
```

2. When the git CLI isn't available (installed from a wheel, etc.), fall back gracefully to just `package_version`.
3. Stop writing `prompt-snapshot.md` in `commands/run.py`. The code comment now explains what replaced it.

## Semantics

Version is captured **once at run start**, not on every save. It identifies which code *produced* the outputs. If a run is resumed on a different commit, the version on disk is preserved — the run belongs to its original commit, and the provenance trail stays intact.

Contrast with `pid` (from #123): *that's* "which process most recently touched this state" and gets rewritten on every save. Different questions, different semantics, both useful.

## Tests

- `_git_metadata`: happy path (real git repo), `FileNotFoundError` fallback, `CalledProcessError` fallback
- `_compute_version`: always includes `package_version`; includes `git_*` when available; omits them when `_git_metadata` returns None
- `PipelineState`: version written on fresh state, preserved across reload
- Regression guard: `prompt-snapshot.md` is never written

## Test plan
- [x] 470 tests pass, 100% line + branch coverage maintained
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run mypy src/` passes

Ref #127
Closes #127

🤖 Generated with [Claude Code](https://claude.com/claude-code)