### PR TITLE
feat: exponential-backoff retry for transient API and network failures (#77)

### DIFF
--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -11,6 +11,7 @@ import anthropic
 import jsonschema
 
 from diogenes.config import DEFAULT_MODEL, ConfigError, DioConfig, load_config
+from diogenes.retry import is_retriable_anthropic, retry_with_backoff
 
 
 @dataclass
@@ -458,7 +459,10 @@ class APIClient:
             ]
 
         try:
-            response = self._client.messages.create(**api_kwargs)
+            response = retry_with_backoff(
+                lambda: self._client.messages.create(**api_kwargs),
+                is_retriable=is_retriable_anthropic,
+            )
         except anthropic.APIError as e:
             msg = f"API call failed: {e}"
             raise SubAgentError(prompt_file.stem, msg) from e

--- a/src/diogenes/retry.py
+++ b/src/diogenes/retry.py
@@ -1,0 +1,99 @@
+"""Exponential-backoff retry for transient API and network failures.
+
+Retriable failures are those where the correct response is 'wait and try
+again': model-overload responses (Anthropic 529), rate limiting (429),
+5xx gateway errors, and transport-level timeouts or connection errors.
+Non-retriable failures — 4xx authentication/authorization/bad-request
+errors, JSON validation failures, missing resources — are raised
+immediately because retrying them would just burn tokens on the same
+broken call.
+
+Callers supply a domain-specific ``is_retriable`` predicate so the core
+loop stays agnostic to which library's exceptions it's handling.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import time
+from typing import TYPE_CHECKING
+
+import anthropic
+import requests
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+logger = logging.getLogger(__name__)
+
+_MAX_ATTEMPTS = 3
+_BASE_DELAY_SECONDS = 1.0
+_MAX_DELAY_SECONDS = 30.0
+_JITTER_FRACTION = 0.1
+
+
+def retry_with_backoff[T](
+    call: Callable[[], T],
+    *,
+    is_retriable: Callable[[BaseException], bool],
+    max_attempts: int = _MAX_ATTEMPTS,
+    base_delay: float = _BASE_DELAY_SECONDS,
+    max_delay: float = _MAX_DELAY_SECONDS,
+) -> T:
+    """Execute ``call``, retrying on transient failures.
+
+    Retries are bounded by ``max_attempts`` (total attempts, including the
+    first). Delay doubles on each failure — 1s, 2s, 4s, … — capped at
+    ``max_delay``, with up to 10% jitter added to avoid thundering-herd
+    lockstep with other callers hitting the same overloaded backend.
+
+    The ``is_retriable`` predicate is consulted for every raised
+    exception. Non-retriable exceptions propagate immediately on the
+    first hit; retriable ones propagate only after ``max_attempts``
+    have been exhausted.
+    """
+    for attempt in range(1, max_attempts + 1):
+        try:
+            return call()
+        except BaseException as exc:
+            if attempt == max_attempts or not is_retriable(exc):
+                raise
+            delay = min(base_delay * (2 ** (attempt - 1)), max_delay)
+            jitter = random.uniform(0, delay * _JITTER_FRACTION)  # noqa: S311
+            logger.warning(
+                "retry %d/%d after %.2fs: %s",
+                attempt,
+                max_attempts,
+                delay + jitter,
+                exc,
+            )
+            time.sleep(delay + jitter)
+    # Unreachable: the loop either returns (success path) or raises
+    # (either a non-retriable exception immediately, or the last
+    # retriable exception on the final attempt). This line exists
+    # only so the type checker can conclude the function always returns
+    # or raises, and is excluded from coverage accordingly.
+    msg = "retry_with_backoff exhausted without returning or raising"  # pragma: no cover
+    raise RuntimeError(msg)  # pragma: no cover
+
+
+_RETRIABLE_HTTP_STATUS = {429, 502, 503, 504, 529}
+
+
+def is_retriable_anthropic(exc: BaseException) -> bool:
+    """Return True if an anthropic SDK exception is a transient failure."""
+    if isinstance(exc, (anthropic.APIConnectionError, anthropic.APITimeoutError)):
+        return True
+    if isinstance(exc, anthropic.APIStatusError):
+        return exc.status_code in _RETRIABLE_HTTP_STATUS
+    return False
+
+
+def is_retriable_http(exc: BaseException) -> bool:
+    """Return True if a requests-library exception is a transient failure."""
+    if isinstance(exc, (requests.Timeout, requests.ConnectionError)):
+        return True
+    if isinstance(exc, requests.HTTPError) and exc.response is not None:
+        return exc.response.status_code in _RETRIABLE_HTTP_STATUS
+    return False

--- a/src/diogenes/search.py
+++ b/src/diogenes/search.py
@@ -16,6 +16,8 @@ import pypdf
 import requests
 import trafilatura
 
+from diogenes.retry import is_retriable_http, retry_with_backoff
+
 
 @dataclass
 class SearchResult:
@@ -177,13 +179,18 @@ def fetch_page_extract(url: str) -> str:
             scanned image PDF, encrypted PDF, etc.).
 
     """
