### PR TITLE
feat: replace print() with progress logger (#104)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,11 +128,10 @@ docstring-quotes = "double"
     "INP001", # Scripts are not a package; no __init__.py needed.
 ]
 "src/diogenes/cli.py" = [
-    "T201",   # CLI uses print for user-facing output.
+    "T201",   # CLI entry dispatcher prints before any run-scoped logger exists.
     "PLC0415", # Lazy imports for subcommands are intentional.
 ]
 "src/diogenes/commands/**/*.py" = [
-    "T201",    # Command implementations use print for user-facing output.
     "PLR0911", # Command execute() has early-return error handling per step.
     "PLR0912", # _dispatch_step branches per pipeline step.
     "PLR0913", # _dispatch_step takes context args for all handler signatures.
@@ -140,17 +139,17 @@ docstring-quotes = "double"
     "C901",    # _dispatch_step maps steps to handlers with per-step args.
     "C416",    # Dict comprehension in archive assembly is clearer than dict().
     "ANN401",  # _dispatch_step accepts Any — handlers have heterogeneous signatures.
+    "G004",    # Progress-log f-strings: readability > lazy-formatting micro-perf.
 ]
 "src/diogenes/pipeline.py" = [
-    "T201",    # Pipeline steps print progress for user-facing output.
     "PLR0913", # Later steps receive all prior step outputs as arguments.
+    "G004",    # Progress-log f-strings: readability > lazy-formatting micro-perf.
 ]
 "src/diogenes/api_client.py" = [
     "PLR0913", # call_sub_agent has keyword-only params for composability.
     "C901",    # _parse_json_response handles multiple extraction strategies.
     "PLR0912", # _strip_to_schema recurses through schema structure.
     "ANN401",  # _strip_to_schema and _preview accept Any — JSON data is untyped.
-    "T201",    # Schema-strip notifications printed for observability.
 ]
 "src/diogenes/mcp_server.py" = [
     "C901",    # dio_validate_packets handles both CLI and skill output formats.

--- a/src/diogenes/api_client.py
+++ b/src/diogenes/api_client.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any
@@ -12,6 +13,8 @@ import jsonschema
 
 from diogenes.config import DEFAULT_MODEL, ConfigError, DioConfig, load_config
 from diogenes.retry import is_retriable_anthropic, retry_with_backoff
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass
@@ -519,11 +522,12 @@ class APIClient:
             stripped = _strip_to_schema(result, schema_dict)
             if stripped:
                 max_detail = 5
-                print(
-                    f"    schema-strip ({prompt_file.stem}): "
-                    f"removed {len(stripped)} non-schema field(s): "
-                    + "; ".join(stripped[:max_detail])
-                    + (" ..." if len(stripped) > max_detail else "")
+                logger.info(
+                    "    schema-strip (%s): removed %d non-schema field(s): %s%s",
+                    prompt_file.stem,
+                    len(stripped),
+                    "; ".join(stripped[:max_detail]),
+                    " ..." if len(stripped) > max_detail else "",
                 )
             _validate_against_schema(result, schema_dict, prompt_file.stem)
 

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import shutil
 import time
 from datetime import UTC, datetime
@@ -11,6 +12,7 @@ from typing import Any
 from diogenes.api_client import APIClient, SubAgentError
 from diogenes.config import load_config
 from diogenes.events import EventLogger, reconcile_run
+from diogenes.logger import configure_progress_logger
 from diogenes.pipeline import (
     step2_generate_hypotheses,
     step3_design_searches,
@@ -26,6 +28,8 @@ from diogenes.pipeline import (
 from diogenes.schema_validator import ValidationError, parse_input_file, validate_research_input
 from diogenes.search_providers import BraveSearchProvider, GoogleSearchProvider, SerperSearchProvider
 from diogenes.state_machine import PIPELINE_STEPS, PipelineState
+
+logger = logging.getLogger(__name__)
 
 # Resolve prompts from the package (works for both repo checkout and pip install)
 _PACKAGE_DIR = Path(__file__).parent.parent
@@ -173,22 +177,22 @@ def _dispatch_step(
             coverage = reconcile_run(run_dir, event_logger)
             adherence = coverage.get("verbatim_adherence_pct")
             if adherence is not None:
-                print(
+                logger.info(
                     f"  Coverage: {coverage['sources_scored']}/{coverage['sources_attempted']} "
                     f"sources, {adherence}% verbatim adherence"
                 )
             event_logger.write()
             n_events = len(event_logger.events)
             if n_events:
-                print(f"  Events: {n_events}")
+                logger.info(f"  Events: {n_events}")
             # Events file writes itself — return sentinel.
             return {"_self_written": True}
 
     except SubAgentError as e:
-        print(f"ERROR: {e}")
+        logger.info(f"ERROR: {e}")
         return None
 
-    print(f"ERROR: Unknown step '{name}'")
+    logger.info(f"ERROR: Unknown step '{name}'")
     return None
 
 
@@ -200,28 +204,28 @@ def _parse_and_clarify(
 
     Returns the research input dict, or None on error (after printing).
     """
-    print(f"Reading input: {input_path}")
+    logger.info(f"Reading input: {input_path}")
     try:
         raw_input = parse_input_file(input_path)
     except FileNotFoundError as e:
-        print(f"ERROR: {e}")
+        logger.info(f"ERROR: {e}")
         return None
 
     # Route — JSON or text?
     if isinstance(raw_input, dict):
-        print("Input format: JSON — validating schema...")
+        logger.info("Input format: JSON — validating schema...")
         try:
             research_input = validate_research_input(raw_input)
         except ValidationError as e:
-            print(f"ERROR: {e}")
+            logger.info(f"ERROR: {e}")
             return None
-        print(f"  Claims: {len(research_input.get('claims', []))}")
-        print(f"  Queries: {len(research_input.get('queries', []))}")
-        print(f"  Axioms: {len(research_input.get('axioms', []))}")
+        logger.info(f"  Claims: {len(research_input.get('claims', []))}")
+        logger.info(f"  Queries: {len(research_input.get('queries', []))}")
+        logger.info(f"  Axioms: {len(research_input.get('axioms', []))}")
         return research_input
 
     # Text input — call input-clarifier sub-agent
-    print("Input format: text — calling input-clarifier sub-agent...")
+    logger.info("Input format: text — calling input-clarifier sub-agent...")
     clarifier_prompt = _PROMPTS_DIR / "research-input-clarified.md"
 
     try:
@@ -232,11 +236,11 @@ def _parse_and_clarify(
             model=client.model_for("clarifier"),
         )
     except SubAgentError as e:
-        print(f"ERROR: {e}")
+        logger.info(f"ERROR: {e}")
         return None
 
     if clarified.get("error"):
-        print(f"ERROR: Input clarifier failed: {clarified.get('message', 'unknown error')}")
+        logger.info(f"ERROR: Input clarifier failed: {clarified.get('message', 'unknown error')}")
         return None
 
     research_input = {
@@ -248,7 +252,7 @@ def _parse_and_clarify(
     claims_count = len(research_input.get("claims", []))
     queries_count = len(research_input.get("queries", []))
     axioms_count = len(research_input.get("axioms", []))
-    print(f"  Clarified: {claims_count} claims, {queries_count} queries, {axioms_count} axioms")
+    logger.info(f"  Clarified: {claims_count} claims, {queries_count} queries, {axioms_count} axioms")
     return research_input
 
 
@@ -261,24 +265,24 @@ def _create_search_provider() -> SerperSearchProvider | BraveSearchProvider | Go
 
     if cfg.search_provider == "serper":
         if not cfg.serper_api_key:
-            print("ERROR: Serper.dev requires SERPER_API_KEY in .diorc or .env")
-            print("  Sign up free at https://serper.dev/ (2,500 searches/month)")
+            logger.info("ERROR: Serper.dev requires SERPER_API_KEY in .diorc or .env")
+            logger.info("  Sign up free at https://serper.dev/ (2,500 searches/month)")
             return None
         return SerperSearchProvider(cfg.serper_api_key)
 
     if cfg.search_provider == "brave":
         if not cfg.brave_api_key:
-            print("ERROR: Brave Search requires BRAVE_API_KEY in .diorc or .env")
+            logger.info("ERROR: Brave Search requires BRAVE_API_KEY in .diorc or .env")
             return None
         return BraveSearchProvider(cfg.brave_api_key)
 
     if cfg.search_provider == "google":
         if not cfg.google_api_key or not cfg.google_search_engine_id:
-            print("ERROR: Google Search requires GOOGLE_API_KEY and GOOGLE_SEARCH_ENGINE_ID")
+            logger.info("ERROR: Google Search requires GOOGLE_API_KEY and GOOGLE_SEARCH_ENGINE_ID")
             return None
         return GoogleSearchProvider(cfg.google_api_key, cfg.google_search_engine_id)
 
-    print(f"ERROR: Unknown search provider: {cfg.search_provider}")
+    logger.info(f"ERROR: Unknown search provider: {cfg.search_provider}")
     return None
 
 
@@ -299,7 +303,7 @@ def _run_pipeline(parent_dir: Path, input_path: Path) -> int:
     try:
         client = APIClient()
     except SubAgentError as e:
-        print(f"ERROR: {e}")
+        logger.info(f"ERROR: {e}")
         return 1
 
     search_provider = _create_search_provider()
@@ -308,7 +312,11 @@ def _run_pipeline(parent_dir: Path, input_path: Path) -> int:
 
     # Create a fresh timestamped instance subdirectory
     instance_dir = _create_instance_dir(parent_dir)
-    print(f"Instance: {instance_dir}")
+    # Configure the progress logger now that the instance dir exists —
+    # every subsequent logger.info() fans out to progress.log and, if a
+    # TTY is attached, also to stdout.
+    configure_progress_logger(instance_dir / "progress.log")
+    logger.info(f"Instance: {instance_dir}")
 
     # Step 1: parse & clarify the source input into this instance dir.
     # Intentionally run per-instance — clarifier output can drift as
@@ -317,7 +325,7 @@ def _run_pipeline(parent_dir: Path, input_path: Path) -> int:
     if research_input is None:
         return 1
     clarified_path = write_step_output(instance_dir, "research-input-clarified.json", research_input)
-    print(f"  Wrote: {clarified_path}")
+    logger.info(f"  Wrote: {clarified_path}")
 
     # Methodology provenance now lives in pipeline-state.json's 'version'
     # block (package_version + git commit/branch/dirty). The previous
@@ -326,8 +334,8 @@ def _run_pipeline(parent_dir: Path, input_path: Path) -> int:
     # revision produced this run.
 
     # --- Pipeline execution (state-machine-driven) ---
-    print()
-    print(f"=== {instance_dir.name} ===")
+    logger.info("")
+    logger.info(f"=== {instance_dir.name} ===")
 
     event_logger = EventLogger(
         run_id=instance_dir.name,
@@ -348,12 +356,12 @@ def _run_pipeline(parent_dir: Path, input_path: Path) -> int:
         if state.is_complete(step_def.name):
             continue
 
-        print(f"{step_def.display_name}...")
+        logger.info(f"{step_def.display_name}...")
         state.mark_started(step_def.name)
         result = _dispatch_step(step_def, outputs, client, search_provider, event_logger, instance_dir)
         if result is None:
             state.mark_failed(step_def.name, diagnostics="Handler returned None")
-            print(f"ERROR: {step_def.name} returned no result")
+            logger.info(f"ERROR: {step_def.name} returned no result")
             return 1
 
         # Store the result and write to disk (unless the step wrote its own file)
@@ -361,7 +369,7 @@ def _run_pipeline(parent_dir: Path, input_path: Path) -> int:
             output_key = step_def.output_file.replace(".json", "").replace("-", "_")
             outputs[output_key] = result
             out_path = write_step_output(instance_dir, step_def.output_file, result)
-            print(f"  Wrote: {out_path}")
+            logger.info(f"  Wrote: {out_path}")
 
         state.mark_complete(step_def.name, output_file=step_def.output_file)
 
@@ -369,20 +377,20 @@ def _run_pipeline(parent_dir: Path, input_path: Path) -> int:
     usage_data = client.usage.to_dict()
     usage_path = write_step_output(instance_dir, "usage.json", usage_data)
 
-    print()
-    print(f"Research complete. Output: {instance_dir}")
-    print()
+    logger.info("")
+    logger.info(f"Research complete. Output: {instance_dir}")
+    logger.info("")
     totals = usage_data["totals"]
     cost = totals.get("estimated_cost_usd", 0)
-    print(
+    logger.info(
         f"Usage: {totals['api_calls']} API calls, "
         f"{totals['input_tokens']:,} input + {totals['output_tokens']:,} output "
         f"= {totals['total_tokens']:,} tokens"
     )
-    print(f"  Estimated cost: ${cost:.4f}")
+    logger.info(f"  Estimated cost: ${cost:.4f}")
     if totals["web_search_requests"]:
-        print(f"  Web: {totals['web_search_requests']} searches, {totals['web_fetch_requests']} fetches")
-    print(f"  Details: {usage_path}")
+        logger.info(f"  Web: {totals['web_search_requests']} searches, {totals['web_fetch_requests']} fetches")
+    logger.info(f"  Details: {usage_path}")
 
     return 0
 
@@ -411,7 +419,7 @@ def execute(input_file: str, output: str) -> int:
     input_path = Path(input_file)
 
     if not input_path.exists():
-        print(f"ERROR: Input file not found: {input_path}")
+        logger.info(f"ERROR: Input file not found: {input_path}")
         return 1
 
     # Refuse to silently reuse an existing research container. Directing
@@ -419,8 +427,8 @@ def execute(input_file: str, output: str) -> int:
     # always establishes a new research definition from an explicit
     # input file.
     if parent_dir.exists() and any(parent_dir.iterdir()):
-        print(f"ERROR: --output {parent_dir} already exists and is not empty.")
-        print(
+        logger.info(f"ERROR: --output {parent_dir} already exists and is not empty.")
+        logger.info(
             "  Use 'dio rerun --output "
             f"{parent_dir}' to add a new instance to existing research,\n"
             "  or choose a different --output for a new research definition."
@@ -433,8 +441,8 @@ def execute(input_file: str, output: str) -> int:
     parent_dir.mkdir(parents=True, exist_ok=True)
     src_dest = parent_dir / input_path.name
     shutil.copyfile(input_path, src_dest)
-    print(f"Output directory: {parent_dir}")
-    print(f"  Saved source input: {src_dest}")
+    logger.info(f"Output directory: {parent_dir}")
+    logger.info(f"  Saved source input: {src_dest}")
 
     return _run_pipeline(parent_dir, src_dest)
 
@@ -459,17 +467,17 @@ def execute_rerun(output: str) -> int:
     parent_dir = Path(output)
 
     if not parent_dir.exists():
-        print(f"ERROR: --output {parent_dir} does not exist.")
-        print("  'dio rerun' requires a parent populated by a prior 'dio run'.")
+        logger.info(f"ERROR: --output {parent_dir} does not exist.")
+        logger.info("  'dio rerun' requires a parent populated by a prior 'dio run'.")
         return 1
 
     input_path = _find_saved_input(parent_dir)
     if input_path is None:
-        print(f"ERROR: Could not locate a single source input in {parent_dir}.")
-        print("  Expected exactly one regular file (the input copied by 'dio run').")
+        logger.info(f"ERROR: Could not locate a single source input in {parent_dir}.")
+        logger.info("  Expected exactly one regular file (the input copied by 'dio run').")
         return 1
 
-    print(f"Output directory: {parent_dir}")
-    print(f"  Using saved source input: {input_path}")
+    logger.info(f"Output directory: {parent_dir}")
+    logger.info(f"  Using saved source input: {input_path}")
 
     return _run_pipeline(parent_dir, input_path)

--- a/src/diogenes/logger.py
+++ b/src/diogenes/logger.py
@@ -1,0 +1,87 @@
+"""Progress logging for Diogenes CLI and pipeline.
+
+Replaces ad-hoc ``print()`` calls with a configured :mod:`logging` setup:
+an INFO-level logger named ``diogenes`` that fans out to a persistent
+progress log file inside the run's instance directory, and — when stdout
+is a terminal — also to stdout for interactive feedback.
+
+Per-module callers stay simple:
+
+    import logging
+
+    logger = logging.getLogger(__name__)
+    logger.info("Fetching sources...")
+
+The module doing the logging has no idea whether output lands in a
+terminal, a log file, or both. The handler setup in :func:`configure_progress_logger`
+owns that decision, driven by the presence of a TTY at run start.
+
+Two handlers, two formats:
+
+- **File handler**: a small timestamp prefix (``HH:MM:SS``) so a persistent
+  log can be read later without guessing at order or cadence. Always
+  attached.
+- **Stdout handler**: no prefix, matching the bare-print cadence that
+  existed before this module. Only attached when :func:`sys.stdout.isatty`
+  reports a terminal, so piped / backgrounded / CI invocations don't mix
+  logging into pipeline output streams.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path  # noqa: TC003 — needed at runtime for path operations
+
+_LOGGER_NAME = "diogenes"
+_FILE_FORMAT = "%(asctime)s %(message)s"
+_STDOUT_FORMAT = "%(message)s"
+_TIME_FORMAT = "%H:%M:%S"
+
+
+def configure_progress_logger(
+    log_path: Path,
+    *,
+    tee_to_stdout: bool | None = None,
+) -> logging.Logger:
+    """Configure the Diogenes progress logger for a single run.
+
+    Args:
+        log_path: Where the persistent progress log should be written.
+            Parent directory must already exist. Opened in append mode so
+            a resumed run extends the file instead of truncating it.
+        tee_to_stdout: If None (default), check :func:`sys.stdout.isatty`
+            and mirror to stdout only when a terminal is present. Pass
+            True or False to override (useful for tests and for
+            ``--tee``-style CLI flags if ever added).
+
+    Returns:
+        The configured ``diogenes`` logger. Callers typically don't need
+        this — ``logging.getLogger(__name__)`` on any ``diogenes.*``
+        module propagates up to it.
+
+    """
+    logger = logging.getLogger(_LOGGER_NAME)
+    logger.setLevel(logging.INFO)
+    # Stop logs from bubbling to the root logger — that would double-print
+    # in environments where root has a handler (pytest, ipython, etc.).
+    logger.propagate = False
+    # Idempotent setup: remove any handlers from a prior run in the same
+    # process (e.g., two invocations inside one MCP server lifetime).
+    for h in list(logger.handlers):
+        logger.removeHandler(h)
+        h.close()
+
+    file_handler = logging.FileHandler(log_path, mode="a", encoding="utf-8")
+    file_handler.setFormatter(logging.Formatter(_FILE_FORMAT, datefmt=_TIME_FORMAT))
+    logger.addHandler(file_handler)
+
+    if tee_to_stdout is None:
+        tee_to_stdout = sys.stdout.isatty()
+
+    if tee_to_stdout:
+        stdout_handler = logging.StreamHandler(sys.stdout)
+        stdout_handler.setFormatter(logging.Formatter(_STDOUT_FORMAT))
+        logger.addHandler(stdout_handler)
+
+    return logger

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -8,6 +8,7 @@ The coordinator (run command) calls these in sequence.
 from __future__ import annotations
 
 import json
+import logging
 import re
 from datetime import UTC, datetime
 from pathlib import Path
@@ -19,6 +20,8 @@ from diogenes.search import SearchProvider, execute_search_plan, fetch_page_extr
 if TYPE_CHECKING:
     from diogenes.api_client import APIClient
     from diogenes.events import EventLogger
+
+logger = logging.getLogger(__name__)
 
 _PROMPTS_DIR = Path(__file__).parent / "prompts" / "sub-agents"
 
@@ -60,7 +63,7 @@ def step2_generate_hypotheses(
 
     for claim in claims:
         item_id = claim["id"]
-        print(f"  Generating hypotheses for {item_id}: {claim['clarified_text'][:60]}...")
+        logger.info(f"  Generating hypotheses for {item_id}: {claim['clarified_text'][:60]}...")
 
         agent_input = {
             "mode": "claim",
@@ -80,7 +83,7 @@ def step2_generate_hypotheses(
 
     for query in queries:
         item_id = query["id"]
-        print(f"  Generating hypotheses for {item_id}: {query['clarified_text'][:60]}...")
+        logger.info(f"  Generating hypotheses for {item_id}: {query['clarified_text'][:60]}...")
 
         agent_input = {
             "mode": "query",
@@ -106,12 +109,12 @@ def _print_hypothesis_summary(item_id: str, response: dict[str, Any]) -> None:
     approach = response.get("approach", "unknown")
     if approach == "hypotheses":
         count = len(response.get("hypotheses", []))
-        print(f"    {item_id}: {count} hypotheses generated")
+        logger.info(f"    {item_id}: {count} hypotheses generated")
     elif approach == "open-ended":
         count = len(response.get("search_themes", []))
-        print(f"    {item_id}: open-ended, {count} search themes")
+        logger.info(f"    {item_id}: open-ended, {count} search themes")
     else:
-        print(f"    {item_id}: approach={approach}")
+        logger.info(f"    {item_id}: approach={approach}")
 
 
 def step3_design_searches(
@@ -145,7 +148,7 @@ def step3_design_searches(
     for item in items:
         item_id = item["id"]
         item_hypotheses = hypotheses.get(item_id, {})
-        print(f"  Designing searches for {item_id}...")
+        logger.info(f"  Designing searches for {item_id}...")
 
         agent_input = {
             "item": item,
@@ -162,7 +165,7 @@ def step3_design_searches(
         results[item_id] = response
         search_count = len(response.get("searches", []))
         approach = response.get("approach", "unknown")
-        print(f"    {item_id}: {search_count} searches planned ({approach})")
+        logger.info(f"    {item_id}: {search_count} searches planned ({approach})")
 
     return results
 
@@ -210,7 +213,7 @@ def step4_execute_searches(
         item_id = item["id"]
         item_plan = search_plans.get(item_id, {})
         searches = item_plan.get("searches", [])
-        print(f"  Executing {len(searches)} searches for {item_id} via {search_provider.name}...")
+        logger.info(f"  Executing {len(searches)} searches for {item_id} via {search_provider.name}...")
 
         # Phase 4A: Python executes searches
         executions = execute_search_plan(
@@ -219,7 +222,7 @@ def step4_execute_searches(
             max_results_per_search=client.pipeline.results_per_search,
         )
         total_results = sum(len(e.results) for e in executions)
-        print(f"    {total_results} raw results from {len(executions)} searches")
+        logger.info(f"    {total_results} raw results from {len(executions)} searches")
 
         # Phase 4B: LLM scores relevance in batches
         all_scored = _score_results_batched(
@@ -231,7 +234,7 @@ def step4_execute_searches(
 
         # Phase 4C: Python filters and deduplicates
         selected, rejected = _filter_and_deduplicate(all_scored, threshold=threshold)
-        print(f"    {len(selected)} sources selected (score >= {threshold}), {len(rejected)} below threshold")
+        logger.info(f"    {len(selected)} sources selected (score >= {threshold}), {len(rejected)} below threshold")
 
         if event_logger and rejected:
             for rej in rejected:
@@ -372,7 +375,7 @@ def _fetch_sources_for_scoring(
     crashes with SIGABRT under thread contention. Each process gets
     its own lxml instance in separate memory — thread-safety irrelevant.
     """
-    print(f"    Fetching {len(selected)} sources ({_FETCH_WORKERS} processes)...")
+    logger.info(f"    Fetching {len(selected)} sources ({_FETCH_WORKERS} processes)...")
     kwargs_list = [{"url": s.get("url", "")} for s in selected]
     results = parallelize_process(
         func=_fetch_single_source,
@@ -403,7 +406,7 @@ def _fetch_sources_for_scoring(
             )
 
     if results.error_count:
-        print(f"    {item_id}: {results.error_count} of {len(selected)} sources dropped due to fetch failures.")
+        logger.info(f"    {item_id}: {results.error_count} of {len(selected)} sources dropped due to fetch failures.")
 
     # Build enriched sources from successful fetches, matching back to
     # original source metadata (title, snippet)
@@ -421,7 +424,7 @@ def _fetch_sources_for_scoring(
             }
         )
 
-    print(f"    {len(enriched_sources)} sources fetched successfully.")
+    logger.info(f"    {len(enriched_sources)} sources fetched successfully.")
     return enriched_sources
 
 
@@ -461,9 +464,9 @@ def step5_score_sources(
         # Cap at top N by relevance score to control cost
         selected = all_selected[:_MAX_SOURCES_TO_SCORE]
         if len(all_selected) > _MAX_SOURCES_TO_SCORE:
-            print(f"  Scoring top {len(selected)} of {len(all_selected)} sources for {item_id}...")
+            logger.info(f"  Scoring top {len(selected)} of {len(all_selected)} sources for {item_id}...")
         else:
-            print(f"  Scoring {len(selected)} sources for {item_id}...")
+            logger.info(f"  Scoring {len(selected)} sources for {item_id}...")
 
         # Phase A: Python fetches page content.
         enriched_sources = _fetch_sources_for_scoring(item_id, selected, event_logger)
@@ -506,7 +509,7 @@ def step5_score_sources(
             if "items" not in sc:
                 sc["items"] = [item_id]
 
-        print(f"    {item_id}: {len(all_scorecards)} sources scored")
+        logger.info(f"    {item_id}: {len(all_scorecards)} sources scored")
         results[item_id] = {"id": item_id, "scorecards": all_scorecards}
 
     return results
@@ -630,7 +633,7 @@ def _extract_evidence_for_item(
         for sc in substantive
     ]
 
-    print(f"    Extracting from {len(substantive)} sources ({_EXTRACT_WORKERS} threads)...")
+    logger.info(f"    Extracting from {len(substantive)} sources ({_EXTRACT_WORKERS} threads)...")
     results = parallelize_thread(
         func=_extract_single_source,
         kwargs_list=kwargs_list,
@@ -661,15 +664,15 @@ def _extract_evidence_for_item(
             )
 
         if res["dropped"]:
-            print(f"      {res['url'][:60]}: {res['kept']} verified / {res['dropped']} dropped")
+            logger.info(f"      {res['url'][:60]}: {res['kept']} verified / {res['dropped']} dropped")
         else:
-            print(f"      {res['url'][:60]}: {res['kept']} packet(s) verified")
+            logger.info(f"      {res['url'][:60]}: {res['kept']} packet(s) verified")
 
     # Log API failures from the parallel run
     for exc in results.exceptions:
         err = f"extractor error: {exc}"
         errors.append(err)
-        print(f"      extractor FAILED: {exc}")
+        logger.info(f"      extractor FAILED: {exc}")
         if event_logger:
             event_logger.log(
                 step="step5b_extract_evidence",
@@ -747,7 +750,7 @@ def step5b_extract_evidence(
         item_scorecards = scorecards.get(item_id, {}).get("scorecards", [])
 
         if not item_scorecards:
-            print(f"  No scorecards for {item_id}; skipping evidence extraction.")
+            logger.info(f"  No scorecards for {item_id}; skipping evidence extraction.")
             results[item_id] = {"id": item_id, "packets": []}
             continue
 
@@ -760,7 +763,7 @@ def step5b_extract_evidence(
             else:
                 substantive.append(sc)
 
-        print(
+        logger.info(
             f"  Extracting evidence for {item_id} "
             f"({len(substantive)} sources, one call each; "
             f"{len(skipped)} skipped for insufficient content)..."
@@ -777,7 +780,7 @@ def step5b_extract_evidence(
                 "packets": [],
                 "extraction_notes": note,
             }
-            print(f"    {item_id}: 0 evidence packets (all sources insufficient)")
+            logger.info(f"    {item_id}: 0 evidence packets (all sources insufficient)")
             continue
 
         aggregated_packets, extractor_errors, verbatim_stats = _extract_evidence_for_item(
@@ -817,7 +820,7 @@ def step5b_extract_evidence(
             response["extraction_notes"] = " ".join(notes_parts)
 
         results[item_id] = response
-        print(f"    {item_id}: {len(aggregated_packets)} evidence packets total")
+        logger.info(f"    {item_id}: {len(aggregated_packets)} evidence packets total")
 
     return results
 
@@ -857,7 +860,7 @@ def steps678_synthesize_and_assess(
         item_hypotheses = hypotheses.get(item_id, {})
         item_scorecards = scorecards.get(item_id, {}).get("scorecards", [])
         item_packets = evidence_packets.get(item_id, {}).get("packets", [])
-        print(f"  Synthesizing {item_id} ({len(item_scorecards)} sources, {len(item_packets)} packets)...")
+        logger.info(f"  Synthesizing {item_id} ({len(item_scorecards)} sources, {len(item_packets)} packets)...")
 
         agent_input = {
             "item": item,
@@ -880,7 +883,7 @@ def steps678_synthesize_and_assess(
         results[item_id] = response
         assessment = response.get("assessment", {})
         verdict = assessment.get("verdict", assessment.get("answer", ""))
-        print(f"    {item_id}: {verdict[:80]}")
+        logger.info(f"    {item_id}: {verdict[:80]}")
 
     return results
 
@@ -918,7 +921,7 @@ def step9_self_audit(
 
     for item in items:
         item_id = item["id"]
-        print(f"  Auditing {item_id}...")
+        logger.info(f"  Auditing {item_id}...")
 
         agent_input = {
             "item": item,
@@ -950,7 +953,7 @@ def step9_self_audit(
             audit.get("evaluation_consistency", {}).get("rating", "?"),
             audit.get("synthesis_fairness", {}).get("rating", "?"),
         ]
-        print(f"    {item_id}: audit [{', '.join(ratings)}]")
+        logger.info(f"    {item_id}: audit [{', '.join(ratings)}]")
 
     return results
 
@@ -991,7 +994,7 @@ def step10_report(
     for item in items:
         item_id = item["id"]
         mode = "claim" if item_id.startswith("C") else "query"
-        print(f"  Assembling report for {item_id} ({mode})...")
+        logger.info(f"  Assembling report for {item_id} ({mode})...")
 
         agent_input = {
             "item": item,
@@ -1021,7 +1024,7 @@ def step10_report(
             "verdict",
             response.get("assessment_summary", {}).get("answer", ""),
         )
-        print(f"    {item_id}: {verdict[:80]}")
+        logger.info(f"    {item_id}: {verdict[:80]}")
 
     return results
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,31 @@
+"""Shared pytest fixtures."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+import pytest
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+
+@pytest.fixture(autouse=True)
+def _reset_diogenes_logger() -> Iterator[None]:
+    """Restore the ``diogenes`` logger to defaults between tests.
+
+    ``configure_progress_logger`` sets ``propagate=False`` and attaches
+    a FileHandler to ``diogenes``. If one test calls it and another test
+    relies on pytest's ``caplog`` to capture records (which attaches at
+    the root logger), the second test will see no output because the
+    propagation chain was cut at ``diogenes``. Resetting after each test
+    keeps logger state test-local.
+    """
+    yield
+    logger = logging.getLogger("diogenes")
+    for handler in list(logger.handlers):
+        logger.removeHandler(handler)
+        handler.close()
+    logger.propagate = True
+    logger.setLevel(logging.NOTSET)

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -1,0 +1,97 @@
+"""Tests for the progress logger setup."""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+from unittest.mock import MagicMock
+
+from diogenes.logger import configure_progress_logger
+
+if TYPE_CHECKING:
+    import pytest
+
+
+class TestConfigureProgressLogger:
+    """Tests for configure_progress_logger."""
+
+    def test_attaches_file_handler(self, tmp_path: pytest.TempPathFactory) -> None:
+        log_path = tmp_path / "progress.log"  # type: ignore[operator]
+        logger = configure_progress_logger(log_path, tee_to_stdout=False)
+        # Exactly one handler (file); no stdout handler when tee disabled
+        file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+        stream_handlers = [
+            h
+            for h in logger.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]
+        assert len(file_handlers) == 1
+        assert len(stream_handlers) == 0
+
+    def test_tee_adds_stdout_handler(self, tmp_path: pytest.TempPathFactory) -> None:
+        log_path = tmp_path / "progress.log"  # type: ignore[operator]
+        logger = configure_progress_logger(log_path, tee_to_stdout=True)
+        stream_handlers = [
+            h
+            for h in logger.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]
+        assert len(stream_handlers) == 1
+
+    def test_writes_lines_to_file(self, tmp_path: pytest.TempPathFactory) -> None:
+        log_path = tmp_path / "progress.log"  # type: ignore[operator]
+        configure_progress_logger(log_path, tee_to_stdout=False)
+        pipe_logger = logging.getLogger("diogenes.pipeline")
+        pipe_logger.info("hello from a pipeline step")
+        # Flush file handlers
+        for h in logging.getLogger("diogenes").handlers:
+            h.flush()
+        content = log_path.read_text()
+        assert "hello from a pipeline step" in content
+
+    def test_reconfigure_is_idempotent(self, tmp_path: pytest.TempPathFactory) -> None:
+        """Calling configure twice leaves exactly one FileHandler, not two."""
+        log_path = tmp_path / "progress.log"  # type: ignore[operator]
+        configure_progress_logger(log_path, tee_to_stdout=False)
+        configure_progress_logger(log_path, tee_to_stdout=False)
+        logger = logging.getLogger("diogenes")
+        file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
+        assert len(file_handlers) == 1
+
+    def test_auto_detect_tty_true(
+        self,
+        tmp_path: pytest.TempPathFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When tee_to_stdout is None and stdout is a TTY, stdout handler attaches."""
+        fake_stdout = MagicMock()
+        fake_stdout.isatty.return_value = True
+        monkeypatch.setattr("diogenes.logger.sys.stdout", fake_stdout)
+
+        log_path = tmp_path / "progress.log"  # type: ignore[operator]
+        logger = configure_progress_logger(log_path)
+        stream_handlers = [
+            h
+            for h in logger.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]
+        assert len(stream_handlers) == 1
+
+    def test_auto_detect_tty_false(
+        self,
+        tmp_path: pytest.TempPathFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When tee_to_stdout is None and stdout is not a TTY, no stdout handler."""
+        fake_stdout = MagicMock()
+        fake_stdout.isatty.return_value = False
+        monkeypatch.setattr("diogenes.logger.sys.stdout", fake_stdout)
+
+        log_path = tmp_path / "progress.log"  # type: ignore[operator]
+        logger = configure_progress_logger(log_path)
+        stream_handlers = [
+            h
+            for h in logger.handlers
+            if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.FileHandler)
+        ]
+        assert len(stream_handlers) == 0

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -250,17 +250,20 @@ class TestFetchSourcesForScoring:
 class TestPrintHypothesisSummary:
     """Tests for _print_hypothesis_summary."""
 
-    def test_hypotheses_approach(self, capsys: pytest.CaptureFixture[str]) -> None:
-        _print_hypothesis_summary("Q001", {"approach": "hypotheses", "hypotheses": [1, 2, 3]})
-        assert "3 hypotheses" in capsys.readouterr().out
+    def test_hypotheses_approach(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("INFO", logger="diogenes.pipeline"):
+            _print_hypothesis_summary("Q001", {"approach": "hypotheses", "hypotheses": [1, 2, 3]})
+        assert "3 hypotheses" in caplog.text
 
-    def test_open_ended_approach(self, capsys: pytest.CaptureFixture[str]) -> None:
-        _print_hypothesis_summary("Q001", {"approach": "open-ended", "search_themes": [1, 2]})
-        assert "2 search themes" in capsys.readouterr().out
+    def test_open_ended_approach(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("INFO", logger="diogenes.pipeline"):
+            _print_hypothesis_summary("Q001", {"approach": "open-ended", "search_themes": [1, 2]})
+        assert "2 search themes" in caplog.text
 
-    def test_unknown_approach(self, capsys: pytest.CaptureFixture[str]) -> None:
-        _print_hypothesis_summary("Q001", {"approach": "custom"})
-        assert "approach=custom" in capsys.readouterr().out
+    def test_unknown_approach(self, caplog: pytest.LogCaptureFixture) -> None:
+        with caplog.at_level("INFO", logger="diogenes.pipeline"):
+            _print_hypothesis_summary("Q001", {"approach": "custom"})
+        assert "approach=custom" in caplog.text
 
 
 class TestStep2GenerateHypotheses:


### PR DESCRIPTION
## Summary

Ref #104

Pipeline and command code wrote directly to stdout via `print()`. That coupled the library to `sys.stdout`, prevented callers from redirecting output, and forced terminal formatting on non-interactive callers.

- New `diogenes.logger.configure_progress_logger()`:
  - Always attaches a FileHandler writing to the run instances `progress.log`
  - Attaches a stdout StreamHandler only when stdout is a TTY (caller can override with `tee_to_stdout=True/False`)
  - Idempotent — repeat calls replace handlers, not stack them
- `commands/run.py` wires the logger per instance inside `_run_pipeline`
- pipeline.py, commands/run.py, api_client.py all log via `logging.getLogger(__name__)` (76 `print()` calls replaced)
- Ruff T201 (no-print) now enforced across pipeline and commands; kept only for `cli.py` (entry dispatcher prints before the run-scoped logger exists)
- New `tests/conftest.py` autouse fixture resets the `diogenes` logger between tests — `configure_progress_logger()` sets `propagate=False`, which would otherwise silently break caplog-based tests that run afterward

## Test plan

- [x] 526 tests passing
- [x] 100% line + branch coverage maintained
- [x] mypy: no new errors vs develop (99 preexisting, unchanged)
- [x] ruff check + format clean
- [ ] Verify `progress.log` is written inside the instance dir on a live run
- [ ] Verify stdout tee behaves correctly in a real TTY vs redirected-to-file