### PR TITLE
feat: classify dio_search failures so the agent can offer web_search fallback (#88)

### DIFF
--- a/ai-research-methodology/skills/research/SKILL.md
+++ b/ai-research-methodology/skills/research/SKILL.md
@@ -499,6 +499,25 @@ When synthesis finishes, report to the user:
 | {ID} | {description of issue needing correction} |
 ```
 
+## Search-tool preference
+
+- **Prefer `dio_search` / `dio_search_batch`** for every web search inside
+  `/research`. They use a configured provider (Serper, Brave, etc.) with a
+  quota-based free tier and are cheaper per call than `web_search`.
+- **Never use `web_search` silently.** It is reserved for fallback after
+  `dio_search` reports a failure and the user has confirmed they want to
+  continue.
+- **Structured error handling.** When `dio_search` or `dio_search_batch`
+  returns `{"error": true, ...}`, inspect `error_kind`:
+  - `quota_exhausted` / `rate_limited` / `network_error` — tell the user,
+    and if `fallback_available` is true, offer to continue the remaining
+    searches with `web_search`. Make the token-cost change explicit in the
+    offer so the user can decide.
+  - `auth_failed` — the search provider's API key is missing/invalid.
+    Report and stop; `web_search` cannot substitute for a misconfigured
+    provider.
+  - `other` — surface the message and ask the user how to proceed.
+
 ## Constraints
 
 - Do not proceed without user confirmation (Step 2)

--- a/src/diogenes/mcp_server.py
+++ b/src/diogenes/mcp_server.py
@@ -22,6 +22,7 @@ import json
 from pathlib import Path
 from typing import Any
 
+import requests
 from mcp.server.fastmcp import FastMCP
 
 from diogenes.config import ConfigError, load_config
@@ -217,13 +218,88 @@ def dio_execute_step(run_dir: str, step_name: str) -> str:
     )
 
 
+def _classify_search_error(exc: BaseException, provider_name: str) -> dict[str, Any]:
+    """Classify a search-provider failure into an actionable category.
+
+    Returns a structured error payload for dio_search / dio_search_batch
+    responses. The ``error_kind`` tag lets the calling agent decide
+    whether to stop, ask the user, or fall back to ``web_search``:
+
+    - ``quota_exhausted`` / ``rate_limited`` — the provider's free tier
+      is tapped out or we're hammering it. Falling back to ``web_search``
+      is reasonable, but the user should be told because web_search costs
+      tokens per call rather than being free on a quota.
+    - ``auth_failed`` — API key is missing, invalid, or revoked. Not a
+      fallback situation; fix the config.
+    - ``network_error`` — transport failure that already survived #77's
+      retry loop. Something upstream is down; stopping is usually right.
+    - ``other`` — anything else. Surface the message and let the agent
+      use judgment.
+
+    The ``fallback_available`` flag is set for categories where calling
+    ``web_search`` as an alternative makes sense. Set to False for
+    auth_failed (web_search won't help) and True for the others.
+    """
+    error_kind = "other"
+    fallback_available = True
+
+    if isinstance(exc, (requests.ConnectionError, requests.Timeout)):
+        error_kind = "network_error"
+    elif isinstance(exc, requests.HTTPError) and exc.response is not None:
+        status = exc.response.status_code
+        quota_exhausted_status = 402
+        rate_limited_status = 429
+        auth_failed_statuses = {401, 403}
+        if status == quota_exhausted_status:
+            error_kind = "quota_exhausted"
+        elif status == rate_limited_status:
+            error_kind = "rate_limited"
+        elif status in auth_failed_statuses:
+            error_kind = "auth_failed"
+            fallback_available = False
+
+    messages = {
+        "quota_exhausted": (
+            f"Search provider '{provider_name}' quota exhausted. "
+            "You can continue with web_search (higher token cost per call) "
+            "or wait for the quota to reset."
+        ),
+        "rate_limited": (
+            f"Search provider '{provider_name}' is rate-limiting requests. "
+            "You can continue with web_search or wait and retry."
+        ),
+        "auth_failed": (
+            f"Search provider '{provider_name}' rejected credentials. "
+            "Fix the API key in .diorc or .env; web_search cannot substitute "
+            "for a misconfigured provider."
+        ),
+        "network_error": (
+            f"Search provider '{provider_name}' is unreachable after retries. "
+            "You can continue with web_search or wait for the service to recover."
+        ),
+        "other": f"Search failed ({provider_name}): {exc}",
+    }
+
+    return {
+        "error": True,
+        "error_kind": error_kind,
+        "message": messages[error_kind],
+        "fallback_available": fallback_available,
+    }
+
+
 @server.tool(
     name="dio_search",
     description=(
         "Execute a web search for the Diogenes research methodology. "
         "Returns titles, URLs, and snippets from the configured search "
         "provider. ONLY use this within /research workflows — do not use "
-        "as a general web search replacement. Uses a limited search API quota."
+        "as a general web search replacement. Uses a limited search API "
+        "quota. On failure, returns a structured error with 'error_kind' "
+        "(quota_exhausted / rate_limited / auth_failed / network_error / "
+        "other) and 'fallback_available'; the caller can offer web_search "
+        "as a fallback for quota/rate/network issues, but must not switch "
+        "silently — the user needs to know the token cost changes."
     ),
 )
 def dio_search(query: str, max_results: int = 5) -> str:
@@ -242,13 +318,14 @@ def dio_search(query: str, max_results: int = 5) -> str:
         results, total = provider.search(query, max_results=max_results)
     except Exception as exc:  # noqa: BLE001
         logger = get_mcp_logger()
+        classification = _classify_search_error(exc, provider.name)
         logger.log(
             step="step4_execute_searches",
             kind="search_error",
-            detail=f"Search provider '{provider.name}' error for query '{query}': {exc}",
+            detail=(f"Search provider '{provider.name}' {classification['error_kind']} for query '{query}': {exc}"),
             layer="mcp",
         )
-        return json.dumps({"error": True, "message": f"Search failed: {exc}", "query": query})
+        return json.dumps({**classification, "query": query})
 
     output: dict[str, Any] = {
         "provider": provider.name,
@@ -350,13 +427,14 @@ def dio_search_batch(queries: list[str], max_results_per_query: int = 5) -> str:
             results, total = provider.search(query, max_results=max_results_per_query)
         except Exception as exc:  # noqa: BLE001
             logger = get_mcp_logger()
+            classification = _classify_search_error(exc, provider.name)
             logger.log(
                 step="step4_execute_searches",
                 kind="search_error",
-                detail=f"Search provider '{provider.name}' error for query '{query}': {exc}",
+                detail=(f"Search provider '{provider.name}' {classification['error_kind']} for query '{query}': {exc}"),
                 layer="mcp",
             )
-            all_results.append({"query": query, "error": str(exc), "results": []})
+            all_results.append({**classification, "query": query, "results": []})
             continue
         all_results.append(
             {

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -193,7 +193,8 @@ class TestDioSearch:
         assert len(result["results"]) == 1
 
     @patch("diogenes.mcp_server._create_search_provider")
-    def test_search_error(self, mock_create: MagicMock) -> None:
+    def test_search_error_generic(self, mock_create: MagicMock) -> None:
+        """An unclassified exception surfaces with error_kind='other'."""
         from diogenes.mcp_server import dio_search
 
         mock_provider = MagicMock()
@@ -202,9 +203,155 @@ class TestDioSearch:
         mock_create.return_value = mock_provider
 
         reset_mcp_logger()
-        result = json.loads(dio_search("test query"))
-        assert result["error"] is True
+        try:
+            result = json.loads(dio_search("test query"))
+            assert result["error"] is True
+            assert result["error_kind"] == "other"
+            assert result["fallback_available"] is True
+            assert result["query"] == "test query"
+        finally:
+            reset_mcp_logger()
+
+    @patch("diogenes.mcp_server._create_search_provider")
+    def test_search_quota_exhausted(self, mock_create: MagicMock) -> None:
+        """HTTP 402 maps to quota_exhausted with fallback available."""
+        import requests as req
+
+        from diogenes.mcp_server import dio_search
+
+        resp = MagicMock()
+        resp.status_code = 402
+        http_err = req.HTTPError()
+        http_err.response = resp
+
+        mock_provider = MagicMock()
+        mock_provider.name = "serper"
+        mock_provider.search.side_effect = http_err
+        mock_create.return_value = mock_provider
+
         reset_mcp_logger()
+        try:
+            result = json.loads(dio_search("test query"))
+            assert result["error_kind"] == "quota_exhausted"
+            assert result["fallback_available"] is True
+            assert "quota" in result["message"].lower()
+        finally:
+            reset_mcp_logger()
+
+    @patch("diogenes.mcp_server._create_search_provider")
+    def test_search_rate_limited(self, mock_create: MagicMock) -> None:
+        import requests as req
+
+        from diogenes.mcp_server import dio_search
+
+        resp = MagicMock()
+        resp.status_code = 429
+        http_err = req.HTTPError()
+        http_err.response = resp
+
+        mock_provider = MagicMock()
+        mock_provider.name = "brave"
+        mock_provider.search.side_effect = http_err
+        mock_create.return_value = mock_provider
+
+        reset_mcp_logger()
+        try:
+            result = json.loads(dio_search("q"))
+            assert result["error_kind"] == "rate_limited"
+            assert result["fallback_available"] is True
+        finally:
+            reset_mcp_logger()
+
+    @patch("diogenes.mcp_server._create_search_provider")
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_search_auth_failed(self, mock_create: MagicMock, status: int) -> None:
+        """401/403 is auth; web_search can't substitute, so fallback=False."""
+        import requests as req
+
+        from diogenes.mcp_server import dio_search
+
+        resp = MagicMock()
+        resp.status_code = status
+        http_err = req.HTTPError()
+        http_err.response = resp
+
+        mock_provider = MagicMock()
+        mock_provider.name = "serper"
+        mock_provider.search.side_effect = http_err
+        mock_create.return_value = mock_provider
+
+        reset_mcp_logger()
+        try:
+            result = json.loads(dio_search("q"))
+            assert result["error_kind"] == "auth_failed"
+            assert result["fallback_available"] is False
+        finally:
+            reset_mcp_logger()
+
+    @patch("diogenes.mcp_server._create_search_provider")
+    def test_search_network_error(self, mock_create: MagicMock) -> None:
+        import requests as req
+
+        from diogenes.mcp_server import dio_search
+
+        mock_provider = MagicMock()
+        mock_provider.name = "serper"
+        mock_provider.search.side_effect = req.ConnectionError("down")
+        mock_create.return_value = mock_provider
+
+        reset_mcp_logger()
+        try:
+            result = json.loads(dio_search("q"))
+            assert result["error_kind"] == "network_error"
+            assert result["fallback_available"] is True
+        finally:
+            reset_mcp_logger()
+
+    @patch("diogenes.mcp_server._create_search_provider")
+    def test_search_http_error_without_response(self, mock_create: MagicMock) -> None:
+        """HTTPError without a response object falls through to 'other'."""
+        import requests as req
+
+        from diogenes.mcp_server import dio_search
+
+        http_err = req.HTTPError()
+        http_err.response = None
+
+        mock_provider = MagicMock()
+        mock_provider.name = "serper"
+        mock_provider.search.side_effect = http_err
+        mock_create.return_value = mock_provider
+
+        reset_mcp_logger()
+        try:
+            result = json.loads(dio_search("q"))
+            assert result["error_kind"] == "other"
+        finally:
+            reset_mcp_logger()
+
+    @patch("diogenes.mcp_server._create_search_provider")
+    def test_search_http_error_unknown_status(self, mock_create: MagicMock) -> None:
+        """A status code that doesn't map to any specific kind → 'other'."""
+        import requests as req
+
+        from diogenes.mcp_server import dio_search
+
+        resp = MagicMock()
+        resp.status_code = 418  # I'm a teapot — not a classified kind
+        http_err = req.HTTPError()
+        http_err.response = resp
+
+        mock_provider = MagicMock()
+        mock_provider.name = "serper"
+        mock_provider.search.side_effect = http_err
+        mock_create.return_value = mock_provider
+
+        reset_mcp_logger()
+        try:
+            result = json.loads(dio_search("q"))
+            assert result["error_kind"] == "other"
+        finally:
+            reset_mcp_logger()
 
 
 class TestDioFetch:
@@ -289,18 +436,33 @@ class TestDioSearchBatch:
 
     @patch("diogenes.mcp_server._create_search_provider")
     def test_batch_partial_error(self, mock_create: MagicMock) -> None:
+        """Per-query errors carry their own classification in the batch result."""
+        import requests as req
+
         from diogenes.mcp_server import dio_search_batch
+
+        resp = MagicMock()
+        resp.status_code = 429
+        http_err = req.HTTPError()
+        http_err.response = resp
 
         mock_provider = MagicMock()
         mock_provider.name = "serper"
-        mock_provider.search.side_effect = [RuntimeError("fail"), ([], 0)]
+        mock_provider.search.side_effect = [http_err, ([], 0)]
         mock_create.return_value = mock_provider
 
         reset_mcp_logger()
-        result = json.loads(dio_search_batch(["q1", "q2"]))
-        assert len(result["results"]) == 2
-        assert "error" in result["results"][0]
-        reset_mcp_logger()
+        try:
+            result = json.loads(dio_search_batch(["q1", "q2"]))
+            assert len(result["results"]) == 2
+            # First query errored with rate_limited classification
+            assert result["results"][0]["error"] is True
+            assert result["results"][0]["error_kind"] == "rate_limited"
+            assert result["results"][0]["fallback_available"] is True
+            # Second query succeeded
+            assert "error" not in result["results"][1]
+        finally:
+            reset_mcp_logger()
 
 
 class TestDioFlushEvents:


### PR DESCRIPTION
## Summary

Closes #88.

Previously `dio_search` / `dio_search_batch` caught all provider errors and returned a generic `{"error": true, "message": str(exc)}`. The calling agent had no way to tell a quota exhaustion from a network blip from an auth failure — so it couldn't make an informed decision about whether to fall back to `web_search` or stop.

## Structured error responses

```json
{
  "error": true,
  "error_kind": "quota_exhausted" | "rate_limited" | "auth_failed" | "network_error" | "other",
  "message": "<actionable description>",
  "fallback_available": true,
  "query": "..."
}
```

| HTTP / Exception | `error_kind` | `fallback_available` |
|------------------|--------------|-----------------------|
| 402 | `quota_exhausted` | ✅ |
| 429 | `rate_limited` | ✅ |
| 401 / 403 | `auth_failed` | ❌ (web_search won't fix a misconfigured provider) |
| `ConnectionError` / `Timeout` | `network_error` | ✅ |
| anything else | `other` | ✅ |

Note: the `network_error` path is only reached for **persistent** failures, because #77's retry loop already handles transient ones inside `search_providers.py`.

## Skill prompt update

`SKILL.md` gains a *Search-tool preference* section instructing the skill to:

- Prefer `dio_search` / `dio_search_batch` for all searches inside `/research`
- **Never switch to `web_search` silently** — reserved for post-error fallback the user has confirmed, because the per-call token cost changes
- Inspect `error_kind` on failure:
  - quota / rate / network → offer `web_search` if `fallback_available`
  - `auth_failed` → report and stop
  - `other` → surface and ask

## Tests

- Every classifier branch: `quota_exhausted`, `rate_limited`, `auth_failed` (401+403 parametrized), `network_error`, HTTPError without response, HTTPError with unknown status (418 teapot), generic RuntimeError
- `dio_search_batch`: per-query classification, surviving queries succeed

## Test plan
- [x] **510 tests pass, 100% line + branch coverage maintained**
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run mypy src/` passes

Ref #88
Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)