-    try:
+
+    def fetch() -> requests.Response:
         resp = requests.get(
             url,
             timeout=_FETCH_TIMEOUT,
             headers={"User-Agent": "Diogenes/0.1 (research-methodology)"},
         )
         resp.raise_for_status()
+        return resp
+
+    try:
+        resp = retry_with_backoff(fetch, is_retriable=is_retriable_http)
     except requests.RequestException as exc:
         msg = f"Fetch failed for {url}: {exc}"
         raise FetchError(msg) from exc

--- a/src/diogenes/search_providers.py
+++ b/src/diogenes/search_providers.py
@@ -6,6 +6,7 @@ from typing import Any
 
 import requests
 
+from diogenes.retry import is_retriable_http, retry_with_backoff
 from diogenes.search import SearchResult
 
 _DEFAULT_TIMEOUT = 10
@@ -40,13 +41,17 @@ class SerperSearchProvider:
             "num": max_results,
         }
 
-        resp = requests.post(
-            self.API_URL,
-            headers=headers,
-            json=payload,
-            timeout=_DEFAULT_TIMEOUT,
-        )
-        resp.raise_for_status()
+        def fetch() -> requests.Response:
+            resp = requests.post(
+                self.API_URL,
+                headers=headers,
+                json=payload,
+                timeout=_DEFAULT_TIMEOUT,
+            )
+            resp.raise_for_status()
+            return resp
+
+        resp = retry_with_backoff(fetch, is_retriable=is_retriable_http)
         data = resp.json()
 
         organic = data.get("organic", [])
@@ -96,13 +101,17 @@ class BraveSearchProvider:
             "count": max_results,
         }
 
-        resp = requests.get(
-            self.API_URL,
-            headers=headers,
-            params=params,
-            timeout=_DEFAULT_TIMEOUT,
-        )
-        resp.raise_for_status()
+        def fetch() -> requests.Response:
+            resp = requests.get(
+                self.API_URL,
+                headers=headers,
+                params=params,
+                timeout=_DEFAULT_TIMEOUT,
+            )
+            resp.raise_for_status()
+            return resp
+
+        resp = retry_with_backoff(fetch, is_retriable=is_retriable_http)
         data = resp.json()
 
         web_results = data.get("web", {}).get("results", [])
@@ -150,8 +159,12 @@ class GoogleSearchProvider:
             "num": min(max_results, 10),
         }
 
