### PR TITLE
refactor: narrow self-audit to analytical ROBIS domains only (#115)

### DIFF
--- a/ai-research-methodology/skills/research/prompts/compiled/reports.md
+++ b/ai-research-methodology/skills/research/prompts/compiled/reports.md
@@ -606,13 +606,8 @@ Your output MUST conform to this JSON Schema. This is the canonical specificatio
         },
         "domains": {
           "type": "object",
+          "description": "Per-domain rollup for the self-audit section. Eligibility criteria and search comprehensiveness are enforced deterministically by the pipeline (no LLM judgment captured here); only the cross-source analytical domains appear.",
           "properties": {
-            "eligibility_criteria": {
-              "type": "string"
-            },
-            "search_comprehensiveness": {
-              "type": "string"
-            },
             "evaluation_consistency": {
               "type": "string"
             },

--- a/ai-research-methodology/skills/research/prompts/compiled/self-audit.md
+++ b/ai-research-methodology/skills/research/prompts/compiled/self-audit.md
@@ -327,23 +327,26 @@ stage.
 
 ## Task
 
-### Step 9: Self-Audit (ROBIS four domains)
+### Step 9: Self-Audit (ROBIS analytical domains)
 
-Audit the research process against four domains. Rate each Pass /
-Concern / Fail:
+Audit the research process against the two domains that require
+cross-source analytical judgment. Rate each Pass / Concern / Fail:
 
-1. **Eligibility criteria**: Were relevance criteria defined before
-   searching, or did they shift after seeing results?
-2. **Search comprehensiveness**: Was the search broad enough? Did it
-   stop when sufficient evidence was found for one hypothesis?
-3. **Evaluation consistency**: Was the same scoring rigor applied to
+1. **Evaluation consistency**: Was the same scoring rigor applied to
    all sources regardless of whether they supported or contradicted
    the hypothesis?
-4. **Synthesis fairness**: Was all evidence synthesized fairly, or
+2. **Synthesis fairness**: Was all evidence synthesized fairly, or
    were some sources weighted disproportionately?
 
 If any domain rates Concern or Fail, document why and assess the
 impact on conclusions.
+
+**Note on scope:** the other two classical ROBIS domains — eligibility
+criteria and search comprehensiveness — are now enforced
+deterministically by the pipeline itself (fixed relevance threshold,
+canonical step sequence, fetch/score event log in pipeline-events.json).
+An LLM opinion on whether those criteria shifted is less authoritative
+than the recorded data, so they are omitted from this prompt.
 
 ### Step 9b: Source-Back Verification
 
@@ -429,19 +432,12 @@ Your output MUST conform to this JSON Schema. This is the canonical specificatio
   "$defs": {
     "process_audit": {
       "type": "object",
+      "description": "LLM judgment on the two ROBIS domains that require cross-source analytical comparison. The other two classical domains (eligibility criteria, search comprehensiveness) are enforced deterministically by the pipeline and no longer sourced from the LLM.",
       "required": [
-        "eligibility_criteria",
-        "search_comprehensiveness",
         "evaluation_consistency",
         "synthesis_fairness"
       ],
       "properties": {
-        "eligibility_criteria": {
-          "$ref": "#/$defs/audit_domain"
-        },
-        "search_comprehensiveness": {
-          "$ref": "#/$defs/audit_domain"
-        },
         "evaluation_consistency": {
           "$ref": "#/$defs/audit_domain"
         },

--- a/ai-research-methodology/standalone/research.md
+++ b/ai-research-methodology/standalone/research.md
@@ -1054,23 +1054,26 @@ stage.
 
 ## Task
 
-### Step 9: Self-Audit (ROBIS four domains)
+### Step 9: Self-Audit (ROBIS analytical domains)
 
-Audit the research process against four domains. Rate each Pass /
-Concern / Fail:
+Audit the research process against the two domains that require
+cross-source analytical judgment. Rate each Pass / Concern / Fail:
 
-1. **Eligibility criteria**: Were relevance criteria defined before
-   searching, or did they shift after seeing results?
-2. **Search comprehensiveness**: Was the search broad enough? Did it
-   stop when sufficient evidence was found for one hypothesis?
-3. **Evaluation consistency**: Was the same scoring rigor applied to
+1. **Evaluation consistency**: Was the same scoring rigor applied to
    all sources regardless of whether they supported or contradicted
    the hypothesis?
-4. **Synthesis fairness**: Was all evidence synthesized fairly, or
+2. **Synthesis fairness**: Was all evidence synthesized fairly, or
    were some sources weighted disproportionately?
 
 If any domain rates Concern or Fail, document why and assess the
 impact on conclusions.
+
+**Note on scope:** the other two classical ROBIS domains — eligibility
+criteria and search comprehensiveness — are now enforced
+deterministically by the pipeline itself (fixed relevance threshold,
+canonical step sequence, fetch/score event log in pipeline-events.json).
+An LLM opinion on whether those criteria shifted is less authoritative
+than the recorded data, so they are omitted from this prompt.
 
 ### Step 9b: Source-Back Verification
 

--- a/src/diogenes/pipeline.py
+++ b/src/diogenes/pipeline.py
@@ -948,8 +948,6 @@ def step9_self_audit(
         results[item_id] = response
         audit = response.get("process_audit", {})
         ratings = [
-            audit.get("eligibility_criteria", {}).get("rating", "?"),
-            audit.get("search_comprehensiveness", {}).get("rating", "?"),
             audit.get("evaluation_consistency", {}).get("rating", "?"),
             audit.get("synthesis_fairness", {}).get("rating", "?"),
         ]

--- a/src/diogenes/prompts/sub-agents/self-audit.md
+++ b/src/diogenes/prompts/sub-agents/self-audit.md
@@ -38,23 +38,26 @@ stage.
 
 ## Task
 
-### Step 9: Self-Audit (ROBIS four domains)
+### Step 9: Self-Audit (ROBIS analytical domains)
 
-Audit the research process against four domains. Rate each Pass /
-Concern / Fail:
+Audit the research process against the two domains that require
+cross-source analytical judgment. Rate each Pass / Concern / Fail:
 
-1. **Eligibility criteria**: Were relevance criteria defined before
-   searching, or did they shift after seeing results?
-2. **Search comprehensiveness**: Was the search broad enough? Did it
-   stop when sufficient evidence was found for one hypothesis?
-3. **Evaluation consistency**: Was the same scoring rigor applied to
+1. **Evaluation consistency**: Was the same scoring rigor applied to
    all sources regardless of whether they supported or contradicted
    the hypothesis?
-4. **Synthesis fairness**: Was all evidence synthesized fairly, or
+2. **Synthesis fairness**: Was all evidence synthesized fairly, or
    were some sources weighted disproportionately?
 
 If any domain rates Concern or Fail, document why and assess the
 impact on conclusions.
+
+**Note on scope:** the other two classical ROBIS domains — eligibility
+criteria and search comprehensiveness — are now enforced
+deterministically by the pipeline itself (fixed relevance threshold,
+canonical step sequence, fetch/score event log in pipeline-events.json).
+An LLM opinion on whether those criteria shifted is less authoritative
+than the recorded data, so they are omitted from this prompt.
 
 ### Step 9b: Source-Back Verification
 

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -1199,23 +1199,21 @@ def _write_self_audit(item_dir: Path, audit: dict[str, Any], report: dict[str, A
     item_for_title = {"id": audit.get("id", "?")}
     lines = [f"# {_subpage_title(item_for_title, report, 'Self-Audit')}", ""]
 
-    # CLI format: process_audit with named domains
+    # CLI format: process_audit with named domains. Eligibility and
+    # search comprehensiveness are enforced deterministically by the
+    # pipeline (not rated here); only the cross-source analytical
+    # domains appear.
     process = audit.get("process_audit", {})
     if isinstance(process, dict) and process:
         lines.extend(
             [
-                "## Process Audit (ROBIS 4 Domains)",
+                "## Process Audit (Analytical Domains)",
                 "",
                 "| Domain | Rating | Rationale |",
                 "|--------|--------|-----------|",
             ]
         )
-        for domain_key in (
-            "eligibility_criteria",
-            "search_comprehensiveness",
-            "evaluation_consistency",
-            "synthesis_fairness",
-        ):
+        for domain_key in ("evaluation_consistency", "synthesis_fairness"):
             d = process.get(domain_key, {})
             if isinstance(d, dict):
                 rating = d.get("rating", "—")

--- a/src/diogenes/schemas/reports.schema.json
+++ b/src/diogenes/schemas/reports.schema.json
@@ -224,13 +224,8 @@
         },
         "domains": {
           "type": "object",
+          "description": "Per-domain rollup for the self-audit section. Eligibility criteria and search comprehensiveness are enforced deterministically by the pipeline (no LLM judgment captured here); only the cross-source analytical domains appear.",
           "properties": {
-            "eligibility_criteria": {
-              "type": "string"
-            },
-            "search_comprehensiveness": {
-              "type": "string"
-            },
             "evaluation_consistency": {
               "type": "string"
             },

--- a/src/diogenes/schemas/self-audit.schema.json
+++ b/src/diogenes/schemas/self-audit.schema.json
@@ -32,19 +32,12 @@
   "$defs": {
     "process_audit": {
       "type": "object",
+      "description": "LLM judgment on the two ROBIS domains that require cross-source analytical comparison. The other two classical domains (eligibility criteria, search comprehensiveness) are enforced deterministically by the pipeline and no longer sourced from the LLM.",
       "required": [
-        "eligibility_criteria",
-        "search_comprehensiveness",
         "evaluation_consistency",
         "synthesis_fairness"
       ],
       "properties": {
-        "eligibility_criteria": {
-          "$ref": "#/$defs/audit_domain"
-        },
-        "search_comprehensiveness": {
-          "$ref": "#/$defs/audit_domain"
-        },
         "evaluation_consistency": {
           "$ref": "#/$defs/audit_domain"
         },

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -3235,7 +3235,7 @@ class TestRendererDefensiveGuards:
         assert result == {}
 
     def test_write_self_audit_process_non_dict_domain(self, tmp_path: pytest.TempPathFactory) -> None:
-        """Cover 1240->1233: process_audit domain value is not a dict."""
+        """Cover the `not a dict` skip branch in the process_audit domain loop."""
         from diogenes.renderer import _write_self_audit
 
         item_dir = tmp_path / "item"
@@ -3243,13 +3243,13 @@ class TestRendererDefensiveGuards:
         audit = {
             "id": "C001",
             "process_audit": {
-                "eligibility_criteria": "not a dict",  # Skip this one
-                "search_comprehensiveness": {"rating": "Pass"},  # Include this one
+                "evaluation_consistency": "not a dict",  # Skip this one
+                "synthesis_fairness": {"rating": "Pass"},  # Include this one
             },
         }
         _write_self_audit(item_dir, audit, {})
         content = (item_dir / "self-audit.md").read_text()
-        assert "Search Comprehensiveness" in content
+        assert "Synthesis Fairness" in content
 
     def test_write_assessment_gaps_non_list_non_dict(self, tmp_path: pytest.TempPathFactory) -> None:
         """Cover 1190->1208: gaps is truthy but neither list nor dict.


### PR DESCRIPTION
## Summary

Ref #115

Two of the four classical ROBIS domains are now enforced deterministically by the pipeline rather than by LLM judgment:

- **Eligibility criteria**: the relevance threshold is a Python constant applied uniformly — it cannot shift.
- **Search comprehensiveness**: `pipeline-events.json` records exactly how many searches ran, how many results were capped or rejected, and how many sources were fetched/scored. An LLM opinion on comprehensiveness is less authoritative than that recorded data.

The self-audit prompt and schema now only ask the LLM about the two domains that genuinely require cross-source analytical judgment (`evaluation_consistency` and `synthesis_fairness`), plus source-back verification (9b) and the reading list (9c).

## Changes

- **Prompt** (`self-audit.md`): drops Steps 9.1 and 9.2; adds a note explaining where the omitted domains are enforced instead.
- **Schemas** (`self-audit.schema.json`, `reports.schema.json`): drop `eligibility_criteria` and `search_comprehensiveness` keys.
- **Pipeline** (`pipeline.py` step 9 log, `renderer.py` `_write_self_audit`): drop the two removed keys from output. Renderer heading becomes "Process Audit (Analytical Domains)".
- Renderer still silently ignores extra domain keys in old on-disk `self-audit.json` files (forward-compat for prior runs).
- Compiled prompts regenerated via `scripts/compile-prompts.py`.

## Test plan

- [x] 540 tests passing, 100% line + branch coverage maintained
- [x] ruff check + format clean
- [x] mypy: 101 errors, same count as develop — no new errors
- [ ] Next smoke run produces a schema-valid self-audit.json with only the two domains