### PR TITLE
feat: add dio resume for interrupted research runs (#118)

### DIFF
--- a/src/diogenes/cli.py
+++ b/src/diogenes/cli.py
@@ -3,6 +3,7 @@
 Usage:
     dio run <input-file> --output <dir>
     dio rerun --output <dir>
+    dio resume <instance-dir>
     dio fact-check <document> --output <dir>
     dio render <run-dir> --output <dir>
 """
@@ -45,6 +46,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "--output",
         required=True,
         help="Parent output directory previously populated by 'dio run'",
+    )
+
+    # --- dio resume ---
+    resume_parser = subparsers.add_parser(
+        "resume",
+        help="Finish a previously interrupted instance from where it left off",
+    )
+    resume_parser.add_argument(
+        "instance_dir",
+        help="Path to the timestamped instance directory to resume",
     )
 
     # --- dio fact-check ---
@@ -94,6 +105,11 @@ def main() -> int:
         from diogenes.commands.run import execute_rerun
 
         return execute_rerun(args.output)
+
+    if args.command == "resume":
+        from diogenes.commands.run import execute_resume
+
+        return execute_resume(args.instance_dir)
 
     if args.command == "fact-check":
         print(f"dio fact-check: doc={args.document} output={args.output}")

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -1,7 +1,8 @@
-"""Implementations of the 'dio run' and 'dio rerun' commands."""
+"""Implementations of the 'dio run', 'dio rerun', and 'dio resume' commands."""
 
 from __future__ import annotations
 
+import json
 import logging
 import shutil
 import time
@@ -333,7 +334,118 @@ def _run_pipeline(parent_dir: Path, input_path: Path) -> int:
     # prompts are in the git repo, and the version stamp identifies which
     # revision produced this run.
 
-    # --- Pipeline execution (state-machine-driven) ---
+    state = PipelineState(instance_dir)
+
+    # Accumulated step outputs — keyed by output filename stem.
+    # Step 1 (clarify) is done before the loop; seed the outputs.
+    outputs: dict[str, Any] = {"research_input": research_input}
+    state.mark_complete("step_01_research_input_clarified", output_file="research-input-clarified.json")
+
+    return _execute_pipeline_loop(instance_dir, state, outputs, client, search_provider)
+
+
+# Steps whose output files are written by the step itself and not consumed by
+# any downstream handler. These do not need to be loaded back into the
+# `outputs` dict when resuming.
+_SELF_WRITTEN_STEP_NAMES = frozenset({"step_10_archive", "step_11_pipeline_events"})
+
+
+def _load_prior_outputs(instance_dir: Path, state: PipelineState) -> dict[str, Any] | None:
+    """Load step outputs from disk for steps already marked complete.
+
+    Keyed identically to the live pipeline (``research_input``,
+    ``hypotheses``, ``search_plans``, …) so the resumed loop's dispatcher
+    can read prior work without re-executing. Returns None if a step is
+    marked complete in state but its output file is missing — the state
+    file is inconsistent with the directory contents and we refuse to
+    guess which is authoritative.
+    """
+    outputs: dict[str, Any] = {}
+    for step_def in PIPELINE_STEPS:
+        if not state.is_complete(step_def.name):
+            continue
+        if step_def.name in _SELF_WRITTEN_STEP_NAMES:
+            continue
+        if not step_def.output_file:
+            continue
+        out_path = instance_dir / step_def.output_file
+        if not out_path.exists():
+            logger.info(
+                f"ERROR: State claims {step_def.name} complete "
+                f"but {step_def.output_file} is missing from {instance_dir}."
+            )
+            return None
+        key = step_def.output_file.replace(".json", "").replace("-", "_")
+        # research-input-clarified.json → research_input_clarified; the
+        # pipeline's internal key for Step 1 is `research_input`. Normalize.
+        if key == "research_input_clarified":
+            key = "research_input"
+        outputs[key] = json.loads(out_path.read_text())
+    return outputs
+
+
+def _resume_pipeline(instance_dir: Path) -> int:
+    """Execute the pipeline loop against an existing instance directory.
+
+    Reads pipeline-state.json to determine which steps are already complete,
+    hydrates the ``outputs`` dict from their persisted JSON files, and
+    runs the remainder of the state-machine loop. Any step in ``running``
+    or ``failed`` status is retried — partial output files from the prior
+    attempt, if any, are overwritten when the step completes.
+
+    Assumes the previous process for this instance is no longer running.
+    No PID or heartbeat check — if the user resumes over a live run, that
+    is user error.
+    """
+    if not instance_dir.exists():
+        logger.info(f"ERROR: Instance directory {instance_dir} does not exist.")
+        return 1
+
+    state_file = instance_dir / "pipeline-state.json"
+    if not state_file.exists():
+        logger.info(f"ERROR: {state_file} not found.")
+        logger.info("  'dio resume' requires an instance directory produced by a prior 'dio run' or 'dio rerun'.")
+        return 1
+
+    configure_progress_logger(instance_dir / "progress.log")
+    logger.info(f"Resuming: {instance_dir}")
+
+    state = PipelineState(instance_dir)
+    if state.all_complete():
+        logger.info("All steps already complete. Nothing to do.")
+        return 0
+
+    outputs = _load_prior_outputs(instance_dir, state)
+    if outputs is None:
+        return 1
+
+    try:
+        client = APIClient()
+    except SubAgentError as e:
+        logger.info(f"ERROR: {e}")
+        return 1
+
+    search_provider = _create_search_provider()
+    if search_provider is None:
+        return 1
+
+    return _execute_pipeline_loop(instance_dir, state, outputs, client, search_provider)
+
+
+def _execute_pipeline_loop(
+    instance_dir: Path,
+    state: PipelineState,
+    outputs: dict[str, Any],
+    client: APIClient,
+    search_provider: SerperSearchProvider | BraveSearchProvider | GoogleSearchProvider,
+) -> int:
+    """Iterate the canonical step sequence, skipping already-complete steps.
+
+    Shared by ``dio run``, ``dio rerun``, and ``dio resume``. Takes a
+    pre-hydrated ``outputs`` dict and ``PipelineState`` so each caller can
+    decide how to seed state (fresh clarification vs disk-loaded prior
+    outputs).
+    """
     logger.info("")
     logger.info(f"=== {instance_dir.name} ===")
 
@@ -344,14 +456,6 @@ def _run_pipeline(parent_dir: Path, input_path: Path) -> int:
         execution_path="cli",
     )
 
-    state = PipelineState(instance_dir)
-
-    # Accumulated step outputs — keyed by output filename stem.
-    # Step 1 (clarify) is done before the loop; seed the outputs.
-    outputs: dict[str, Any] = {"research_input": research_input}
-    state.mark_complete("step_01_research_input_clarified", output_file="research-input-clarified.json")
-
-    # Iterate the canonical step sequence from the state machine.
     for step_def in PIPELINE_STEPS:
         if state.is_complete(step_def.name):
             continue
@@ -481,3 +585,27 @@ def execute_rerun(output: str) -> int:
     logger.info(f"  Using saved source input: {input_path}")
 
     return _run_pipeline(parent_dir, input_path)
+
+
+def execute_resume(instance_dir: str) -> int:
+    """Execute the ``dio resume`` command — finish a previously interrupted instance.
+
+    Points at a specific timestamped instance directory (not the parent
+    container) and picks up from the first non-complete step as recorded
+    in pipeline-state.json. Prior steps' outputs are read from disk;
+    interrupted (``running``) and ``failed`` steps are re-executed.
+
+    Assumes the prior process driving this instance is no longer alive —
+    there is no PID or heartbeat check. Resuming over a concurrently
+    running instance is user error.
+
+    Args:
+        instance_dir: Path to an instance directory (the timestamped
+            subdirectory under the research container) containing a
+            pipeline-state.json from a prior run.
+
+    Returns:
+        Exit code (0 for success, non-zero for failure).
+
+    """
+    return _resume_pipeline(Path(instance_dir))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -23,6 +23,12 @@ class TestBuildParser:
         assert args.command == "rerun"
         assert args.output == "/path/to/research"
 
+    def test_resume_subcommand(self) -> None:
+        parser = _build_parser()
+        args = parser.parse_args(["resume", "/path/to/research/2026-04-22-120000"])
+        assert args.command == "resume"
+        assert args.instance_dir == "/path/to/research/2026-04-22-120000"
+
     def test_factcheck_subcommand(self) -> None:
         parser = _build_parser()
         args = parser.parse_args(["fact-check", "doc.md", "--output", "out/"])
@@ -51,6 +57,14 @@ class TestMain:
         mock_rerun.return_value = 0
         assert main() == 0
         mock_rerun.assert_called_once_with("/dir")
+
+    @patch("diogenes.commands.run.execute_resume")
+    @patch("diogenes.cli.argparse.ArgumentParser.parse_args")
+    def test_resume_delegates(self, mock_parse: MagicMock, mock_resume: MagicMock) -> None:
+        mock_parse.return_value = MagicMock(command="resume", instance_dir="/dir/2026-04-22-120000")
+        mock_resume.return_value = 0
+        assert main() == 0
+        mock_resume.assert_called_once_with("/dir/2026-04-22-120000")
 
     @patch("diogenes.cli.argparse.ArgumentParser.parse_args")
     def test_factcheck_not_implemented(self, mock_parse: MagicMock) -> None:

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -11,10 +12,12 @@ from diogenes.commands.run import (
     _create_search_provider,
     _dispatch_step,
     _find_saved_input,
+    _load_prior_outputs,
     _parse_and_clarify,
     _timestamp,
     execute,
     execute_rerun,
+    execute_resume,
 )
 from diogenes.events import EventLogger
 from diogenes.state_machine import PIPELINE_STEPS, StepDefinition
@@ -674,3 +677,291 @@ class TestExecuteRerun:
         # Each instance has its own clarified JSON
         new_instance = next(d for d in instance_dirs if d.name != "2026-04-22-100000")
         assert (new_instance / "research-input-clarified.json").exists()
+
+
+def _seed_instance(
+    instance_dir: Path,
+    *,
+    completed_step_files: dict[str, dict[str, Any]],
+    running_step: str | None = None,
+) -> None:
+    """Seed a timestamped instance directory with prior step outputs + state.
+
+    ``completed_step_files`` maps output_file names to the JSON content
+    to write; each such step is marked ``complete`` in pipeline-state.json.
+    ``running_step`` optionally marks one step as still in ``running``
+    status to simulate an interrupted run.
+    """
+    from diogenes.state_machine import PIPELINE_STEPS, PipelineState
+
+    instance_dir.mkdir(parents=True, exist_ok=True)
+    for filename, payload in completed_step_files.items():
+        (instance_dir / filename).write_text(json.dumps(payload))
+
+    state = PipelineState(instance_dir)
+    for step_def in PIPELINE_STEPS:
+        if step_def.output_file and step_def.output_file in completed_step_files:
+            state.mark_complete(step_def.name, output_file=step_def.output_file)
+    if running_step:
+        state.mark_started(running_step)
+
+
+class TestLoadPriorOutputs:
+    """Tests for _load_prior_outputs."""
+
+    def test_loads_completed_outputs(self, tmp_path: pytest.TempPathFactory) -> None:
+        """Each completed step's JSON is loaded under the pipeline's internal key."""
+        from diogenes.state_machine import PipelineState
+
+        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        _seed_instance(
+            instance_dir,
+            completed_step_files={
+                "research-input-clarified.json": {"claims": [], "queries": [{"text": "t"}]},
+                "hypotheses.json": {"Q001": {"approach": "hypotheses"}},
+            },
+        )
+        state = PipelineState(instance_dir)
+        outputs = _load_prior_outputs(instance_dir, state)
+        assert outputs is not None
+        assert "research_input" in outputs
+        assert "hypotheses" in outputs
+        assert outputs["research_input"]["queries"][0]["text"] == "t"
+
+    def test_skips_self_written_steps(self, tmp_path: pytest.TempPathFactory) -> None:
+        """archive.json and pipeline-events.json are not hoisted into outputs."""
+        from diogenes.state_machine import PipelineState
+
+        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        _seed_instance(
+            instance_dir,
+            completed_step_files={
+                "research-input-clarified.json": {"claims": [], "queries": []},
+                "archive.json": {"all": "steps"},
+                "pipeline-events.json": {"events": []},
+            },
+        )
+        state = PipelineState(instance_dir)
+        outputs = _load_prior_outputs(instance_dir, state)
+        assert outputs is not None
+        assert "archive" not in outputs
+        assert "pipeline_events" not in outputs
+
+    def test_missing_output_file_is_inconsistent(self, tmp_path: pytest.TempPathFactory) -> None:
+        """State says complete but file is gone → refuse to guess, return None."""
+        from diogenes.state_machine import PipelineState
+
+        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        _seed_instance(
+            instance_dir,
+            completed_step_files={"research-input-clarified.json": {"claims": [], "queries": []}},
+        )
+        (instance_dir / "research-input-clarified.json").unlink()
+        state = PipelineState(instance_dir)
+        assert _load_prior_outputs(instance_dir, state) is None
+
+    def test_skips_step_without_output_file(
+        self,
+        tmp_path: pytest.TempPathFactory,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Defensive: a completed step with output_file=None is skipped, not a crash.
+
+        PIPELINE_STEPS today has no such step, but StepDefinition permits it
+        and this branch guards against a future step that mutates existing
+        artifacts without creating a new file.
+        """
+        from diogenes.state_machine import PipelineState, StepDefinition
+
+        fake_step = StepDefinition(
+            name="step_fake_no_output",
+            display_name="Fake",
+            output_file=None,
+            category="python_only",
+        )
+        monkeypatch.setattr("diogenes.commands.run.PIPELINE_STEPS", [fake_step])
+
+        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir.mkdir()
+        state = PipelineState(instance_dir)
+        state.mark_complete("step_fake_no_output")
+
+        # _load_prior_outputs walks the patched steps and must skip the
+        # output_file=None step without erroring out.
+        outputs = _load_prior_outputs(instance_dir, state)
+        assert outputs == {}
+
+
+class TestExecuteResume:
+    """Tests for execute_resume."""
+
+    def test_missing_instance_dir(self) -> None:
+        assert execute_resume("/nonexistent/path") == 1
+
+    def test_missing_state_file(self, tmp_path: pytest.TempPathFactory) -> None:
+        """Instance dir exists but no pipeline-state.json → exit 1."""
+        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir.mkdir()
+        assert execute_resume(str(instance_dir)) == 1
+
+    def test_all_steps_complete_is_noop(self, tmp_path: pytest.TempPathFactory) -> None:
+        """Fully complete instance → exit 0 without dispatching anything."""
+        from diogenes.state_machine import PIPELINE_STEPS, PipelineState
+
+        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir.mkdir()
+        state = PipelineState(instance_dir)
+        for step_def in PIPELINE_STEPS:
+            state.mark_complete(step_def.name, output_file=step_def.output_file)
+
+        with patch("diogenes.commands.run._dispatch_step") as mock_dispatch:
+            assert execute_resume(str(instance_dir)) == 0
+            mock_dispatch.assert_not_called()
+
+    def test_inconsistent_state_missing_output(self, tmp_path: pytest.TempPathFactory) -> None:
+        """State says step complete but its output file is missing → exit 1."""
+        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        _seed_instance(
+            instance_dir,
+            completed_step_files={"research-input-clarified.json": {"claims": [], "queries": []}},
+        )
+        (instance_dir / "research-input-clarified.json").unlink()
+        assert execute_resume(str(instance_dir)) == 1
+
+    @patch("diogenes.commands.run.APIClient")
+    def test_api_client_failure(self, mock_cls: MagicMock, tmp_path: pytest.TempPathFactory) -> None:
+        from diogenes.api_client import SubAgentError
+
+        mock_cls.side_effect = SubAgentError("config", "No API key")
+        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        _seed_instance(
+            instance_dir,
+            completed_step_files={"research-input-clarified.json": {"claims": [], "queries": []}},
+        )
+        assert execute_resume(str(instance_dir)) == 1
+
+    @patch("diogenes.commands.run._create_search_provider")
+    @patch("diogenes.commands.run.APIClient")
+    def test_search_provider_failure(
+        self,
+        mock_api: MagicMock,
+        mock_sp: MagicMock,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        mock_api.return_value = MagicMock(model="m")
+        mock_sp.return_value = None
+        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        _seed_instance(
+            instance_dir,
+            completed_step_files={"research-input-clarified.json": {"claims": [], "queries": []}},
+        )
+        assert execute_resume(str(instance_dir)) == 1
+
+    @patch("diogenes.commands.run._dispatch_step")
+    @patch("diogenes.commands.run._parse_and_clarify")
+    @patch("diogenes.commands.run._create_search_provider")
+    @patch("diogenes.commands.run.APIClient")
+    def test_resumes_from_first_incomplete_step(
+        self,
+        mock_api_cls: MagicMock,
+        mock_sp: MagicMock,
+        mock_parse: MagicMock,
+        mock_dispatch: MagicMock,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        """Completed steps are skipped; clarifier is NOT called (no re-parsing)."""
+        mock_client = MagicMock(model="m")
+        mock_client.usage.to_dict.return_value = {
+            "totals": {
+                "api_calls": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "estimated_cost_usd": 0.0,
+                "web_search_requests": 0,
+                "web_fetch_requests": 0,
+            },
+            "per_call": [],
+        }
+        mock_api_cls.return_value = mock_client
+        mock_sp.return_value = MagicMock()
+
+        def dispatch_side_effect(step_def, outputs, client, sp, el, rd):
+            if step_def.name in ("step_10_archive", "step_11_pipeline_events"):
+                return {"_self_written": True}
+            return {"result": "ok"}
+
+        mock_dispatch.side_effect = dispatch_side_effect
+
+        # Seed: steps 1-3 complete on disk; 4-11 remain.
+        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        _seed_instance(
+            instance_dir,
+            completed_step_files={
+                "research-input-clarified.json": {"claims": [], "queries": [{"text": "t"}], "axioms": []},
+                "hypotheses.json": {"Q001": {"approach": "hypotheses"}},
+                "search-plans.json": {"Q001": {"plan": "x"}},
+            },
+        )
+
+        assert execute_resume(str(instance_dir)) == 0
+
+        # Clarifier was NOT called — we read from disk instead.
+        mock_parse.assert_not_called()
+
+        # Dispatch fired only for the 8 remaining steps (step_04 through step_11).
+        dispatched = [c.args[0].name for c in mock_dispatch.call_args_list]
+        assert "step_02_hypotheses" not in dispatched
+        assert "step_03_search_plans" not in dispatched
+        assert dispatched[0] == "step_04_search_results"
+        assert len(dispatched) == 8
+
+    @patch("diogenes.commands.run._dispatch_step")
+    @patch("diogenes.commands.run._create_search_provider")
+    @patch("diogenes.commands.run.APIClient")
+    def test_retries_running_step(
+        self,
+        mock_api_cls: MagicMock,
+        mock_sp: MagicMock,
+        mock_dispatch: MagicMock,
+        tmp_path: pytest.TempPathFactory,
+    ) -> None:
+        """A step left in 'running' status (interrupted) is re-executed."""
+        mock_client = MagicMock(model="m")
+        mock_client.usage.to_dict.return_value = {
+            "totals": {
+                "api_calls": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "estimated_cost_usd": 0.0,
+                "web_search_requests": 0,
+                "web_fetch_requests": 0,
+            },
+            "per_call": [],
+        }
+        mock_api_cls.return_value = mock_client
+        mock_sp.return_value = MagicMock()
+
+        def dispatch_side_effect(step_def, outputs, client, sp, el, rd):
+            if step_def.name in ("step_10_archive", "step_11_pipeline_events"):
+                return {"_self_written": True}
+            return {"result": "ok"}
+
+        mock_dispatch.side_effect = dispatch_side_effect
+
+        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        _seed_instance(
+            instance_dir,
+            completed_step_files={
+                "research-input-clarified.json": {"claims": [], "queries": [], "axioms": []},
+                "hypotheses.json": {"Q001": {}},
+            },
+            running_step="step_03_search_plans",
+        )
+
+        assert execute_resume(str(instance_dir)) == 0
+
+        # The interrupted step is the first one re-dispatched.
+        dispatched = [c.args[0].name for c in mock_dispatch.call_args_list]
+        assert dispatched[0] == "step_03_search_plans"


### PR DESCRIPTION
## Summary

Ref #118

New command: `dio resume <instance-dir>` — finishes a previously interrupted research run by picking up at the first non-complete step recorded in `pipeline-state.json`.

- Points at a specific timestamped instance directory (not the parent)
- Reads completed step outputs from disk; does NOT re-call the input clarifier
- Re-executes any step left in `running` (interrupted) or `failed` status
- Refuses inconsistent state: if `pipeline-state.json` claims a step complete but its output file is missing, exits with an error rather than guessing
- No PID/heartbeat check — per the issues recommended simplest design, user asserts the prior process is dead

## Implementation

- Extracted `_execute_pipeline_loop` from `_run_pipeline`; shared by `run`, `rerun`, and `resume`
- `_resume_pipeline` validates the instance dir, loads prior step outputs via `_load_prior_outputs` (skipping self-written archive/events), and hands off to the shared loop
- `dio resume` wired into `cli.py` alongside `run` and `rerun`

## Test plan

- [x] 540 tests passing (+14 new: 4 for `_load_prior_outputs`, 8 for `execute_resume`, 2 for the CLI wiring)
- [x] 100% line + branch coverage maintained
- [x] ruff check + format clean
- [x] mypy: +2 net errors vs develop, matching the pre-existing `dispatch_side_effect` untyped helper pattern
- [ ] Manual verification on a real interrupted run (smoke test)