-        resp = requests.get(self.API_URL, params=params, timeout=_DEFAULT_TIMEOUT)
-        resp.raise_for_status()
+        def fetch() -> requests.Response:
+            resp = requests.get(self.API_URL, params=params, timeout=_DEFAULT_TIMEOUT)
+            resp.raise_for_status()
+            return resp
+
+        resp = retry_with_backoff(fetch, is_retriable=is_retriable_http)
         data = resp.json()
 
         items = data.get("items", [])

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -1,0 +1,138 @@
+"""Tests for retry module."""
+
+from unittest.mock import MagicMock
+
+import anthropic
+import pytest
+import requests
+
+from diogenes.retry import (
+    is_retriable_anthropic,
+    is_retriable_http,
+    retry_with_backoff,
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep retry tests fast — suppress real sleeps and jitter randomness."""
+    monkeypatch.setattr("diogenes.retry.time.sleep", lambda _s: None)
+    monkeypatch.setattr("diogenes.retry.random.uniform", lambda _a, _b: 0.0)
+
+
+class _TransientError(Exception):
+    """Stand-in retriable exception for retry-loop tests."""
+
+
+class _FatalError(Exception):
+    """Stand-in non-retriable exception for retry-loop tests."""
+
+
+def _is_transient(exc: BaseException) -> bool:
+    return isinstance(exc, _TransientError)
+
+
+class TestRetryWithBackoff:
+    """Tests for the retry loop itself."""
+
+    def test_success_first_attempt(self) -> None:
+        call = MagicMock(return_value="ok")
+        result = retry_with_backoff(call, is_retriable=_is_transient)
+        assert result == "ok"
+        assert call.call_count == 1
+
+    def test_retries_then_succeeds(self) -> None:
+        call = MagicMock(side_effect=[_TransientError(), _TransientError(), "ok"])
+        result = retry_with_backoff(call, is_retriable=_is_transient, max_attempts=3)
+        assert result == "ok"
+        assert call.call_count == 3
+
+    def test_exhausts_retries_and_raises(self) -> None:
+        call = MagicMock(side_effect=_TransientError("third"))
+        with pytest.raises(_TransientError, match="third"):
+            retry_with_backoff(call, is_retriable=_is_transient, max_attempts=3)
+        assert call.call_count == 3
+
+    def test_non_retriable_raises_immediately(self) -> None:
+        call = MagicMock(side_effect=[_FatalError("nope")])
+        with pytest.raises(_FatalError, match="nope"):
+            retry_with_backoff(call, is_retriable=_is_transient, max_attempts=3)
+        # Only the first attempt ran — we don't retry non-retriable errors
+        assert call.call_count == 1
+
+    def test_delay_is_capped(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Delay doubles on each failure but is clamped to max_delay."""
+        sleeps: list[float] = []
+        monkeypatch.setattr("diogenes.retry.time.sleep", sleeps.append)
+
+        call = MagicMock(side_effect=[_TransientError(), _TransientError(), "ok"])
+        retry_with_backoff(
+            call,
+            is_retriable=_is_transient,
+            max_attempts=3,
+            base_delay=10.0,
+            max_delay=15.0,
+        )
+        # First retry: 10s. Second retry: min(20s, cap 15s) = 15s.
+        assert sleeps == [10.0, 15.0]
+
+
+class TestIsRetriableAnthropic:
+    """Exception classifier for the anthropic SDK."""
+
+    def test_connection_error(self) -> None:
+        exc = anthropic.APIConnectionError(request=MagicMock())
+        assert is_retriable_anthropic(exc) is True
+
+    def test_timeout(self) -> None:
+        exc = anthropic.APITimeoutError(request=MagicMock())
+        assert is_retriable_anthropic(exc) is True
+
+    @pytest.mark.parametrize("status", [429, 502, 503, 504, 529])
+    def test_retriable_status_codes(self, status: int) -> None:
+        exc = MagicMock(spec=anthropic.APIStatusError)
+        exc.status_code = status
+        assert is_retriable_anthropic(exc) is True
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 418, 500])
+    def test_non_retriable_status_codes(self, status: int) -> None:
+        exc = MagicMock(spec=anthropic.APIStatusError)
+        exc.status_code = status
+        assert is_retriable_anthropic(exc) is False
+
+    def test_unrelated_exception(self) -> None:
+        assert is_retriable_anthropic(ValueError("nope")) is False
+
+
+class TestIsRetriableHttp:
+    """Exception classifier for the requests library."""
+
+    def test_timeout(self) -> None:
+        assert is_retriable_http(requests.Timeout()) is True
+
+    def test_connection_error(self) -> None:
+        assert is_retriable_http(requests.ConnectionError()) is True
+
+    @pytest.mark.parametrize("status", [429, 502, 503, 504, 529])
+    def test_retriable_http_status(self, status: int) -> None:
+        resp = MagicMock()
+        resp.status_code = status
+        exc = requests.HTTPError()
+        exc.response = resp
+        assert is_retriable_http(exc) is True
+
+    @pytest.mark.parametrize("status", [400, 401, 403, 404, 500])
+    def test_non_retriable_http_status(self, status: int) -> None:
+        resp = MagicMock()
+        resp.status_code = status
+        exc = requests.HTTPError()
+        exc.response = resp
+        assert is_retriable_http(exc) is False
+
+    def test_http_error_without_response(self) -> None:
+        exc = requests.HTTPError()
+        exc.response = None
+        assert is_retriable_http(exc) is False
+
+    def test_unrelated_exception(self) -> None:
+        assert is_retriable_http(ValueError("nope")) is False


### PR DESCRIPTION
## Summary

Closes #77.

Live pipeline runs have hit transient failures mid-execution — Anthropic 529 (model overloaded), 5xx gateway errors from search providers, and network timeouts during page fetch. Each of these interrupts the run and wastes the tokens already spent on earlier steps, even though a simple retry would have succeeded.

## New module: `src/diogenes/retry.py`

- `retry_with_backoff(call, is_retriable, max_attempts, base_delay, max_delay)` — generic retry loop. Exponential doubling (1s → 2s → 4s…) capped at `max_delay`, with up to 10% jitter added to avoid lockstep with other callers hitting the same overloaded backend.
- `is_retriable_anthropic` — true for `APIConnectionError`, `APITimeoutError`, and `APIStatusError` in {429, 502, 503, 504, 529}.
- `is_retriable_http` — true for `Timeout`, `ConnectionError`, and `HTTPError` with a response status in the same set.

## Call sites wired through the retry

- `api_client.py` `call_sub_agent` — wraps `self._client.messages.create`
- `search_providers.py` — Serper / Brave / Google providers each wrap their `requests.post`/`requests.get` + `raise_for_status`
- `search.py` `fetch_page_extract` — wraps the HTTP fetch + `raise_for_status`

## What is *not* retried (by design)

- HTTP 4xx (400/401/403/404) — indicates a broken request or auth problem; retrying burns tokens without fixing anything.
- JSON validation failures from sub-agent output — the model needs different input, not another shot at the same one.
- Configuration errors surfaced by `APIClient.__init__` (no API key, etc.) — same reason.

## Tests

- Retry loop: success-first, retry-then-succeed, exhaust-then-raise, non-retriable-raises-immediately, delay capped at `max_delay`
- `is_retriable_anthropic` and `is_retriable_http`: connection/timeout, parametrized retriable and non-retriable status codes, unrelated exception, HTTPError without response
- `time.sleep` and `random.uniform` auto-patched via an autouse fixture so the suite stays fast and deterministic

## Test plan
- [x] **503 tests pass, 100% line + branch coverage maintained**
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run mypy src/` passes

Ref #77
Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)