### PR TITLE
feat: expose pipeline tuning parameters via .diorc [pipeline] section (#76)

### DIFF
--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -270,7 +270,6 @@ class APIClient:
     """
 
     DEFAULT_MODEL = DEFAULT_MODEL  # From config.py — single source of truth
-    DEFAULT_MAX_TOKENS = 8192
     _PROMPTS_DIR = Path(__file__).parent / "prompts"
     _COMMON_GUIDELINES_PATH = _PROMPTS_DIR / "common-guidelines.md"
     _SCHEMAS_DIR = Path(__file__).parent / "schemas"
@@ -289,7 +288,7 @@ class APIClient:
             config: Pre-loaded configuration. If omitted, loads from all config sources
                 (environment variable, .diorc files, .env file).
             model: Anthropic model ID. Overrides the value in config.
-            max_tokens: Maximum response tokens. Defaults to 8192.
+            max_tokens: Maximum response tokens. Overrides config.pipeline.max_output_tokens.
             guidelines_path: Path to common guidelines file. Defaults to
                 prompts/common-guidelines.md in the repo root.
 
@@ -304,9 +303,10 @@ class APIClient:
             msg = str(e)
             raise SubAgentError(agent_name, msg) from e
 
+        self.config = cfg
         self._client = anthropic.Anthropic(api_key=cfg.api_key, base_url=cfg.base_url)
         self._model = model or cfg.model or self.DEFAULT_MODEL
-        self._max_tokens = max_tokens or self.DEFAULT_MAX_TOKENS
+        self._max_tokens = max_tokens or cfg.pipeline.max_output_tokens
 
         gp = Path(guidelines_path) if guidelines_path is not None else self._COMMON_GUIDELINES_PATH
         if gp.exists():
@@ -320,6 +320,26 @@ class APIClient:
     def model(self) -> str:
         """The model ID configured for this client."""
         return self._model
+
+    @property
+    def pipeline(self) -> Any:
+        """Shortcut to the tunable pipeline config block."""
+        return self.config.pipeline
+
+    def model_for(self, agent_name: str) -> str:
+        """Return the Anthropic model ID for a named sub-agent.
+
+        Falls back to the client's default model when no override is
+        configured. Intended for use inside pipeline step functions
+        that call :meth:`call_sub_agent`, e.g.:
+
+            response = client.call_sub_agent(
+                prompt_path=...,
+                user_input=...,
+                model=client.model_for("relevance_scorer"),
+            )
+        """
+        return self.config.pipeline.model_overrides.get(agent_name, self._model)
 
     def _compose_system_prompt(
         self,

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -229,6 +229,7 @@ def _parse_and_clarify(
             prompt_path=clarifier_prompt,
             user_input=raw_input,
             output_schema="research-input-clarified.schema.json",
+            model=client.model_for("clarifier"),
         )
     except SubAgentError as e:
         print(f"ERROR: {e}")

--- a/src/diogenes/config.py
+++ b/src/diogenes/config.py
@@ -4,16 +4,40 @@ from __future__ import annotations
 
 import os
 import tomllib
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
 
 DEFAULT_BASE_URL = "https://api.anthropic.com"
 DEFAULT_MODEL = "claude-sonnet-4-6"
 
+# Pipeline tuning defaults. These match the values historically hard-coded
+# across pipeline.py / api_client.py / search.py. Keeping them here lets
+# .diorc override any of them without editing source.
+_DEFAULT_RESULTS_PER_SEARCH = 5
+_DEFAULT_SCORING_BATCH_SIZE = 5
+_DEFAULT_RELEVANCE_THRESHOLD = 5
+_DEFAULT_SEARCH_TERMS_PER_QUERY = 3
+_DEFAULT_MAX_OUTPUT_TOKENS = 8192
+
 
 class ConfigError(Exception):
     """Raised when Diogenes configuration cannot be resolved."""
+
+
+@dataclass
+class PipelineConfig:
+    """Tunable pipeline parameters, overridable via ``[pipeline]`` in .diorc."""
+
+    results_per_search: int = _DEFAULT_RESULTS_PER_SEARCH
+    scoring_batch_size: int = _DEFAULT_SCORING_BATCH_SIZE
+    relevance_threshold: int = _DEFAULT_RELEVANCE_THRESHOLD
+    search_terms_per_query: int = _DEFAULT_SEARCH_TERMS_PER_QUERY
+    max_output_tokens: int = _DEFAULT_MAX_OUTPUT_TOKENS
+    # Per-agent model overrides keyed by logical sub-agent name (e.g.,
+    # "relevance_scorer"). Absent keys fall back to the global ``model``
+    # on DioConfig. See APIClient.model_for().
+    model_overrides: dict[str, str] = field(default_factory=dict)
 
 
 @dataclass
@@ -28,6 +52,7 @@ class DioConfig:
     brave_api_key: str = ""
     google_api_key: str = ""
     google_search_engine_id: str = ""
+    pipeline: PipelineConfig = field(default_factory=PipelineConfig)
 
 
 def _parse_dotenv(path: Path) -> dict[str, str]:
@@ -155,6 +180,8 @@ def load_config() -> DioConfig:
         or str(search_sect.get("google_search_engine_id", ""))
     )
 
+    pipeline_cfg = _load_pipeline_config(toml)
+
     return DioConfig(
         api_key=api_key,
         base_url=base_url,
@@ -164,4 +191,29 @@ def load_config() -> DioConfig:
         brave_api_key=brave_api_key,
         google_api_key=google_api_key,
         google_search_engine_id=google_search_engine_id,
+        pipeline=pipeline_cfg,
     )
+
+
+def _load_pipeline_config(toml: dict[str, Any]) -> PipelineConfig:
+    """Build a PipelineConfig from the ``[pipeline]`` section of .diorc.
+
+    Any field not present in the TOML falls back to the dataclass default.
+    Model overrides come from the nested ``[pipeline.model_overrides]``
+    subtable and are stored as a ``dict[str, str]``.
+    """
+    pipeline_sect = _section(toml, "pipeline")
+    overrides_raw = pipeline_sect.get("model_overrides", {})
+    model_overrides = {str(k): str(v) for k, v in overrides_raw.items()} if isinstance(overrides_raw, dict) else {}
+
+    cfg = PipelineConfig(model_overrides=model_overrides)
+    for field_name in (
+        "results_per_search",
+        "scoring_batch_size",
+        "relevance_threshold",
+        "search_terms_per_query",
+        "max_output_tokens",
+    ):
+        if field_name in pipeline_sect:
+            setattr(cfg, field_name, int(pipeline_sect[field_name]))
+    return cfg

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -22,10 +22,12 @@ if TYPE_CHECKING:
 
 _PROMPTS_DIR = Path(__file__).parent / "prompts" / "sub-agents"
 
-# Model overrides for cost optimization. Set to None to use the client default.
-# Testing showed Haiku produces different verdicts than Sonnet on scoring steps,
-# which changes downstream assessments. Correctness > cost. See issue #84.
-_SCORING_MODEL: str | None = None
+# Per-sub-agent model overrides are now configurable via .diorc under
+# [pipeline.model_overrides]. Each call site uses client.model_for("<name>")
+# to resolve: override if configured, default model otherwise. Historical
+# testing (#84) showed Haiku produces different verdicts than Sonnet on
+# scoring steps — overrides default to empty so behavior matches pre-#76
+# unless a user opts in.
 
 
 def step2_generate_hypotheses(
@@ -70,6 +72,7 @@ def step2_generate_hypotheses(
             prompt_path=prompt_path,
             user_input=agent_input,
             output_schema="hypotheses.schema.json",
+            model=client.model_for("hypothesis_generator"),
         )
 
         results[item_id] = response
@@ -89,6 +92,7 @@ def step2_generate_hypotheses(
             prompt_path=prompt_path,
             user_input=agent_input,
             output_schema="hypotheses.schema.json",
+            model=client.model_for("hypothesis_generator"),
         )
 
         results[item_id] = response
@@ -152,6 +156,7 @@ def step3_design_searches(
             prompt_path=prompt_path,
             user_input=agent_input,
             output_schema="search-plans.schema.json",
+            model=client.model_for("search_designer"),
         )
 
         results[item_id] = response
@@ -160,10 +165,6 @@ def step3_design_searches(
         print(f"    {item_id}: {search_count} searches planned ({approach})")
 
     return results
-
-
-_RELEVANCE_BATCH_SIZE = 5
-_RELEVANCE_THRESHOLD = 5
 
 
 def step4_execute_searches(
@@ -177,8 +178,13 @@ def step4_execute_searches(
 
     Three phases:
     - 4A (Python): Execute searches via search provider. Zero LLM tokens.
-    - 4B (LLM, batched): Score relevance 0-10 in batches of 5. Tiny calls.
+    - 4B (LLM, batched): Score relevance 0-10 in batches. Tiny calls.
     - 4C (Python): Sort by score, filter by threshold, deduplicate.
+
+    Pipeline tunables read from ``client.pipeline``:
+    - ``results_per_search`` controls how many results each search query returns
+    - ``scoring_batch_size`` controls how many results are scored per LLM call
+    - ``relevance_threshold`` controls the inclusion cut-off for Step 4C
 
     Args:
         research_input: The clarified research input (output of step 1).
@@ -196,6 +202,7 @@ def step4_execute_searches(
     """
     scorer_prompt = _PROMPTS_DIR / "search-results.md"
     results: dict[str, Any] = {}
+    threshold = client.pipeline.relevance_threshold
 
     items = [*research_input.get("claims", []), *research_input.get("queries", [])]
 
@@ -206,7 +213,11 @@ def step4_execute_searches(
         print(f"  Executing {len(searches)} searches for {item_id} via {search_provider.name}...")
 
         # Phase 4A: Python executes searches
-        executions = execute_search_plan(item_plan, search_provider)
+        executions = execute_search_plan(
+            item_plan,
+            search_provider,
+            max_results_per_search=client.pipeline.results_per_search,
+        )
         total_results = sum(len(e.results) for e in executions)
         print(f"    {total_results} raw results from {len(executions)} searches")
 
@@ -219,21 +230,19 @@ def step4_execute_searches(
         )
 
         # Phase 4C: Python filters and deduplicates
-        selected, rejected = _filter_and_deduplicate(all_scored)
-        print(
-            f"    {len(selected)} sources selected (score >= {_RELEVANCE_THRESHOLD}), {len(rejected)} below threshold"
-        )
+        selected, rejected = _filter_and_deduplicate(all_scored, threshold=threshold)
+        print(f"    {len(selected)} sources selected (score >= {threshold}), {len(rejected)} below threshold")
 
         if event_logger and rejected:
             for rej in rejected:
                 event_logger.log(
                     step="step4_execute_searches",
                     kind="below_threshold",
-                    detail=f"Relevance score {rej.get('relevance_score', '?')}/10 below threshold {_RELEVANCE_THRESHOLD}",
+                    detail=f"Relevance score {rej.get('relevance_score', '?')}/10 below threshold {threshold}",
                     url=rej.get("url", ""),
                     item_id=item_id,
                     score=rej.get("relevance_score"),
-                    threshold=float(_RELEVANCE_THRESHOLD),
+                    threshold=float(threshold),
                     layer="pipeline",
                 )
 
@@ -247,7 +256,7 @@ def step4_execute_searches(
                 "total_results_found": total_results,
                 "total_selected": len(selected),
                 "total_rejected": len(rejected),
-                "relevance_threshold": _RELEVANCE_THRESHOLD,
+                "relevance_threshold": threshold,
             },
         }
 
@@ -262,17 +271,19 @@ def _score_results_batched(
 ) -> list[dict[str, Any]]:
     """Score all search results in batches via the relevance-scorer sub-agent."""
     all_scored: list[dict[str, Any]] = []
+    batch_size = client.pipeline.scoring_batch_size
+    terms_per_query = client.pipeline.search_terms_per_query
 
     for execution in executions:
         results_list = execution.results
         search_id = execution.search_id
 
         # Determine search intent from the execution
-        search_intent = f"Search {search_id}: {' '.join(execution.terms[:3])}"
+        search_intent = f"Search {search_id}: {' '.join(execution.terms[:terms_per_query])}"
 
         # Process in batches
-        for i in range(0, len(results_list), _RELEVANCE_BATCH_SIZE):
-            batch = results_list[i : i + _RELEVANCE_BATCH_SIZE]
+        for i in range(0, len(results_list), batch_size):
+            batch = results_list[i : i + batch_size]
             batch_input = {
                 "item_id": item["id"],
                 "clarified_text": item.get("clarified_text", ""),
@@ -285,7 +296,7 @@ def _score_results_batched(
                 user_input=batch_input,
                 output_schema="relevance-scores.schema.json",
                 include_guidelines=False,
-                model=_SCORING_MODEL,
+                model=client.model_for("relevance_scorer"),
             )
 
             # Enrich scores with metadata from original results
@@ -305,6 +316,8 @@ def _score_results_batched(
 
 def _filter_and_deduplicate(
     scored_results: list[dict[str, Any]],
+    *,
+    threshold: int,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
     """Filter by relevance threshold and deduplicate by URL."""
     # Sort by score descending
@@ -322,7 +335,7 @@ def _filter_and_deduplicate(
             continue
         seen_urls.add(url)
 
-        if score >= _RELEVANCE_THRESHOLD:
+        if score >= threshold:
             selected.append(result)
         else:
             rejected.append(result)
@@ -469,8 +482,8 @@ def step5_score_sources(
                 prompt_path=scorer_prompt,
                 user_input=batch_input,
                 output_schema="scorecards.schema.json",
-                max_tokens=8192,
-                model=_SCORING_MODEL,
+                max_tokens=client.pipeline.max_output_tokens,
+                model=client.model_for("source_scorer"),
             )
 
             all_scorecards.extend(response.get("scorecards", []))
@@ -565,7 +578,8 @@ def _extract_single_source(
             "scorecards": [scorecard],
         },
         output_schema="evidence-packets.schema.json",
-        max_tokens=8192,
+        max_tokens=client.pipeline.max_output_tokens,
+        model=client.model_for("evidence_extractor"),
     )
 
     claimed_packets = response.get("packets", []) or []
@@ -860,6 +874,7 @@ def steps678_synthesize_and_assess(
             user_input=agent_input,
             output_schema="synthesis.schema.json",
             max_tokens=16384,
+            model=client.model_for("synthesizer"),
         )
 
         results[item_id] = response
@@ -924,6 +939,7 @@ def step9_self_audit(
             user_input=agent_input,
             output_schema="self-audit.schema.json",
             max_tokens=16384,
+            model=client.model_for("self_auditor"),
         )
 
         results[item_id] = response
@@ -997,6 +1013,7 @@ def step10_report(
             user_input=agent_input,
             output_schema="reports.schema.json",
             max_tokens=16384,
+            model=client.model_for("reporter"),
         )
 
         results[item_id] = response

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -346,6 +346,51 @@ class TestAPIClient:
         client = APIClient(config=cfg, model="claude-haiku-4-5-20251001", guidelines_path="/dev/null")
         assert client.model == "claude-haiku-4-5-20251001"
 
+    def test_pipeline_property_exposes_tunables(self) -> None:
+        """client.pipeline is a shortcut to config.pipeline."""
+        cfg = self._make_config()
+        client = APIClient(config=cfg, guidelines_path="/dev/null")
+        assert client.pipeline is cfg.pipeline
+        # Defaults match the pre-#76 hard-coded values
+        assert client.pipeline.relevance_threshold == 5
+        assert client.pipeline.max_output_tokens == 8192
+
+    def test_max_tokens_defaults_to_config(self) -> None:
+        """APIClient picks up max_output_tokens from config.pipeline."""
+        from diogenes.config import PipelineConfig
+
+        cfg = DioConfig(api_key="k", pipeline=PipelineConfig(max_output_tokens=4096))
+        client = APIClient(config=cfg, guidelines_path="/dev/null")
+        assert client._max_tokens == 4096
+
+    def test_max_tokens_explicit_overrides_config(self) -> None:
+        """Explicit max_tokens on APIClient wins over config."""
+        from diogenes.config import PipelineConfig
+
+        cfg = DioConfig(api_key="k", pipeline=PipelineConfig(max_output_tokens=4096))
+        client = APIClient(config=cfg, max_tokens=2048, guidelines_path="/dev/null")
+        assert client._max_tokens == 2048
+
+    def test_model_for_returns_override(self) -> None:
+        """model_for returns the override when configured."""
+        from diogenes.config import PipelineConfig
+
+        cfg = DioConfig(
+            api_key="k",
+            pipeline=PipelineConfig(
+                model_overrides={"relevance_scorer": "claude-haiku-4-5-20251001"},
+            ),
+        )
+        client = APIClient(config=cfg, guidelines_path="/dev/null")
+        assert client.model_for("relevance_scorer") == "claude-haiku-4-5-20251001"
+
+    def test_model_for_falls_back_to_default(self) -> None:
+        """model_for returns the client's default model when no override."""
+        cfg = self._make_config()
+        client = APIClient(config=cfg, guidelines_path="/dev/null")
+        # No override configured for 'hypothesis_generator' → default model
+        assert client.model_for("hypothesis_generator") == client.model
+
     def test_missing_guidelines_path(self) -> None:
         cfg = self._make_config()
         client = APIClient(config=cfg, guidelines_path="/nonexistent/guidelines.md")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -221,3 +221,71 @@ class TestLoadConfig:
         diorc.write_text('[api]\nbase_url = "https://custom.api.com"\n')
         cfg = load_config()
         assert cfg.base_url == "https://custom.api.com"
+
+
+class TestPipelineConfig:
+    """Tests for the [pipeline] section in .diorc."""
+
+    def test_defaults_when_section_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """Omitting [pipeline] falls back to the dataclass defaults."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+        monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
+        cfg = load_config()
+        # The defaults match the hard-coded values from before this PR.
+        assert cfg.pipeline.results_per_search == 5
+        assert cfg.pipeline.scoring_batch_size == 5
+        assert cfg.pipeline.relevance_threshold == 5
+        assert cfg.pipeline.search_terms_per_query == 3
+        assert cfg.pipeline.max_output_tokens == 8192
+        assert cfg.pipeline.model_overrides == {}
+
+    def test_fields_override_defaults(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+        """[pipeline] fields in .diorc override the dataclass defaults."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+        monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
+        diorc = tmp_path / ".diorc"  # type: ignore[operator]
+        diorc.write_text(
+            "[pipeline]\n"
+            "results_per_search = 10\n"
+            "scoring_batch_size = 7\n"
+            "relevance_threshold = 6\n"
+            "search_terms_per_query = 4\n"
+            "max_output_tokens = 16384\n"
+        )
+        cfg = load_config()
+        assert cfg.pipeline.results_per_search == 10
+        assert cfg.pipeline.scoring_batch_size == 7
+        assert cfg.pipeline.relevance_threshold == 6
+        assert cfg.pipeline.search_terms_per_query == 4
+        assert cfg.pipeline.max_output_tokens == 16384
+
+    def test_model_overrides_parsed(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+        """[pipeline.model_overrides] becomes a dict[str, str]."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+        monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
+        diorc = tmp_path / ".diorc"  # type: ignore[operator]
+        diorc.write_text(
+            "[pipeline.model_overrides]\n"
+            'relevance_scorer = "claude-haiku-4-5-20251001"\n'
+            'clarifier = "claude-sonnet-4-6"\n'
+        )
+        cfg = load_config()
+        assert cfg.pipeline.model_overrides == {
+            "relevance_scorer": "claude-haiku-4-5-20251001",
+            "clarifier": "claude-sonnet-4-6",
+        }
+
+    def test_model_overrides_non_dict_falls_back_to_empty(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        """If model_overrides is not a table (malformed .diorc), treat as empty."""
+        monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
+        monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
+        diorc = tmp_path / ".diorc"  # type: ignore[operator]
+        # Writing model_overrides as a string (not a table) is technically valid TOML
+        # but not what we expect; should gracefully fall back.
+        diorc.write_text('[pipeline]\nmodel_overrides = "not-a-table"\n')
+        cfg = load_config()
+        assert cfg.pipeline.model_overrides == {}

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -79,7 +79,7 @@ class TestFilterAndDeduplicate:
             {"url": "https://a.com", "relevance_score": 8},
             {"url": "https://b.com", "relevance_score": 3},
         ]
-        selected, rejected = _filter_and_deduplicate(results)
+        selected, rejected = _filter_and_deduplicate(results, threshold=5)
         assert len(selected) == 1
         assert selected[0]["url"] == "https://a.com"
         assert len(rejected) == 1
@@ -89,7 +89,7 @@ class TestFilterAndDeduplicate:
             {"url": "https://a.com", "relevance_score": 8},
             {"url": "https://a.com", "relevance_score": 7},
         ]
-        selected, rejected = _filter_and_deduplicate(results)
+        selected, rejected = _filter_and_deduplicate(results, threshold=5)
         assert len(selected) == 1
 
     def test_sorted_by_score(self) -> None:
@@ -97,13 +97,28 @@ class TestFilterAndDeduplicate:
             {"url": "https://a.com", "relevance_score": 5},
             {"url": "https://b.com", "relevance_score": 9},
         ]
-        selected, _ = _filter_and_deduplicate(results)
+        selected, _ = _filter_and_deduplicate(results, threshold=5)
         assert selected[0]["url"] == "https://b.com"
 
     def test_empty_input(self) -> None:
-        selected, rejected = _filter_and_deduplicate([])
+        selected, rejected = _filter_and_deduplicate([], threshold=5)
         assert selected == []
         assert rejected == []
+
+    def test_threshold_is_parameterized(self) -> None:
+        """Raising the threshold changes which sources clear the bar."""
+        results = [
+            {"url": "https://a.com", "relevance_score": 8},
+            {"url": "https://b.com", "relevance_score": 6},
+        ]
+        # Threshold 7: only the 8-scorer selected
+        selected_hi, rejected_hi = _filter_and_deduplicate(list(results), threshold=7)
+        assert len(selected_hi) == 1
+        assert len(rejected_hi) == 1
+        # Threshold 6: both pass
+        selected_lo, rejected_lo = _filter_and_deduplicate(list(results), threshold=6)
+        assert len(selected_lo) == 2
+        assert rejected_lo == []
 
 
 class TestScorecardsWithoutContent:
@@ -509,6 +524,15 @@ class TestStep5bExtractEvidence:
 class TestStep4ExecuteSearches:
     """Tests for step4_execute_searches."""
 
+    def _client_with_defaults(self) -> MagicMock:
+        """Mock APIClient whose .pipeline uses the real dataclass defaults."""
+        from diogenes.config import PipelineConfig
+
+        client = MagicMock()
+        client.pipeline = PipelineConfig()
+        client.model_for.return_value = "claude-sonnet-4-6"
+        return client
+
     @patch("diogenes.pipeline.execute_search_plan")
     def test_executes_searches(self, mock_exec: MagicMock) -> None:
         from diogenes.search import SearchExecution, SearchResult
@@ -523,7 +547,7 @@ class TestStep4ExecuteSearches:
                 total_results_available=1,
             )
         ]
-        mock_client = MagicMock()
+        mock_client = self._client_with_defaults()
         mock_client.call_sub_agent.return_value = {
             "scores": [{"url": "https://a.com", "relevance_score": 8}],
         }
@@ -551,7 +575,7 @@ class TestStep4ExecuteSearches:
                 total_results_available=1,
             )
         ]
-        mock_client = MagicMock()
+        mock_client = self._client_with_defaults()
         mock_client.call_sub_agent.return_value = {
             "scores": [{"url": "https://a.com", "relevance_score": 2}],  # Below threshold
         }


### PR DESCRIPTION
## Summary

Closes #76.

Pipeline parameters were previously hard-coded across `pipeline.py`, `api_client.py`, and `search.py`. Experimenting with them required editing source. This change surfaces them as `.diorc` configuration so users can tune per-run without code changes.

## New `[pipeline]` section

All fields optional; absence keeps the dataclass defaults, which match the pre-#76 hard-coded values:

```toml
[pipeline]
results_per_search = 5
scoring_batch_size = 5
relevance_threshold = 5
search_terms_per_query = 3
max_output_tokens = 8192

[pipeline.model_overrides]
relevance_scorer = "claude-haiku-4-5-20251001"
clarifier = "claude-sonnet-4-6"
```

## Plumbing

- **`config.py`**: new `PipelineConfig` dataclass, parsed from `[pipeline]` and the nested `[pipeline.model_overrides]` subtable. Stored on `DioConfig.pipeline`.
- **`api_client.py`**: `APIClient` keeps `self.config`; exposes `self.pipeline` shortcut. New `APIClient.model_for(agent_name)` returns the configured override or the default model. `max_tokens` default now reads from `config.pipeline.max_output_tokens`.
- **`pipeline.py`**: module-level `_RELEVANCE_BATCH_SIZE` / `_RELEVANCE_THRESHOLD` / `_SCORING_MODEL` constants deleted. Values now read from `client.pipeline` at step execution time. Hardcoded `terms[:3]` replaced with `client.pipeline.search_terms_per_query`. `execute_search_plan` called with `max_results_per_search` from config. Every `call_sub_agent` site uses `client.model_for('<logical name>')`.
- **`commands/run.py`**: clarifier call uses `client.model_for('clarifier')`.

## Agent-name → override key mapping

Each `call_sub_agent` site uses a stable logical name for lookup. Users can override any of: `clarifier`, `hypothesis_generator`, `search_designer`, `relevance_scorer`, `source_scorer`, `evidence_extractor`, `synthesizer`, `self_auditor`, `reporter`.

Unknown keys in the config are harmless — they simply never match a call site.

## Tests

- `config.py`: defaults, every field overridable, model_overrides parsed, graceful fallback when model_overrides is not a table
- `api_client.py`: `pipeline` property, `max_tokens` defaults from config, explicit `max_tokens` override wins, `model_for` with override, `model_for` fallback
- `pipeline.py`: `_filter_and_deduplicate` now takes `threshold=` kwarg (parameterized threshold test added). Step 4 tests swap raw `MagicMock` clients for ones whose `.pipeline` is a real `PipelineConfig` instance.

## Test plan
- [x] **520 tests pass, 100% line + branch coverage maintained**
- [x] `uv run ruff check` passes
- [x] `uv run ruff format --check .` passes
- [x] `uv run mypy src/` passes

Ref #76
Closes #76

🤖 Generated with [Claude Code](https://claude.com/claude-code)