### PR TITLE
ci: enforce mypy on tests; fix 101 pre-existing errors (#147)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
         run: uv sync --frozen --group dev
 
       - name: Run mypy
-        run: uv run mypy src/
+        run: uv run mypy src tests
 
   dependency-audit:
     name: "ci: dependency-audit"

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,6 +1,8 @@
 """Tests for api_client module."""
 
 import json
+from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -227,7 +229,7 @@ class TestStripToSchema:
         assert len(stripped) == 1
 
     def test_non_dict_data(self) -> None:
-        schema = {"properties": {"x": {}}}
+        schema: dict[str, Any] = {"properties": {"x": {}}}
         stripped = _strip_to_schema("not a dict", schema)
         assert stripped == []
 
@@ -325,15 +327,15 @@ class TestAPIClient:
     def _make_config(self) -> DioConfig:
         return DioConfig(api_key="test-key")
 
-    def test_init_with_config(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_init_with_config(self, tmp_path: Path) -> None:
         cfg = self._make_config()
         # Create a guidelines file so it can be loaded
-        guidelines = tmp_path / "guidelines.md"  # type: ignore[operator]
+        guidelines = tmp_path / "guidelines.md"
         guidelines.write_text("# Guidelines\nBe nice.")
         client = APIClient(config=cfg, guidelines_path=guidelines)
         assert client.model == "claude-sonnet-4-6"
 
-    def test_init_no_config_raises(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    def test_init_no_config_raises(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         for var in ("SERPER_API_KEY", "BRAVE_API_KEY", "GOOGLE_API_KEY", "GOOGLE_SEARCH_ENGINE_ID"):
             monkeypatch.delenv(var, raising=False)
@@ -407,7 +409,7 @@ class TestAPIClient:
             )
 
     @patch("diogenes.api_client.anthropic.Anthropic")
-    def test_call_sub_agent_success(self, mock_anthropic_cls: MagicMock, tmp_path: pytest.TempPathFactory) -> None:
+    def test_call_sub_agent_success(self, mock_anthropic_cls: MagicMock, tmp_path: Path) -> None:
         # Set up mock
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -428,7 +430,7 @@ class TestAPIClient:
         mock_client.messages.create.return_value = mock_response
 
         # Create prompt file
-        prompt = tmp_path / "test-prompt.md"  # type: ignore[operator]
+        prompt = tmp_path / "test-prompt.md"
         prompt.write_text("# Test Prompt\nDo stuff.")
 
         cfg = self._make_config()
@@ -439,9 +441,7 @@ class TestAPIClient:
         assert len(client.usage.calls) == 1
 
     @patch("diogenes.api_client.anthropic.Anthropic")
-    def test_call_sub_agent_with_dict_input(
-        self, mock_anthropic_cls: MagicMock, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    def test_call_sub_agent_with_dict_input(self, mock_anthropic_cls: MagicMock, tmp_path: Path) -> None:
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
 
@@ -459,7 +459,7 @@ class TestAPIClient:
         mock_response.content = [mock_block]
         mock_client.messages.create.return_value = mock_response
 
-        prompt = tmp_path / "prompt.md"  # type: ignore[operator]
+        prompt = tmp_path / "prompt.md"
         prompt.write_text("Prompt")
 
         cfg = self._make_config()
@@ -468,7 +468,7 @@ class TestAPIClient:
         assert result == {"ok": True}
 
     @patch("diogenes.api_client.anthropic.Anthropic")
-    def test_call_sub_agent_api_error(self, mock_anthropic_cls: MagicMock, tmp_path: pytest.TempPathFactory) -> None:
+    def test_call_sub_agent_api_error(self, mock_anthropic_cls: MagicMock, tmp_path: Path) -> None:
         import anthropic
 
         mock_client = MagicMock()
@@ -479,7 +479,7 @@ class TestAPIClient:
             body=None,
         )
 
-        prompt = tmp_path / "prompt.md"  # type: ignore[operator]
+        prompt = tmp_path / "prompt.md"
         prompt.write_text("Prompt")
 
         cfg = self._make_config()
@@ -488,9 +488,7 @@ class TestAPIClient:
             client.call_sub_agent(prompt_path=prompt, user_input="test")
 
     @patch("diogenes.api_client.anthropic.Anthropic")
-    def test_call_sub_agent_empty_response(
-        self, mock_anthropic_cls: MagicMock, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    def test_call_sub_agent_empty_response(self, mock_anthropic_cls: MagicMock, tmp_path: Path) -> None:
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
 
@@ -505,7 +503,7 @@ class TestAPIClient:
         mock_response.content = []  # No content blocks
         mock_client.messages.create.return_value = mock_response
 
-        prompt = tmp_path / "prompt.md"  # type: ignore[operator]
+        prompt = tmp_path / "prompt.md"
         prompt.write_text("Prompt")
 
         cfg = self._make_config()
@@ -514,7 +512,7 @@ class TestAPIClient:
             client.call_sub_agent(prompt_path=prompt, user_input="test")
 
     @patch("diogenes.api_client.anthropic.Anthropic")
-    def test_call_sub_agent_with_schema(self, mock_anthropic_cls: MagicMock, tmp_path: pytest.TempPathFactory) -> None:
+    def test_call_sub_agent_with_schema(self, mock_anthropic_cls: MagicMock, tmp_path: Path) -> None:
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
 
@@ -534,7 +532,7 @@ class TestAPIClient:
         mock_response.content = [mock_block]
         mock_client.messages.create.return_value = mock_response
 
-        prompt = tmp_path / "prompt.md"  # type: ignore[operator]
+        prompt = tmp_path / "prompt.md"
         prompt.write_text("Prompt")
 
         cfg = self._make_config()
@@ -547,13 +545,11 @@ class TestAPIClient:
         assert "queries" in result
 
     @patch("diogenes.api_client.anthropic.Anthropic")
-    def test_call_sub_agent_schema_not_found(
-        self, mock_anthropic_cls: MagicMock, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    def test_call_sub_agent_schema_not_found(self, mock_anthropic_cls: MagicMock, tmp_path: Path) -> None:
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
 
-        prompt = tmp_path / "prompt.md"  # type: ignore[operator]
+        prompt = tmp_path / "prompt.md"
         prompt.write_text("Prompt")
 
         cfg = self._make_config()
@@ -566,9 +562,7 @@ class TestAPIClient:
             )
 
     @patch("diogenes.api_client.anthropic.Anthropic")
-    def test_call_sub_agent_with_guidelines(
-        self, mock_anthropic_cls: MagicMock, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    def test_call_sub_agent_with_guidelines(self, mock_anthropic_cls: MagicMock, tmp_path: Path) -> None:
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
 
@@ -586,9 +580,9 @@ class TestAPIClient:
         mock_response.content = [mock_block]
         mock_client.messages.create.return_value = mock_response
 
-        prompt = tmp_path / "prompt.md"  # type: ignore[operator]
+        prompt = tmp_path / "prompt.md"
         prompt.write_text("Prompt")
-        guidelines = tmp_path / "guidelines.md"  # type: ignore[operator]
+        guidelines = tmp_path / "guidelines.md"
         guidelines.write_text("# Guidelines")
 
         cfg = self._make_config()
@@ -602,9 +596,7 @@ class TestAPIClient:
         assert len(system_blocks) == 2  # guidelines + prompt
 
     @patch("diogenes.api_client.anthropic.Anthropic")
-    def test_call_sub_agent_no_guidelines(
-        self, mock_anthropic_cls: MagicMock, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    def test_call_sub_agent_no_guidelines(self, mock_anthropic_cls: MagicMock, tmp_path: Path) -> None:
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
 
@@ -622,7 +614,7 @@ class TestAPIClient:
         mock_response.content = [mock_block]
         mock_client.messages.create.return_value = mock_response
 
-        prompt = tmp_path / "prompt.md"  # type: ignore[operator]
+        prompt = tmp_path / "prompt.md"
         prompt.write_text("Prompt")
 
         cfg = self._make_config()
@@ -634,9 +626,7 @@ class TestAPIClient:
         assert len(system_blocks) == 1  # prompt only
 
     @patch("diogenes.api_client.anthropic.Anthropic")
-    def test_call_sub_agent_with_web_search(
-        self, mock_anthropic_cls: MagicMock, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    def test_call_sub_agent_with_web_search(self, mock_anthropic_cls: MagicMock, tmp_path: Path) -> None:
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
 
@@ -656,7 +646,7 @@ class TestAPIClient:
         mock_response.content = [mock_block]
         mock_client.messages.create.return_value = mock_response
 
-        prompt = tmp_path / "prompt.md"  # type: ignore[operator]
+        prompt = tmp_path / "prompt.md"
         prompt.write_text("Prompt")
 
         cfg = self._make_config()
@@ -668,9 +658,7 @@ class TestAPIClient:
         assert client.usage.total_web_searches == 3
 
     @patch("diogenes.api_client.anthropic.Anthropic")
-    def test_call_sub_agent_schema_strip_and_validate(
-        self, mock_anthropic_cls: MagicMock, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    def test_call_sub_agent_schema_strip_and_validate(self, mock_anthropic_cls: MagicMock, tmp_path: Path) -> None:
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
 
@@ -696,7 +684,7 @@ class TestAPIClient:
         mock_response.content = [mock_block]
         mock_client.messages.create.return_value = mock_response
 
-        prompt = tmp_path / "prompt.md"  # type: ignore[operator]
+        prompt = tmp_path / "prompt.md"
         prompt.write_text("Prompt")
 
         cfg = self._make_config()
@@ -710,9 +698,7 @@ class TestAPIClient:
         assert "extra_field" not in result
 
     @patch("diogenes.api_client.anthropic.Anthropic")
-    def test_call_sub_agent_skips_non_text_blocks(
-        self, mock_anthropic_cls: MagicMock, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    def test_call_sub_agent_skips_non_text_blocks(self, mock_anthropic_cls: MagicMock, tmp_path: Path) -> None:
         """Covers branch 485->484: response contains non-text blocks."""
         mock_client = MagicMock()
         mock_anthropic_cls.return_value = mock_client
@@ -735,7 +721,7 @@ class TestAPIClient:
         mock_response.content = [tool_block, text_block]
         mock_client.messages.create.return_value = mock_response
 
-        prompt = tmp_path / "prompt.md"  # type: ignore[operator]
+        prompt = tmp_path / "prompt.md"
         prompt.write_text("Prompt")
 
         cfg = self._make_config()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 """Tests for cli module."""
 
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -85,10 +86,10 @@ class TestMain:
         mock_execute.assert_called_once_with("input.json", "out/")
 
     @patch("diogenes.cli.argparse.ArgumentParser.parse_args")
-    def test_render_dispatches(self, mock_parse: MagicMock, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run"  # type: ignore[operator]
+    def test_render_dispatches(self, mock_parse: MagicMock, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run"
         run_dir.mkdir()
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
 
         args = MagicMock(spec=["command", "input_dir", "output"])
         args.command = "render"

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -38,96 +38,96 @@ class TestTimestamp:
 class TestCreateInstanceDir:
     """Tests for _create_instance_dir."""
 
-    def test_creates_unique_dir(self, tmp_path: pytest.TempPathFactory) -> None:
-        parent = tmp_path  # type: ignore[assignment]
-        instance = _create_instance_dir(parent)  # type: ignore[arg-type]
+    def test_creates_unique_dir(self, tmp_path: Path) -> None:
+        parent = tmp_path
+        instance = _create_instance_dir(parent)
         assert instance.exists()
         assert instance.parent == parent
         # Directory name is a timestamp
         assert len(instance.name) == 17
 
-    def test_collision_retry(self, tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_collision_retry(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """If the first timestamp collides, sleep and retry with a later stamp."""
         # Pre-create a collision at the first timestamp we'll generate
         from diogenes.commands import run as run_mod
 
         ts1 = "2026-04-22-120000"
         ts2 = "2026-04-22-120001"
-        (tmp_path / ts1).mkdir()  # type: ignore[operator]
+        (tmp_path / ts1).mkdir()
 
         stamps = iter([ts1, ts2])
         monkeypatch.setattr(run_mod, "_timestamp", lambda: next(stamps))
         # Patch sleep so the test runs fast
-        monkeypatch.setattr(run_mod.time, "sleep", lambda _s: None)
+        monkeypatch.setattr("time.sleep", lambda _s: None)
 
-        instance = _create_instance_dir(tmp_path)  # type: ignore[arg-type]
+        instance = _create_instance_dir(tmp_path)
         assert instance.name == ts2
 
-    def test_exhausts_retries_raises(self, tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_exhausts_retries_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         """If every retry hits a collision, raise RuntimeError."""
         from diogenes.commands import run as run_mod
 
         ts = "2026-04-22-120000"
-        (tmp_path / ts).mkdir()  # type: ignore[operator]
+        (tmp_path / ts).mkdir()
 
         monkeypatch.setattr(run_mod, "_timestamp", lambda: ts)
-        monkeypatch.setattr(run_mod.time, "sleep", lambda _s: None)
+        monkeypatch.setattr("time.sleep", lambda _s: None)
 
         with pytest.raises(RuntimeError, match="unique instance dir"):
-            _create_instance_dir(tmp_path)  # type: ignore[arg-type]
+            _create_instance_dir(tmp_path)
 
 
 class TestFindSavedInput:
     """Tests for _find_saved_input."""
 
-    def test_single_file_found(self, tmp_path: pytest.TempPathFactory) -> None:
-        (tmp_path / "input.md").write_text("content")  # type: ignore[operator]
-        result = _find_saved_input(tmp_path)  # type: ignore[arg-type]
+    def test_single_file_found(self, tmp_path: Path) -> None:
+        (tmp_path / "input.md").write_text("content")
+        result = _find_saved_input(tmp_path)
         assert result is not None
         assert result.name == "input.md"
 
-    def test_ignores_subdirectories(self, tmp_path: pytest.TempPathFactory) -> None:
-        (tmp_path / "input.md").write_text("content")  # type: ignore[operator]
-        (tmp_path / "2026-04-22-120000").mkdir()  # type: ignore[operator]
-        result = _find_saved_input(tmp_path)  # type: ignore[arg-type]
+    def test_ignores_subdirectories(self, tmp_path: Path) -> None:
+        (tmp_path / "input.md").write_text("content")
+        (tmp_path / "2026-04-22-120000").mkdir()
+        result = _find_saved_input(tmp_path)
         assert result is not None
         assert result.name == "input.md"
 
-    def test_ignores_hidden_files(self, tmp_path: pytest.TempPathFactory) -> None:
-        (tmp_path / "input.md").write_text("content")  # type: ignore[operator]
-        (tmp_path / ".DS_Store").write_text("")  # type: ignore[operator]
-        result = _find_saved_input(tmp_path)  # type: ignore[arg-type]
+    def test_ignores_hidden_files(self, tmp_path: Path) -> None:
+        (tmp_path / "input.md").write_text("content")
+        (tmp_path / ".DS_Store").write_text("")
+        result = _find_saved_input(tmp_path)
         assert result is not None
         assert result.name == "input.md"
 
-    def test_zero_candidates_returns_none(self, tmp_path: pytest.TempPathFactory) -> None:
-        (tmp_path / "2026-04-22-120000").mkdir()  # type: ignore[operator]
-        assert _find_saved_input(tmp_path) is None  # type: ignore[arg-type]
+    def test_zero_candidates_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "2026-04-22-120000").mkdir()
+        assert _find_saved_input(tmp_path) is None
 
-    def test_multiple_candidates_returns_none(self, tmp_path: pytest.TempPathFactory) -> None:
-        (tmp_path / "a.md").write_text("content")  # type: ignore[operator]
-        (tmp_path / "b.md").write_text("content")  # type: ignore[operator]
-        assert _find_saved_input(tmp_path) is None  # type: ignore[arg-type]
+    def test_multiple_candidates_returns_none(self, tmp_path: Path) -> None:
+        (tmp_path / "a.md").write_text("content")
+        (tmp_path / "b.md").write_text("content")
+        assert _find_saved_input(tmp_path) is None
 
 
 class TestParseAndClarify:
     """Tests for _parse_and_clarify."""
 
-    def test_json_input(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "input.json"  # type: ignore[operator]
+    def test_json_input(self, tmp_path: Path) -> None:
+        path = tmp_path / "input.json"
         path.write_text(json.dumps({"claims": [{"text": "Test"}], "queries": []}))
         result = _parse_and_clarify(path, MagicMock())
         assert result is not None
         assert "claims" in result
 
-    def test_json_invalid_schema(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "input.json"  # type: ignore[operator]
+    def test_json_invalid_schema(self, tmp_path: Path) -> None:
+        path = tmp_path / "input.json"
         path.write_text(json.dumps({"bad": "schema"}))
         result = _parse_and_clarify(path, MagicMock())
         assert result is None
 
-    def test_text_input(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "input.md"  # type: ignore[operator]
+    def test_text_input(self, tmp_path: Path) -> None:
+        path = tmp_path / "input.md"
         path.write_text("Is AI reliable?")
 
         mock_client = MagicMock()
@@ -139,8 +139,8 @@ class TestParseAndClarify:
         assert result is not None
         assert "queries" in result
 
-    def test_text_input_clarifier_error(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "input.md"  # type: ignore[operator]
+    def test_text_input_clarifier_error(self, tmp_path: Path) -> None:
+        path = tmp_path / "input.md"
         path.write_text("bad input")
 
         mock_client = MagicMock()
@@ -148,10 +148,10 @@ class TestParseAndClarify:
         result = _parse_and_clarify(path, mock_client)
         assert result is None
 
-    def test_text_input_api_failure(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_text_input_api_failure(self, tmp_path: Path) -> None:
         from diogenes.api_client import SubAgentError
 
-        path = tmp_path / "input.md"  # type: ignore[operator]
+        path = tmp_path / "input.md"
         path.write_text("test")
 
         mock_client = MagicMock()
@@ -174,7 +174,7 @@ class TestCreateSearchProvider:
         mock_config.return_value = DioConfig(api_key="key", serper_api_key="skey")
         provider = _create_search_provider()
         assert provider is not None
-        assert provider.name == "serper"  # type: ignore[union-attr]
+        assert provider.name == "serper"
 
     @patch("diogenes.commands.run.load_config")
     def test_brave(self, mock_config: MagicMock) -> None:
@@ -183,7 +183,7 @@ class TestCreateSearchProvider:
         mock_config.return_value = DioConfig(api_key="key", search_provider="brave", brave_api_key="bkey")
         provider = _create_search_provider()
         assert provider is not None
-        assert provider.name == "brave"  # type: ignore[union-attr]
+        assert provider.name == "brave"
 
     @patch("diogenes.commands.run.load_config")
     def test_google(self, mock_config: MagicMock) -> None:
@@ -197,7 +197,7 @@ class TestCreateSearchProvider:
         )
         provider = _create_search_provider()
         assert provider is not None
-        assert provider.name == "google"  # type: ignore[union-attr]
+        assert provider.name == "google"
 
     @patch("diogenes.commands.run.load_config")
     def test_serper_missing_key(self, mock_config: MagicMock) -> None:
@@ -235,22 +235,25 @@ class TestCreateSearchProvider:
 class TestDispatchStep:
     """Tests for _dispatch_step."""
 
-    def _make_context(self, tmp_path: pytest.TempPathFactory) -> tuple:
-        outputs = {"research_input": {"claims": [], "queries": []}}
+    def _make_context(
+        self,
+        tmp_path: Path,
+    ) -> tuple[dict[str, Any], MagicMock, MagicMock, EventLogger, Path]:
+        outputs: dict[str, Any] = {"research_input": {"claims": [], "queries": []}}
         client = MagicMock()
         client.model = "test-model"
         search_provider = MagicMock()
-        event_logger = EventLogger(run_id="test", output_dir=tmp_path)  # type: ignore[arg-type]
-        run_dir = tmp_path  # type: ignore[assignment]
+        event_logger = EventLogger(run_id="test", output_dir=tmp_path)
+        run_dir = tmp_path
         return outputs, client, search_provider, event_logger, run_dir
 
-    def test_step_01_returns_research_input(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_01_returns_research_input(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         step = PIPELINE_STEPS[0]  # step_01
         result = _dispatch_step(step, outputs, client, sp, el, rd)
         assert result == outputs["research_input"]
 
-    def test_step_02_calls_handler(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_02_calls_handler(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         client.call_sub_agent = MagicMock(return_value={"approach": "hypotheses", "hypotheses": []})
         step = PIPELINE_STEPS[1]  # step_02
@@ -258,14 +261,14 @@ class TestDispatchStep:
             result = _dispatch_step(step, outputs, client, sp, el, rd)
         mock.assert_called_once()
 
-    def test_step_10_archive(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_10_archive(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         step = PIPELINE_STEPS[9]  # step_10_archive
         with patch("diogenes.commands.run.step11_archive") as mock:
             result = _dispatch_step(step, outputs, client, sp, el, rd)
         assert result == {"_self_written": True}
 
-    def test_step_11_events(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_11_events(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         step = PIPELINE_STEPS[10]  # step_11_pipeline_events
         with patch(
@@ -275,13 +278,13 @@ class TestDispatchStep:
             result = _dispatch_step(step, outputs, client, sp, el, rd)
         assert result == {"_self_written": True}
 
-    def test_unknown_step(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_unknown_step(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         step = StepDefinition(name="unknown_step", display_name="Unknown", output_file="x.json", category="llm")
         result = _dispatch_step(step, outputs, client, sp, el, rd)
         assert result is None
 
-    def test_step_03_calls_handler(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_03_calls_handler(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         outputs["hypotheses"] = {}
         step = PIPELINE_STEPS[2]  # step_03
@@ -289,7 +292,7 @@ class TestDispatchStep:
             _dispatch_step(step, outputs, client, sp, el, rd)
         mock.assert_called_once()
 
-    def test_step_04_calls_handler(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_04_calls_handler(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         outputs["search_plans"] = {}
         step = PIPELINE_STEPS[3]  # step_04
@@ -297,7 +300,7 @@ class TestDispatchStep:
             _dispatch_step(step, outputs, client, sp, el, rd)
         mock.assert_called_once()
 
-    def test_step_05_calls_handler(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_05_calls_handler(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         outputs["search_results"] = {}
         step = PIPELINE_STEPS[4]  # step_05
@@ -305,7 +308,7 @@ class TestDispatchStep:
             _dispatch_step(step, outputs, client, sp, el, rd)
         mock.assert_called_once()
 
-    def test_step_06_calls_handler(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_06_calls_handler(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         outputs["hypotheses"] = {}
         outputs["scorecards"] = {}
@@ -314,7 +317,7 @@ class TestDispatchStep:
             _dispatch_step(step, outputs, client, sp, el, rd)
         mock.assert_called_once()
 
-    def test_step_07_calls_handler(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_07_calls_handler(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         outputs["hypotheses"] = {}
         outputs["scorecards"] = {}
@@ -324,7 +327,7 @@ class TestDispatchStep:
             _dispatch_step(step, outputs, client, sp, el, rd)
         mock.assert_called_once()
 
-    def test_step_08_calls_handler(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_08_calls_handler(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         outputs["hypotheses"] = {}
         outputs["search_results"] = {}
@@ -336,7 +339,7 @@ class TestDispatchStep:
             _dispatch_step(step, outputs, client, sp, el, rd)
         mock.assert_called_once()
 
-    def test_step_09_calls_handler(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_09_calls_handler(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         outputs["hypotheses"] = {}
         outputs["search_results"] = {}
@@ -348,7 +351,7 @@ class TestDispatchStep:
             _dispatch_step(step, outputs, client, sp, el, rd)
         mock.assert_called_once()
 
-    def test_step_11_events_with_events_logged(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_11_events_with_events_logged(self, tmp_path: Path) -> None:
         """Covers line 186: n_events is nonzero so the print fires."""
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         # Add events to the logger so n_events > 0
@@ -362,7 +365,7 @@ class TestDispatchStep:
             result = _dispatch_step(step, outputs, client, sp, el, rd)
         assert result == {"_self_written": True}
 
-    def test_step_11_no_adherence(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_11_no_adherence(self, tmp_path: Path) -> None:
         outputs, client, sp, el, rd = self._make_context(tmp_path)
         step = PIPELINE_STEPS[10]
         with patch(
@@ -372,7 +375,7 @@ class TestDispatchStep:
             result = _dispatch_step(step, outputs, client, sp, el, rd)
         assert result == {"_self_written": True}
 
-    def test_subagent_error_returns_none(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_subagent_error_returns_none(self, tmp_path: Path) -> None:
         from diogenes.api_client import SubAgentError
 
         outputs, client, sp, el, rd = self._make_context(tmp_path)
@@ -386,13 +389,13 @@ class TestExecute:
     """Tests for execute function."""
 
     @patch("diogenes.commands.run.APIClient")
-    def test_api_client_failure(self, mock_cls: MagicMock, tmp_path: pytest.TempPathFactory) -> None:
+    def test_api_client_failure(self, mock_cls: MagicMock, tmp_path: Path) -> None:
         from diogenes.api_client import SubAgentError
 
         mock_cls.side_effect = SubAgentError("config", "No API key")
-        input_path = tmp_path / "input.json"  # type: ignore[operator]
+        input_path = tmp_path / "input.json"
         input_path.write_text(json.dumps({"claims": [], "queries": [{"text": "t"}]}))
-        output_dir = tmp_path / "output"  # type: ignore[operator]
+        output_dir = tmp_path / "output"
         assert execute(str(input_path), str(output_dir)) == 1
 
     @patch("diogenes.commands.run._create_search_provider")
@@ -401,12 +404,12 @@ class TestExecute:
         self,
         mock_api: MagicMock,
         mock_sp: MagicMock,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
     ) -> None:
         mock_sp.return_value = None
-        input_path = tmp_path / "input.json"  # type: ignore[operator]
+        input_path = tmp_path / "input.json"
         input_path.write_text(json.dumps({"claims": [], "queries": [{"text": "t"}]}))
-        output_dir = tmp_path / "output"  # type: ignore[operator]
+        output_dir = tmp_path / "output"
         assert execute(str(input_path), str(output_dir)) == 1
 
     def _make_input_file(self, tmp_path: Path, name: str = "input.json") -> Path:
@@ -415,7 +418,7 @@ class TestExecute:
         p.write_text(json.dumps({"claims": [], "queries": [{"text": "test"}]}))
         return p
 
-    def _usage_stub(self, *, with_web: bool = False) -> dict:
+    def _usage_stub(self, *, with_web: bool = False) -> dict[str, Any]:
         return {
             "totals": {
                 "api_calls": 1,
@@ -429,20 +432,20 @@ class TestExecute:
             "per_call": [],
         }
 
-    def test_missing_input_file(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_missing_input_file(self, tmp_path: Path) -> None:
         """Refuse to run if --input doesn't exist."""
-        output_dir = tmp_path / "output"  # type: ignore[operator]
+        output_dir = tmp_path / "output"
         result = execute("/nonexistent/input.md", str(output_dir))
         assert result == 1
         # Must not have created the output directory
         assert not output_dir.exists()
 
-    def test_refuses_nonempty_output(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_refuses_nonempty_output(self, tmp_path: Path) -> None:
         """Refuses to silently reuse an existing research container."""
-        output_dir = tmp_path / "output"  # type: ignore[operator]
+        output_dir = tmp_path / "output"
         output_dir.mkdir()
         (output_dir / "existing.txt").write_text("leftover")
-        input_path = self._make_input_file(tmp_path)  # type: ignore[arg-type]
+        input_path = self._make_input_file(tmp_path)
         result = execute(str(input_path), str(output_dir))
         assert result == 1
 
@@ -456,7 +459,7 @@ class TestExecute:
         mock_sp: MagicMock,
         mock_parse: MagicMock,
         mock_dispatch: MagicMock,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
     ) -> None:
         """Happy path: run completes, creates instance dir, copies source, writes clarified in instance."""
         mock_client = MagicMock()
@@ -466,15 +469,22 @@ class TestExecute:
         mock_sp.return_value = MagicMock()
         mock_parse.return_value = {"claims": [], "queries": [{"text": "test"}], "axioms": []}
 
-        def dispatch_side_effect(step_def, outputs, client, sp, el, rd):
+        def dispatch_side_effect(
+            step_def: StepDefinition,
+            outputs: dict[str, Any],
+            client: object,
+            sp: object,
+            el: object,
+            rd: Path,
+        ) -> dict[str, Any]:
             if step_def.name in ("step_10_archive", "step_11_pipeline_events"):
                 return {"_self_written": True}
             return {"result": "ok"}
 
         mock_dispatch.side_effect = dispatch_side_effect
 
-        input_path = self._make_input_file(tmp_path, "input.md")  # type: ignore[arg-type]
-        output_dir = tmp_path / "output"  # type: ignore[operator]
+        input_path = self._make_input_file(tmp_path, "input.md")
+        output_dir = tmp_path / "output"
         result = execute(str(input_path), str(output_dir))
         assert result == 0
 
@@ -499,15 +509,15 @@ class TestExecute:
         mock_sp: MagicMock,
         mock_parse: MagicMock,
         mock_dispatch: MagicMock,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
     ) -> None:
         """If _parse_and_clarify returns None, execute aborts with exit 1."""
         mock_api_cls.return_value = MagicMock(model="m")
         mock_sp.return_value = MagicMock()
         mock_parse.return_value = None
 
-        input_path = self._make_input_file(tmp_path)  # type: ignore[arg-type]
-        output_dir = tmp_path / "output"  # type: ignore[operator]
+        input_path = self._make_input_file(tmp_path)
+        output_dir = tmp_path / "output"
         result = execute(str(input_path), str(output_dir))
         assert result == 1
 
@@ -521,7 +531,7 @@ class TestExecute:
         mock_sp: MagicMock,
         mock_parse: MagicMock,
         mock_dispatch: MagicMock,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
     ) -> None:
         """A dispatch failure causes execute to return 1."""
         mock_api_cls.return_value = MagicMock(model="m")
@@ -529,8 +539,8 @@ class TestExecute:
         mock_parse.return_value = {"claims": [], "queries": [], "axioms": []}
         mock_dispatch.return_value = None
 
-        input_path = self._make_input_file(tmp_path)  # type: ignore[arg-type]
-        output_dir = tmp_path / "output"  # type: ignore[operator]
+        input_path = self._make_input_file(tmp_path)
+        output_dir = tmp_path / "output"
         result = execute(str(input_path), str(output_dir))
         assert result == 1
 
@@ -544,7 +554,7 @@ class TestExecute:
         mock_sp: MagicMock,
         mock_parse: MagicMock,
         mock_dispatch: MagicMock,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
     ) -> None:
         """Exercises the False branch of the web-search totals print."""
         mock_client = MagicMock(model="m")
@@ -553,15 +563,22 @@ class TestExecute:
         mock_sp.return_value = MagicMock()
         mock_parse.return_value = {"claims": [], "queries": [], "axioms": []}
 
-        def dispatch_side_effect(step_def, outputs, client, sp, el, rd):
+        def dispatch_side_effect(
+            step_def: StepDefinition,
+            outputs: dict[str, Any],
+            client: object,
+            sp: object,
+            el: object,
+            rd: Path,
+        ) -> dict[str, Any]:
             if step_def.name in ("step_10_archive", "step_11_pipeline_events"):
                 return {"_self_written": True}
             return {"result": "ok"}
 
         mock_dispatch.side_effect = dispatch_side_effect
 
-        input_path = self._make_input_file(tmp_path)  # type: ignore[arg-type]
-        output_dir = tmp_path / "output"  # type: ignore[operator]
+        input_path = self._make_input_file(tmp_path)
+        output_dir = tmp_path / "output"
         result = execute(str(input_path), str(output_dir))
         assert result == 0
 
@@ -575,7 +592,7 @@ class TestExecute:
         mock_sp: MagicMock,
         mock_parse: MagicMock,
         mock_dispatch: MagicMock,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
     ) -> None:
         """Regression guard: prompt-snapshot.md is never written.
 
@@ -587,15 +604,22 @@ class TestExecute:
         mock_sp.return_value = MagicMock()
         mock_parse.return_value = {"claims": [], "queries": [], "axioms": []}
 
-        def dispatch_side_effect(step_def, outputs, client, sp, el, rd):
+        def dispatch_side_effect(
+            step_def: StepDefinition,
+            outputs: dict[str, Any],
+            client: object,
+            sp: object,
+            el: object,
+            rd: Path,
+        ) -> dict[str, Any]:
             if step_def.name in ("step_10_archive", "step_11_pipeline_events"):
                 return {"_self_written": True}
             return {"result": "ok"}
 
         mock_dispatch.side_effect = dispatch_side_effect
 
-        input_path = self._make_input_file(tmp_path)  # type: ignore[arg-type]
-        output_dir = tmp_path / "output"  # type: ignore[operator]
+        input_path = self._make_input_file(tmp_path)
+        output_dir = tmp_path / "output"
         result = execute(str(input_path), str(output_dir))
         assert result == 0
         instance_dirs = [d for d in output_dir.iterdir() if d.is_dir()]
@@ -610,9 +634,9 @@ class TestExecuteRerun:
         result = execute_rerun("/nonexistent/path")
         assert result == 1
 
-    def test_missing_source_input(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_missing_source_input(self, tmp_path: Path) -> None:
         """If the parent has no saved source input, rerun aborts."""
-        output_dir = tmp_path / "output"  # type: ignore[operator]
+        output_dir = tmp_path / "output"
         output_dir.mkdir()
         # Only a subdirectory, no regular file
         (output_dir / "2026-04-22-120000").mkdir()
@@ -630,7 +654,7 @@ class TestExecuteRerun:
         mock_sp: MagicMock,
         mock_parse: MagicMock,
         mock_dispatch: MagicMock,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
     ) -> None:
         """Rerun finds the saved input, runs a fresh instance, re-clarifies."""
         mock_client = MagicMock(model="m")
@@ -650,7 +674,14 @@ class TestExecuteRerun:
         mock_sp.return_value = MagicMock()
         mock_parse.return_value = {"claims": [], "queries": [{"text": "t"}], "axioms": []}
 
-        def dispatch_side_effect(step_def, outputs, client, sp, el, rd):
+        def dispatch_side_effect(
+            step_def: StepDefinition,
+            outputs: dict[str, Any],
+            client: object,
+            sp: object,
+            el: object,
+            rd: Path,
+        ) -> dict[str, Any]:
             if step_def.name in ("step_10_archive", "step_11_pipeline_events"):
                 return {"_self_written": True}
             return {"result": "ok"}
@@ -658,7 +689,7 @@ class TestExecuteRerun:
         mock_dispatch.side_effect = dispatch_side_effect
 
         # Simulate a previous `dio run` having populated the parent.
-        output_dir = tmp_path / "output"  # type: ignore[operator]
+        output_dir = tmp_path / "output"
         output_dir.mkdir()
         saved_input = output_dir / "input.md"
         saved_input.write_text("previous research input")
@@ -709,11 +740,11 @@ def _seed_instance(
 class TestLoadPriorOutputs:
     """Tests for _load_prior_outputs."""
 
-    def test_loads_completed_outputs(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_loads_completed_outputs(self, tmp_path: Path) -> None:
         """Each completed step's JSON is loaded under the pipeline's internal key."""
         from diogenes.state_machine import PipelineState
 
-        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir = tmp_path / "instance"
         _seed_instance(
             instance_dir,
             completed_step_files={
@@ -728,11 +759,11 @@ class TestLoadPriorOutputs:
         assert "hypotheses" in outputs
         assert outputs["research_input"]["queries"][0]["text"] == "t"
 
-    def test_skips_self_written_steps(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_skips_self_written_steps(self, tmp_path: Path) -> None:
         """archive.json and pipeline-events.json are not hoisted into outputs."""
         from diogenes.state_machine import PipelineState
 
-        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir = tmp_path / "instance"
         _seed_instance(
             instance_dir,
             completed_step_files={
@@ -747,11 +778,11 @@ class TestLoadPriorOutputs:
         assert "archive" not in outputs
         assert "pipeline_events" not in outputs
 
-    def test_missing_output_file_is_inconsistent(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_missing_output_file_is_inconsistent(self, tmp_path: Path) -> None:
         """State says complete but file is gone → refuse to guess, return None."""
         from diogenes.state_machine import PipelineState
 
-        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir = tmp_path / "instance"
         _seed_instance(
             instance_dir,
             completed_step_files={"research-input-clarified.json": {"claims": [], "queries": []}},
@@ -762,7 +793,7 @@ class TestLoadPriorOutputs:
 
     def test_skips_step_without_output_file(
         self,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Defensive: a completed step with output_file=None is skipped, not a crash.
@@ -781,7 +812,7 @@ class TestLoadPriorOutputs:
         )
         monkeypatch.setattr("diogenes.commands.run.PIPELINE_STEPS", [fake_step])
 
-        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir = tmp_path / "instance"
         instance_dir.mkdir()
         state = PipelineState(instance_dir)
         state.mark_complete("step_fake_no_output")
@@ -798,17 +829,17 @@ class TestExecuteResume:
     def test_missing_instance_dir(self) -> None:
         assert execute_resume("/nonexistent/path") == 1
 
-    def test_missing_state_file(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_missing_state_file(self, tmp_path: Path) -> None:
         """Instance dir exists but no pipeline-state.json → exit 1."""
-        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir = tmp_path / "instance"
         instance_dir.mkdir()
         assert execute_resume(str(instance_dir)) == 1
 
-    def test_all_steps_complete_is_noop(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_all_steps_complete_is_noop(self, tmp_path: Path) -> None:
         """Fully complete instance → exit 0 without dispatching anything."""
         from diogenes.state_machine import PIPELINE_STEPS, PipelineState
 
-        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir = tmp_path / "instance"
         instance_dir.mkdir()
         state = PipelineState(instance_dir)
         for step_def in PIPELINE_STEPS:
@@ -818,9 +849,9 @@ class TestExecuteResume:
             assert execute_resume(str(instance_dir)) == 0
             mock_dispatch.assert_not_called()
 
-    def test_inconsistent_state_missing_output(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_inconsistent_state_missing_output(self, tmp_path: Path) -> None:
         """State says step complete but its output file is missing → exit 1."""
-        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir = tmp_path / "instance"
         _seed_instance(
             instance_dir,
             completed_step_files={"research-input-clarified.json": {"claims": [], "queries": []}},
@@ -829,11 +860,11 @@ class TestExecuteResume:
         assert execute_resume(str(instance_dir)) == 1
 
     @patch("diogenes.commands.run.APIClient")
-    def test_api_client_failure(self, mock_cls: MagicMock, tmp_path: pytest.TempPathFactory) -> None:
+    def test_api_client_failure(self, mock_cls: MagicMock, tmp_path: Path) -> None:
         from diogenes.api_client import SubAgentError
 
         mock_cls.side_effect = SubAgentError("config", "No API key")
-        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir = tmp_path / "instance"
         _seed_instance(
             instance_dir,
             completed_step_files={"research-input-clarified.json": {"claims": [], "queries": []}},
@@ -846,11 +877,11 @@ class TestExecuteResume:
         self,
         mock_api: MagicMock,
         mock_sp: MagicMock,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
     ) -> None:
         mock_api.return_value = MagicMock(model="m")
         mock_sp.return_value = None
-        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir = tmp_path / "instance"
         _seed_instance(
             instance_dir,
             completed_step_files={"research-input-clarified.json": {"claims": [], "queries": []}},
@@ -867,7 +898,7 @@ class TestExecuteResume:
         mock_sp: MagicMock,
         mock_parse: MagicMock,
         mock_dispatch: MagicMock,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
     ) -> None:
         """Completed steps are skipped; clarifier is NOT called (no re-parsing)."""
         mock_client = MagicMock(model="m")
@@ -886,7 +917,14 @@ class TestExecuteResume:
         mock_api_cls.return_value = mock_client
         mock_sp.return_value = MagicMock()
 
-        def dispatch_side_effect(step_def, outputs, client, sp, el, rd):
+        def dispatch_side_effect(
+            step_def: StepDefinition,
+            outputs: dict[str, Any],
+            client: object,
+            sp: object,
+            el: object,
+            rd: Path,
+        ) -> dict[str, Any]:
             if step_def.name in ("step_10_archive", "step_11_pipeline_events"):
                 return {"_self_written": True}
             return {"result": "ok"}
@@ -894,7 +932,7 @@ class TestExecuteResume:
         mock_dispatch.side_effect = dispatch_side_effect
 
         # Seed: steps 1-3 complete on disk; 4-11 remain.
-        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir = tmp_path / "instance"
         _seed_instance(
             instance_dir,
             completed_step_files={
@@ -924,7 +962,7 @@ class TestExecuteResume:
         mock_api_cls: MagicMock,
         mock_sp: MagicMock,
         mock_dispatch: MagicMock,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
     ) -> None:
         """A step left in 'running' status (interrupted) is re-executed."""
         mock_client = MagicMock(model="m")
@@ -943,14 +981,21 @@ class TestExecuteResume:
         mock_api_cls.return_value = mock_client
         mock_sp.return_value = MagicMock()
 
-        def dispatch_side_effect(step_def, outputs, client, sp, el, rd):
+        def dispatch_side_effect(
+            step_def: StepDefinition,
+            outputs: dict[str, Any],
+            client: object,
+            sp: object,
+            el: object,
+            rd: Path,
+        ) -> dict[str, Any]:
             if step_def.name in ("step_10_archive", "step_11_pipeline_events"):
                 return {"_self_written": True}
             return {"result": "ok"}
 
         mock_dispatch.side_effect = dispatch_side_effect
 
-        instance_dir = tmp_path / "instance"  # type: ignore[operator]
+        instance_dir = tmp_path / "instance"
         _seed_instance(
             instance_dir,
             completed_step_files={

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,5 +1,7 @@
 """Tests for config module."""
 
+from pathlib import Path
+
 import pytest
 
 from diogenes.config import (
@@ -17,53 +19,53 @@ from diogenes.config import (
 class TestParseDotenv:
     """Tests for _parse_dotenv."""
 
-    def test_basic_key_value(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / ".env"  # type: ignore[operator]
+    def test_basic_key_value(self, tmp_path: Path) -> None:
+        path = tmp_path / ".env"
         path.write_text("KEY=value\n")
         assert _parse_dotenv(path) == {"KEY": "value"}
 
-    def test_double_quoted(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / ".env"  # type: ignore[operator]
+    def test_double_quoted(self, tmp_path: Path) -> None:
+        path = tmp_path / ".env"
         path.write_text('KEY="quoted value"\n')
         assert _parse_dotenv(path) == {"KEY": "quoted value"}
 
-    def test_single_quoted(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / ".env"  # type: ignore[operator]
+    def test_single_quoted(self, tmp_path: Path) -> None:
+        path = tmp_path / ".env"
         path.write_text("KEY='single quoted'\n")
         assert _parse_dotenv(path) == {"KEY": "single quoted"}
 
-    def test_export_prefix(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / ".env"  # type: ignore[operator]
+    def test_export_prefix(self, tmp_path: Path) -> None:
+        path = tmp_path / ".env"
         path.write_text("export KEY=value\n")
         assert _parse_dotenv(path) == {"KEY": "value"}
 
-    def test_comments_and_empty_lines(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / ".env"  # type: ignore[operator]
+    def test_comments_and_empty_lines(self, tmp_path: Path) -> None:
+        path = tmp_path / ".env"
         path.write_text("# comment\n\nKEY=value\n# another\n")
         assert _parse_dotenv(path) == {"KEY": "value"}
 
-    def test_no_equals_sign_skipped(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / ".env"  # type: ignore[operator]
+    def test_no_equals_sign_skipped(self, tmp_path: Path) -> None:
+        path = tmp_path / ".env"
         path.write_text("NOEQUALS\nKEY=value\n")
         assert _parse_dotenv(path) == {"KEY": "value"}
 
-    def test_multiple_keys(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / ".env"  # type: ignore[operator]
+    def test_multiple_keys(self, tmp_path: Path) -> None:
+        path = tmp_path / ".env"
         path.write_text("A=1\nB=2\nC=3\n")
         assert _parse_dotenv(path) == {"A": "1", "B": "2", "C": "3"}
 
-    def test_value_with_equals(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / ".env"  # type: ignore[operator]
+    def test_value_with_equals(self, tmp_path: Path) -> None:
+        path = tmp_path / ".env"
         path.write_text("KEY=value=with=equals\n")
         assert _parse_dotenv(path) == {"KEY": "value=with=equals"}
 
-    def test_short_quoted_value_not_stripped(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / ".env"  # type: ignore[operator]
+    def test_short_quoted_value_not_stripped(self, tmp_path: Path) -> None:
+        path = tmp_path / ".env"
         path.write_text('KEY=""\n')
         assert _parse_dotenv(path) == {"KEY": ""}
 
-    def test_single_char_value(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / ".env"  # type: ignore[operator]
+    def test_single_char_value(self, tmp_path: Path) -> None:
+        path = tmp_path / ".env"
         path.write_text("KEY=x\n")
         assert _parse_dotenv(path) == {"KEY": "x"}
 
@@ -71,14 +73,14 @@ class TestParseDotenv:
 class TestLoadToml:
     """Tests for _load_toml."""
 
-    def test_existing_file(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "test.toml"  # type: ignore[operator]
+    def test_existing_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "test.toml"
         path.write_text('[api]\nkey = "test-key"\n')
         result = _load_toml(path)
         assert result["api"]["key"] == "test-key"
 
-    def test_missing_file(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "missing.toml"  # type: ignore[operator]
+    def test_missing_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "missing.toml"
         assert _load_toml(path) == {}
 
 
@@ -111,29 +113,29 @@ class TestDioConfig:
 class TestLoadConfig:
     """Tests for load_config."""
 
-    def test_from_env_var(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    def test_from_env_var(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "env-key")
         monkeypatch.chdir(tmp_path)
         cfg = load_config()
         assert cfg.api_key == "env-key"
 
-    def test_from_dotenv(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    def test_from_dotenv(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.chdir(tmp_path)
-        dotenv = tmp_path / ".env"  # type: ignore[operator]
+        dotenv = tmp_path / ".env"
         dotenv.write_text('ANTHROPIC_API_KEY="dotenv-key"\n')
         cfg = load_config()
         assert cfg.api_key == "dotenv-key"
 
-    def test_from_diorc(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    def test_from_diorc(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.chdir(tmp_path)
-        diorc = tmp_path / ".diorc"  # type: ignore[operator]
+        diorc = tmp_path / ".diorc"
         diorc.write_text('[api]\nkey = "diorc-key"\n')
         cfg = load_config()
         assert cfg.api_key == "diorc-key"
 
-    def test_no_key_raises(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    def test_no_key_raises(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         # Clear all search-related env vars too
         for var in ("SERPER_API_KEY", "BRAVE_API_KEY", "GOOGLE_API_KEY", "GOOGLE_SEARCH_ENGINE_ID"):
@@ -142,43 +144,41 @@ class TestLoadConfig:
         with pytest.raises(ConfigError, match="No API key"):
             load_config()
 
-    def test_env_overrides_dotenv(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    def test_env_overrides_dotenv(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "env-wins")
         monkeypatch.chdir(tmp_path)
-        dotenv = tmp_path / ".env"  # type: ignore[operator]
+        dotenv = tmp_path / ".env"
         dotenv.write_text('ANTHROPIC_API_KEY="dotenv-loses"\n')
         cfg = load_config()
         assert cfg.api_key == "env-wins"
 
-    def test_project_diorc_overrides_user(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    def test_project_diorc_overrides_user(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "env-key")
         monkeypatch.chdir(tmp_path)
         # User-level config
-        user_diorc = tmp_path / "userhome" / ".diorc"  # type: ignore[operator]
+        user_diorc = tmp_path / "userhome" / ".diorc"
         user_diorc.parent.mkdir()
         user_diorc.write_text('[api]\nmodel = "user-model"\n')
-        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "userhome")  # type: ignore[operator]
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "userhome")
         # Project-level config
-        project_diorc = tmp_path / ".diorc"  # type: ignore[operator]
+        project_diorc = tmp_path / ".diorc"
         project_diorc.write_text('[api]\nmodel = "project-model"\n')
         cfg = load_config()
         assert cfg.model == "project-model"
 
-    def test_search_provider_config(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    def test_search_provider_config(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
         monkeypatch.setenv("SERPER_API_KEY", "serper-key")
         monkeypatch.chdir(tmp_path)
         cfg = load_config()
         assert cfg.serper_api_key == "serper-key"
 
-    def test_search_keys_from_dotenv(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    def test_search_keys_from_dotenv(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         for var in ("SERPER_API_KEY", "BRAVE_API_KEY", "GOOGLE_API_KEY", "GOOGLE_SEARCH_ENGINE_ID"):
             monkeypatch.delenv(var, raising=False)
         monkeypatch.chdir(tmp_path)
-        dotenv = tmp_path / ".env"  # type: ignore[operator]
+        dotenv = tmp_path / ".env"
         dotenv.write_text(
             "ANTHROPIC_API_KEY=key\n"
             "SERPER_API_KEY=s-key\n"
@@ -192,32 +192,30 @@ class TestLoadConfig:
         assert cfg.google_api_key == "g-key"
         assert cfg.google_search_engine_id == "g-cx"
 
-    def test_load_dotenv_disabled(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    def test_load_dotenv_disabled(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
         monkeypatch.chdir(tmp_path)
         # .diorc disables dotenv loading but provides key
-        diorc = tmp_path / ".diorc"  # type: ignore[operator]
+        diorc = tmp_path / ".diorc"
         diorc.write_text('[api]\nkey = "diorc-key"\n\n[env]\nload_dotenv = false\n')
         # .env exists but should be ignored
-        dotenv = tmp_path / ".env"  # type: ignore[operator]
+        dotenv = tmp_path / ".env"
         dotenv.write_text('ANTHROPIC_API_KEY="should-be-ignored"\n')
         cfg = load_config()
         assert cfg.api_key == "diorc-key"
 
-    def test_search_provider_from_diorc(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    def test_search_provider_from_diorc(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
         monkeypatch.chdir(tmp_path)
-        diorc = tmp_path / ".diorc"  # type: ignore[operator]
+        diorc = tmp_path / ".diorc"
         diorc.write_text('[search]\nprovider = "brave"\n')
         cfg = load_config()
         assert cfg.search_provider == "brave"
 
-    def test_base_url_from_diorc(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    def test_base_url_from_diorc(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
         monkeypatch.chdir(tmp_path)
-        diorc = tmp_path / ".diorc"  # type: ignore[operator]
+        diorc = tmp_path / ".diorc"
         diorc.write_text('[api]\nbase_url = "https://custom.api.com"\n')
         cfg = load_config()
         assert cfg.base_url == "https://custom.api.com"
@@ -226,12 +224,10 @@ class TestLoadConfig:
 class TestPipelineConfig:
     """Tests for the [pipeline] section in .diorc."""
 
-    def test_defaults_when_section_missing(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory
-    ) -> None:
+    def test_defaults_when_section_missing(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """Omitting [pipeline] falls back to the dataclass defaults."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
-        monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
+        monkeypatch.chdir(tmp_path)
         cfg = load_config()
         # The defaults match the hard-coded values from before this PR.
         assert cfg.pipeline.results_per_search == 5
@@ -241,11 +237,11 @@ class TestPipelineConfig:
         assert cfg.pipeline.max_output_tokens == 8192
         assert cfg.pipeline.model_overrides == {}
 
-    def test_fields_override_defaults(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    def test_fields_override_defaults(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """[pipeline] fields in .diorc override the dataclass defaults."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
-        monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
-        diorc = tmp_path / ".diorc"  # type: ignore[operator]
+        monkeypatch.chdir(tmp_path)
+        diorc = tmp_path / ".diorc"
         diorc.write_text(
             "[pipeline]\n"
             "results_per_search = 10\n"
@@ -261,11 +257,11 @@ class TestPipelineConfig:
         assert cfg.pipeline.search_terms_per_query == 4
         assert cfg.pipeline.max_output_tokens == 16384
 
-    def test_model_overrides_parsed(self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory) -> None:
+    def test_model_overrides_parsed(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """[pipeline.model_overrides] becomes a dict[str, str]."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
-        monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
-        diorc = tmp_path / ".diorc"  # type: ignore[operator]
+        monkeypatch.chdir(tmp_path)
+        diorc = tmp_path / ".diorc"
         diorc.write_text(
             "[pipeline.model_overrides]\n"
             'relevance_scorer = "claude-haiku-4-5-20251001"\n'
@@ -278,12 +274,12 @@ class TestPipelineConfig:
         }
 
     def test_model_overrides_non_dict_falls_back_to_empty(
-        self, monkeypatch: pytest.MonkeyPatch, tmp_path: pytest.TempPathFactory
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:
         """If model_overrides is not a table (malformed .diorc), treat as empty."""
         monkeypatch.setenv("ANTHROPIC_API_KEY", "key")
-        monkeypatch.chdir(tmp_path)  # type: ignore[arg-type]
-        diorc = tmp_path / ".diorc"  # type: ignore[operator]
+        monkeypatch.chdir(tmp_path)
+        diorc = tmp_path / ".diorc"
         # Writing model_overrides as a string (not a table) is technically valid TOML
         # but not what we expect; should gracefully fall back.
         diorc.write_text('[pipeline]\nmodel_overrides = "not-a-table"\n')

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,7 @@
 """Tests for events module."""
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -81,20 +82,20 @@ class TestEventLogger:
         assert len(d["events"]) == 1
         assert "summary" in d
 
-    def test_write_to_path(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_write_to_path(self, tmp_path: Path) -> None:
         logger = EventLogger(run_id="test-run")
         logger.log(step="s", kind="k", detail="d", layer="l")
-        path = tmp_path / "events.json"  # type: ignore[operator]
+        path = tmp_path / "events.json"
         result = logger.write(path)
         assert result == path
         data = json.loads(path.read_text())
         assert data["run_id"] == "test-run"
 
-    def test_write_to_output_dir(self, tmp_path: pytest.TempPathFactory) -> None:
-        logger = EventLogger(run_id="test-run", output_dir=tmp_path)  # type: ignore[arg-type]
+    def test_write_to_output_dir(self, tmp_path: Path) -> None:
+        logger = EventLogger(run_id="test-run", output_dir=tmp_path)
         logger.log(step="s", kind="k", detail="d", layer="l")
         result = logger.write()
-        assert result == tmp_path / "pipeline-events.json"  # type: ignore[operator]
+        assert result == tmp_path / "pipeline-events.json"
         assert result.exists()
 
     def test_write_no_path_raises(self) -> None:
@@ -102,31 +103,31 @@ class TestEventLogger:
         with pytest.raises(ValueError, match="No output directory"):
             logger.write()
 
-    def test_set_output_dir(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_set_output_dir(self, tmp_path: Path) -> None:
         logger = EventLogger(run_id="test-run")
-        logger.set_output_dir(tmp_path)  # type: ignore[arg-type]
+        logger.set_output_dir(tmp_path)
         assert logger.output_dir == tmp_path
 
 
 class TestLoadRunJson:
     """Tests for _load_run_json."""
 
-    def test_valid_json(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "data.json"  # type: ignore[operator]
+    def test_valid_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "data.json"
         path.write_text('{"key": "value"}')
         assert _load_run_json(path) == {"key": "value"}
 
-    def test_missing_file(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "missing.json"  # type: ignore[operator]
+    def test_missing_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "missing.json"
         assert _load_run_json(path) == {}
 
-    def test_invalid_json(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "bad.json"  # type: ignore[operator]
+    def test_invalid_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
         path.write_text("not json")
         assert _load_run_json(path) == {}
 
-    def test_non_dict_json(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "array.json"  # type: ignore[operator]
+    def test_non_dict_json(self, tmp_path: Path) -> None:
+        path = tmp_path / "array.json"
         path.write_text("[1, 2, 3]")
         assert _load_run_json(path) == {}
 
@@ -162,9 +163,9 @@ class TestIterItems:
 class TestReconcileRun:
     """Tests for reconcile_run."""
 
-    def _create_run_dir(self, tmp_path: pytest.TempPathFactory) -> pytest.TempPathFactory:
+    def _create_run_dir(self, tmp_path: Path) -> pytest.TempPathFactory:
         """Create a minimal run directory with expected files."""
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
 
         # Search results with selected sources
@@ -214,7 +215,7 @@ class TestReconcileRun:
 
         return run_dir  # type: ignore[return-value]
 
-    def test_basic_reconciliation(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_basic_reconciliation(self, tmp_path: Path) -> None:
         run_dir = self._create_run_dir(tmp_path)
         logger = EventLogger(run_id="test")
         coverage = reconcile_run(run_dir, logger)  # type: ignore[arg-type]
@@ -225,29 +226,29 @@ class TestReconcileRun:
         assert coverage["packets_dropped"] == 3
         assert coverage["verbatim_adherence_pct"] == 70.0
 
-    def test_missing_step_outputs(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-empty"  # type: ignore[operator]
+    def test_missing_step_outputs(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-empty"
         run_dir.mkdir()
         for fname in ("search-results.json", "scorecards.json", "evidence-packets.json"):
             (run_dir / fname).write_text("{}")
         logger = EventLogger(run_id="test")
-        reconcile_run(run_dir, logger)  # type: ignore[arg-type]
+        reconcile_run(run_dir, logger)
         missing_events = [e for e in logger.events if e["kind"] == "missing_step_output"]
         assert len(missing_events) == 5  # hypotheses, search-plans, synthesis, self-audit, reports
 
-    def test_zero_packets(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-zero"  # type: ignore[operator]
+    def test_zero_packets(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-zero"
         run_dir.mkdir()
         for fname in ("search-results.json", "scorecards.json", "evidence-packets.json"):
             (run_dir / fname).write_text("{}")
         logger = EventLogger(run_id="test")
-        coverage = reconcile_run(run_dir, logger)  # type: ignore[arg-type]
+        coverage = reconcile_run(run_dir, logger)
         assert coverage["packets_claimed"] == 0
         assert coverage["verbatim_adherence_pct"] is None
 
-    def test_items_without_verbatim_stats(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_items_without_verbatim_stats(self, tmp_path: Path) -> None:
         """Covers the branch where item_data has no verbatim_stats (208->206)."""
-        run_dir = tmp_path / "run-nostats"  # type: ignore[operator]
+        run_dir = tmp_path / "run-nostats"
         run_dir.mkdir()
 
         search_results = {
@@ -269,13 +270,13 @@ class TestReconcileRun:
             (run_dir / fname).write_text("{}")
 
         logger = EventLogger(run_id="test")
-        coverage = reconcile_run(run_dir, logger)  # type: ignore[arg-type]
+        coverage = reconcile_run(run_dir, logger)
         # With no verbatim_stats, packets_claimed should be 0
         assert coverage["packets_claimed"] == 0
         assert coverage["packets_verified"] == 0
         assert coverage["verbatim_adherence_pct"] is None
 
-    def test_fetch_failures_counted(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_fetch_failures_counted(self, tmp_path: Path) -> None:
         run_dir = self._create_run_dir(tmp_path)
         logger = EventLogger(run_id="test")
         # Pre-log a fetch failure
@@ -285,7 +286,7 @@ class TestReconcileRun:
         assert coverage["sources_attempted"] == 3
         assert coverage["sources_capped"] == 0
 
-    def test_source_capping_logged(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_source_capping_logged(self, tmp_path: Path) -> None:
         run_dir = self._create_run_dir(tmp_path)
         logger = EventLogger(run_id="test")
         # No fetch failures logged, so attempted = scored = 2, but selected = 3

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -9,14 +9,16 @@ from unittest.mock import MagicMock
 from diogenes.logger import configure_progress_logger
 
 if TYPE_CHECKING:
+    from pathlib import Path
+
     import pytest
 
 
 class TestConfigureProgressLogger:
     """Tests for configure_progress_logger."""
 
-    def test_attaches_file_handler(self, tmp_path: pytest.TempPathFactory) -> None:
-        log_path = tmp_path / "progress.log"  # type: ignore[operator]
+    def test_attaches_file_handler(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "progress.log"
         logger = configure_progress_logger(log_path, tee_to_stdout=False)
         # Exactly one handler (file); no stdout handler when tee disabled
         file_handlers = [h for h in logger.handlers if isinstance(h, logging.FileHandler)]
@@ -28,8 +30,8 @@ class TestConfigureProgressLogger:
         assert len(file_handlers) == 1
         assert len(stream_handlers) == 0
 
-    def test_tee_adds_stdout_handler(self, tmp_path: pytest.TempPathFactory) -> None:
-        log_path = tmp_path / "progress.log"  # type: ignore[operator]
+    def test_tee_adds_stdout_handler(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "progress.log"
         logger = configure_progress_logger(log_path, tee_to_stdout=True)
         stream_handlers = [
             h
@@ -38,8 +40,8 @@ class TestConfigureProgressLogger:
         ]
         assert len(stream_handlers) == 1
 
-    def test_writes_lines_to_file(self, tmp_path: pytest.TempPathFactory) -> None:
-        log_path = tmp_path / "progress.log"  # type: ignore[operator]
+    def test_writes_lines_to_file(self, tmp_path: Path) -> None:
+        log_path = tmp_path / "progress.log"
         configure_progress_logger(log_path, tee_to_stdout=False)
         pipe_logger = logging.getLogger("diogenes.pipeline")
         pipe_logger.info("hello from a pipeline step")
@@ -49,9 +51,9 @@ class TestConfigureProgressLogger:
         content = log_path.read_text()
         assert "hello from a pipeline step" in content
 
-    def test_reconfigure_is_idempotent(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_reconfigure_is_idempotent(self, tmp_path: Path) -> None:
         """Calling configure twice leaves exactly one FileHandler, not two."""
-        log_path = tmp_path / "progress.log"  # type: ignore[operator]
+        log_path = tmp_path / "progress.log"
         configure_progress_logger(log_path, tee_to_stdout=False)
         configure_progress_logger(log_path, tee_to_stdout=False)
         logger = logging.getLogger("diogenes")
@@ -60,7 +62,7 @@ class TestConfigureProgressLogger:
 
     def test_auto_detect_tty_true(
         self,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """When tee_to_stdout is None and stdout is a TTY, stdout handler attaches."""
@@ -68,7 +70,7 @@ class TestConfigureProgressLogger:
         fake_stdout.isatty.return_value = True
         monkeypatch.setattr("diogenes.logger.sys.stdout", fake_stdout)
 
-        log_path = tmp_path / "progress.log"  # type: ignore[operator]
+        log_path = tmp_path / "progress.log"
         logger = configure_progress_logger(log_path)
         stream_handlers = [
             h
@@ -79,7 +81,7 @@ class TestConfigureProgressLogger:
 
     def test_auto_detect_tty_false(
         self,
-        tmp_path: pytest.TempPathFactory,
+        tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """When tee_to_stdout is None and stdout is not a TTY, no stdout handler."""
@@ -87,7 +89,7 @@ class TestConfigureProgressLogger:
         fake_stdout.isatty.return_value = False
         monkeypatch.setattr("diogenes.logger.sys.stdout", fake_stdout)
 
-        log_path = tmp_path / "progress.log"  # type: ignore[operator]
+        log_path = tmp_path / "progress.log"
         logger = configure_progress_logger(log_path)
         stream_handlers = [
             h

--- a/tests/test_mcp_server.py
+++ b/tests/test_mcp_server.py
@@ -1,6 +1,7 @@
 """Tests for mcp_server module."""
 
 import json
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -20,14 +21,14 @@ class TestDioInitRun:
         reset_mcp_logger()
         reset_content_cache()
 
-    def test_initializes(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_initializes(self, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_init_run
 
         result = json.loads(dio_init_run(str(tmp_path), "run-1"))
         assert result["initialized"] is True
         assert result["run_id"] == "run-1"
 
-    def test_resets_logger(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_resets_logger(self, tmp_path: Path) -> None:
         from diogenes.events import get_mcp_logger
         from diogenes.mcp_server import dio_init_run
 
@@ -42,20 +43,20 @@ class TestDioInitRun:
 class TestDioNextStep:
     """Tests for dio_next_step tool."""
 
-    def test_first_step(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_first_step(self, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_next_step
 
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         result = json.loads(dio_next_step(str(run_dir)))
         assert result["step"] == "step_01_research_input_clarified"
         assert result["status"] == "ready"
 
-    def test_all_complete(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_all_complete(self, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_next_step
         from diogenes.state_machine import PIPELINE_STEPS, PipelineState
 
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         for step in PIPELINE_STEPS:
@@ -70,11 +71,11 @@ class TestDioNextStep:
         result = json.loads(dio_next_step("/nonexistent/path"))
         assert result["error"] is True
 
-    def test_python_only_step(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_python_only_step(self, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_next_step
         from diogenes.state_machine import PIPELINE_STEPS, PipelineState
 
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         # Complete all steps up to step_10_archive (which is python_only)
@@ -86,11 +87,11 @@ class TestDioNextStep:
         assert result["step"] == "step_10_archive"
         assert "dio_execute_step" in result["instructions"]
 
-    def test_step_with_post_validators(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_with_post_validators(self, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_next_step
         from diogenes.state_machine import PIPELINE_STEPS, PipelineState
 
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         # Complete up to step_06 (evidence_packets has post_validators)
@@ -102,12 +103,12 @@ class TestDioNextStep:
         assert result["step"] == "step_06_evidence_packets"
         assert "post_step" in result
 
-    def test_step_without_prompt_non_python(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_without_prompt_non_python(self, tmp_path: Path) -> None:
         """Covers line 142: step with category != python_only and no prompt field."""
         from diogenes.mcp_server import dio_next_step
         from diogenes.state_machine import StepDefinition
 
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
 
         # Create a custom step with category="hybrid" but no prompt
@@ -126,11 +127,11 @@ class TestDioNextStep:
             result = json.loads(dio_next_step(str(run_dir)))
         assert "dio_execute_step" in result["instructions"]
 
-    def test_step_with_mcp_tools(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_step_with_mcp_tools(self, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_next_step
         from diogenes.state_machine import PIPELINE_STEPS, PipelineState
 
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         # Complete up to step_04 (search_results) so step_05 (scorecards) is next — has mcp_tools
@@ -146,27 +147,27 @@ class TestDioNextStep:
 class TestDioExecuteStep:
     """Tests for dio_execute_step tool."""
 
-    def test_unknown_step(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_unknown_step(self, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_execute_step
 
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         result = json.loads(dio_execute_step(str(run_dir), "nonexistent_step"))
         assert result["error"] is True
 
-    def test_llm_step_rejected(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_llm_step_rejected(self, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_execute_step
 
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         result = json.loads(dio_execute_step(str(run_dir), "step_02_hypotheses"))
         assert result["error"] is True
         assert "llm" in result["message"].lower()
 
-    def test_python_only_step(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_python_only_step(self, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_execute_step
 
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         result = json.loads(dio_execute_step(str(run_dir), "step_10_archive"))
         assert result["executed"] is True
@@ -480,18 +481,18 @@ class TestDioFlushEvents:
         result = json.loads(dio_flush_events())
         assert result["error"] is True
 
-    def test_flush_success(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_flush_success(self, tmp_path: Path) -> None:
         from diogenes.events import get_mcp_logger
         from diogenes.mcp_server import dio_flush_events
 
         logger = get_mcp_logger()
-        logger.set_output_dir(tmp_path)  # type: ignore[arg-type]
+        logger.set_output_dir(tmp_path)
         # Create minimal run files so reconciler doesn't fail
         for fname in ("search-results.json", "scorecards.json", "evidence-packets.json"):
-            (tmp_path / fname).write_text("{}")  # type: ignore[operator]
+            (tmp_path / fname).write_text("{}")
         result = json.loads(dio_flush_events())
         assert "written_to" in result
-        assert (tmp_path / "pipeline-events.json").exists()  # type: ignore[operator]
+        assert (tmp_path / "pipeline-events.json").exists()
 
 
 class TestDioValidatePackets:
@@ -505,13 +506,13 @@ class TestDioValidatePackets:
         reset_mcp_logger()
         reset_content_cache()
 
-    def test_missing_packets_file(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_missing_packets_file(self, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_validate_packets
 
         result = json.loads(dio_validate_packets(str(tmp_path)))
         assert result["error"] is True
 
-    def test_cli_format_validation(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_cli_format_validation(self, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_validate_packets
 
         # Create packets and scorecards in CLI format
@@ -531,15 +532,15 @@ class TestDioValidatePackets:
                 ],
             }
         }
-        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))  # type: ignore[operator]
-        (tmp_path / "scorecards.json").write_text(json.dumps(scorecards))  # type: ignore[operator]
+        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))
+        (tmp_path / "scorecards.json").write_text(json.dumps(scorecards))
 
         result = json.loads(dio_validate_packets(str(tmp_path)))
         assert result["validated"] is True
         assert result["packets_kept"] == 1
         assert result["packets_dropped"] == 1
 
-    def test_skill_format_validation(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_skill_format_validation(self, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_validate_packets
 
         packets = {
@@ -553,14 +554,14 @@ class TestDioValidatePackets:
                 {"url": "https://a.com", "content_extract": "the real text here is good"},
             ],
         }
-        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))  # type: ignore[operator]
-        (tmp_path / "scorecards.json").write_text(json.dumps(scorecards))  # type: ignore[operator]
+        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))
+        (tmp_path / "scorecards.json").write_text(json.dumps(scorecards))
 
         result = json.loads(dio_validate_packets(str(tmp_path)))
         assert result["validated"] is True
         assert result["packets_kept"] == 1
 
-    def test_non_dict_item_skipped(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_non_dict_item_skipped(self, tmp_path: Path) -> None:
         """Covers line 486: non-dict value in packets_data is skipped."""
         from diogenes.mcp_server import dio_validate_packets
 
@@ -569,14 +570,14 @@ class TestDioValidatePackets:
             "Q001": {"id": "Q001", "packets": []},
             "metadata": "not a dict",
         }
-        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))  # type: ignore[operator]
-        (tmp_path / "scorecards.json").write_text("{}")  # type: ignore[operator]
+        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))
+        (tmp_path / "scorecards.json").write_text("{}")
 
         result = json.loads(dio_validate_packets(str(tmp_path)))
         assert result["validated"] is True
         assert result["packets_claimed"] == 0
 
-    def test_cache_url_already_in_content(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_cache_url_already_in_content(self, tmp_path: Path) -> None:
         """Covers branch 468->467: cache URL already has content from scorecards."""
         from diogenes.content_cache import get_content_cache
         from diogenes.mcp_server import dio_validate_packets
@@ -593,13 +594,13 @@ class TestDioValidatePackets:
                 ],
             }
         }
-        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))  # type: ignore[operator]
-        (tmp_path / "scorecards.json").write_text(json.dumps(scorecards))  # type: ignore[operator]
+        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))
+        (tmp_path / "scorecards.json").write_text(json.dumps(scorecards))
 
         result = json.loads(dio_validate_packets(str(tmp_path)))
         assert result["validated"] is True
 
-    def test_cache_url_returns_empty(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_cache_url_returns_empty(self, tmp_path: Path) -> None:
         """Covers branch 470->467: cache.get returns empty/None for a URL."""
         from diogenes.content_cache import get_content_cache
         from diogenes.mcp_server import dio_validate_packets
@@ -608,13 +609,13 @@ class TestDioValidatePackets:
         cache.put("https://empty.com", "")
 
         packets = {"Q001": {"id": "Q001", "packets": []}}
-        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))  # type: ignore[operator]
-        (tmp_path / "scorecards.json").write_text("{}")  # type: ignore[operator]
+        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))
+        (tmp_path / "scorecards.json").write_text("{}")
 
         result = json.loads(dio_validate_packets(str(tmp_path)))
         assert result["validated"] is True
 
-    def test_scorecard_skill_format_empty_url(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_scorecard_skill_format_empty_url(self, tmp_path: Path) -> None:
         """Covers branch 546->543: skill-format scorecard with empty url."""
         from diogenes.mcp_server import dio_validate_packets
 
@@ -625,13 +626,13 @@ class TestDioValidatePackets:
                 {"url": "https://a.com", "content_extract": ""},
             ],
         }
-        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))  # type: ignore[operator]
-        (tmp_path / "scorecards.json").write_text(json.dumps(scorecards))  # type: ignore[operator]
+        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))
+        (tmp_path / "scorecards.json").write_text(json.dumps(scorecards))
 
         result = json.loads(dio_validate_packets(str(tmp_path)))
         assert result["validated"] is True
 
-    def test_scorecard_cli_format_non_dict_values(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_scorecard_cli_format_non_dict_values(self, tmp_path: Path) -> None:
         """Covers branch 550->549: CLI-format scorecards with non-dict items."""
         from diogenes.mcp_server import dio_validate_packets
 
@@ -640,13 +641,13 @@ class TestDioValidatePackets:
             "Q001": {"scorecards": [{"url": "", "content_extract": "content"}]},
             "metadata": "string value",
         }
-        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))  # type: ignore[operator]
-        (tmp_path / "scorecards.json").write_text(json.dumps(scorecards))  # type: ignore[operator]
+        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))
+        (tmp_path / "scorecards.json").write_text(json.dumps(scorecards))
 
         result = json.loads(dio_validate_packets(str(tmp_path)))
         assert result["validated"] is True
 
-    def test_uses_content_cache(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_uses_content_cache(self, tmp_path: Path) -> None:
         from diogenes.content_cache import get_content_cache
         from diogenes.mcp_server import dio_validate_packets
 
@@ -661,8 +662,8 @@ class TestDioValidatePackets:
                 ],
             }
         }
-        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))  # type: ignore[operator]
-        (tmp_path / "scorecards.json").write_text("{}")  # type: ignore[operator]
+        (tmp_path / "evidence-packets.json").write_text(json.dumps(packets))
+        (tmp_path / "scorecards.json").write_text("{}")
 
         result = json.loads(dio_validate_packets(str(tmp_path)))
         assert result["packets_kept"] == 1
@@ -678,12 +679,12 @@ class TestDioRender:
         assert result["error"] is True
 
     @patch("diogenes.mcp_server.render_run")
-    def test_single_run(self, mock_render: MagicMock, tmp_path: pytest.TempPathFactory) -> None:
+    def test_single_run(self, mock_render: MagicMock, tmp_path: Path) -> None:
         from diogenes.mcp_server import dio_render
 
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
-        out_dir = tmp_path / "md"  # type: ignore[operator]
+        out_dir = tmp_path / "md"
 
         result = json.loads(dio_render(str(run_dir), str(out_dir)))
         assert result["input_dir"] == str(run_dir)

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -2,6 +2,7 @@
 
 import json
 from pathlib import Path
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -63,7 +64,7 @@ class TestVerifyPacketVerbatim:
         assert _verify_packet_verbatim(packet, "source content") is False
 
     def test_missing_excerpt(self) -> None:
-        packet = {}
+        packet: dict[str, Any] = {}
         assert _verify_packet_verbatim(packet, "source content") is False
 
     def test_whitespace_only_excerpt(self) -> None:
@@ -141,24 +142,24 @@ class TestScorecardsWithoutContent:
 class TestWriteStepOutput:
     """Tests for write_step_output."""
 
-    def test_writes_json(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_writes_json(self, tmp_path: Path) -> None:
         data = {"key": "value"}
-        path = write_step_output(tmp_path, "output.json", data)  # type: ignore[arg-type]
+        path = write_step_output(tmp_path, "output.json", data)
         assert path.exists()
         assert json.loads(path.read_text()) == data
 
-    def test_writes_list(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_writes_list(self, tmp_path: Path) -> None:
         data = [1, 2, 3]
-        path = write_step_output(tmp_path, "output.json", data)  # type: ignore[arg-type]
+        path = write_step_output(tmp_path, "output.json", data)
         assert json.loads(path.read_text()) == data
 
 
 class TestStep11Archive:
     """Tests for step11_archive."""
 
-    def test_creates_archive(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_creates_archive(self, tmp_path: Path) -> None:
         outputs = {"research_input": {"claims": []}, "hypotheses": {"Q001": {}}}
-        path = step11_archive(tmp_path, outputs)  # type: ignore[arg-type]
+        path = step11_archive(tmp_path, outputs)
         assert path.exists()
         data = json.loads(path.read_text())
         assert "archived_at" in data
@@ -467,7 +468,7 @@ class TestStep5bExtractEvidence:
         )
 
         research_input = {"claims": [{"id": "C001", "clarified_text": "Test"}], "queries": []}
-        hypotheses = {"C001": {}}
+        hypotheses: dict[str, Any] = {"C001": {}}
         scorecards = {
             "C001": {
                 "scorecards": [{"url": "https://a.com", "content_extract": "x" * 200}],
@@ -487,7 +488,7 @@ class TestStep5bExtractEvidence:
         mock_extract.return_value = ([], [], {"claimed": 0, "kept": 0, "dropped": 0})
 
         research_input = {"claims": [{"id": "C001", "clarified_text": "Test"}], "queries": []}
-        hypotheses = {"C001": {}}
+        hypotheses: dict[str, Any] = {"C001": {}}
         # All sources have short content_extract
         scorecards = {
             "C001": {
@@ -508,7 +509,7 @@ class TestStep5bExtractEvidence:
         )
 
         research_input = {"claims": [], "queries": [{"id": "Q001", "clarified_text": "Test"}]}
-        hypotheses = {"Q001": {}}
+        hypotheses: dict[str, Any] = {"Q001": {}}
         scorecards = {
             "Q001": {
                 "scorecards": [
@@ -605,7 +606,7 @@ class TestSteps678SynthesizeAndAssess:
         }
 
         research_input = {"claims": [{"id": "C001", "clarified_text": "Test"}], "queries": []}
-        hypotheses = {"C001": {}}
+        hypotheses: dict[str, Any] = {"C001": {}}
         scorecards = {"C001": {"scorecards": [{"url": "https://a.com"}]}}
         evidence = {"C001": {"packets": [{"excerpt": "test"}]}}
 

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -2,8 +2,7 @@
 
 import json
 from pathlib import Path
-
-import pytest
+from typing import Any
 
 from diogenes.renderer import (
     _add_toc,
@@ -48,17 +47,17 @@ class TestSlugify:
 class TestLoadJson:
     """Tests for _load_json."""
 
-    def test_valid(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "data.json"  # type: ignore[operator]
+    def test_valid(self, tmp_path: Path) -> None:
+        path = tmp_path / "data.json"
         path.write_text('{"key": "value"}')
         assert _load_json(path) == {"key": "value"}
 
-    def test_missing(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "missing.json"  # type: ignore[operator]
+    def test_missing(self, tmp_path: Path) -> None:
+        path = tmp_path / "missing.json"
         assert _load_json(path) == {}
 
-    def test_invalid(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "bad.json"  # type: ignore[operator]
+    def test_invalid(self, tmp_path: Path) -> None:
+        path = tmp_path / "bad.json"
         path.write_text("not json")
         assert _load_json(path) == {}
 
@@ -521,12 +520,12 @@ def _create_realistic_run(run_dir: Path) -> None:
 class TestRenderRun:
     """Tests for render_run."""
 
-    def test_renders_markdown_files(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_renders_markdown_files(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         _create_realistic_run(run_dir)
 
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         render_run(run_dir, output_dir)
 
         # Check that index.md was created
@@ -539,10 +538,10 @@ class TestRenderRun:
         md_files = list(output_dir.rglob("*.md"))
         assert len(md_files) >= 1
 
-    def test_empty_run_dir(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_empty_run_dir(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         # Should not crash with empty dir
         render_run(run_dir, output_dir)
         assert (output_dir / "index.md").exists()
@@ -1183,12 +1182,12 @@ def _create_plugin_format_run(run_dir: Path) -> None:
 class TestRenderRunPluginFormat:
     """Tests for render_run with plugin-format data covering uncovered branches."""
 
-    def test_renders_all_plugin_format_files(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_renders_all_plugin_format_files(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         _create_plugin_format_run(run_dir)
 
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         render_run(run_dir, output_dir)
 
         # Index exists
@@ -1201,12 +1200,12 @@ class TestRenderRunPluginFormat:
         assert "Collection Self-Audit" in index_content
         assert "Overall risk of bias" in index_content
 
-    def test_claim_item_files(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_claim_item_files(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         _create_plugin_format_run(run_dir)
 
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         render_run(run_dir, output_dir)
 
         # Find C001 directory
@@ -1292,12 +1291,12 @@ class TestRenderRunPluginFormat:
         assert "Revisit Triggers" in item_index
         assert "evidence" in item_index.lower()
 
-    def test_query_item_files(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_query_item_files(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         _create_plugin_format_run(run_dir)
 
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         render_run(run_dir, output_dir)
 
         # Find Q001 directory
@@ -1318,8 +1317,8 @@ class TestRenderRunPluginFormat:
 class TestRenderRunWithoutSourceVerificationDiscrepancies:
     """Test self-audit branch where source_verification has no discrepancies."""
 
-    def test_no_discrepancies(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_no_discrepancies(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         _create_plugin_format_run(run_dir)
 
@@ -1333,7 +1332,7 @@ class TestRenderRunWithoutSourceVerificationDiscrepancies:
                 }
         (run_dir / "self-audit.json").write_text(json.dumps(sa, indent=2))
 
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         render_run(run_dir, output_dir)
 
         c001_dirs = [d for d in output_dir.iterdir() if d.is_dir() and d.name.startswith("C001")]
@@ -1344,8 +1343,8 @@ class TestRenderRunWithoutSourceVerificationDiscrepancies:
 class TestRenderRunFallbackReadingList:
     """Test reading-list fallback to scorecards when no reading_list in audit."""
 
-    def test_falls_back_to_scorecards(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_falls_back_to_scorecards(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         _create_plugin_format_run(run_dir)
 
@@ -1355,7 +1354,7 @@ class TestRenderRunFallbackReadingList:
             item.pop("reading_list", None)
         (run_dir / "self-audit.json").write_text(json.dumps(sa, indent=2))
 
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         render_run(run_dir, output_dir)
 
         c001_dirs = [d for d in output_dir.iterdir() if d.is_dir() and d.name.startswith("C001")]
@@ -1368,12 +1367,12 @@ class TestRenderRunFallbackReadingList:
 class TestRenderRunCollectionStatsPluginFormat:
     """Test collection statistics from search_execution_log (plugin format)."""
 
-    def test_execution_log_stats(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_execution_log_stats(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         _create_plugin_format_run(run_dir)
 
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         render_run(run_dir, output_dir)
 
         index_content = (output_dir / "index.md").read_text()
@@ -1385,8 +1384,8 @@ class TestRenderRunCollectionStatsPluginFormat:
 class TestSourceScorecardBiasFormats:
     """Test bias_assessment rendering for dict, string, and other formats."""
 
-    def test_bias_as_other_type(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_bias_as_other_type(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         _create_plugin_format_run(run_dir)
 
@@ -1398,7 +1397,7 @@ class TestSourceScorecardBiasFormats:
         }
         (run_dir / "scorecards.json").write_text(json.dumps(sc, indent=2))
 
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         render_run(run_dir, output_dir)
 
         c001_dirs = [d for d in output_dir.iterdir() if d.is_dir() and d.name.startswith("C001")]
@@ -1410,8 +1409,8 @@ class TestSourceScorecardBiasFormats:
 class TestReliabilityRelevanceRationale:
     """Test reliability and relevance with string rationale fields."""
 
-    def test_string_reliability_with_rationale(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_string_reliability_with_rationale(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         _create_plugin_format_run(run_dir)
 
@@ -1423,7 +1422,7 @@ class TestReliabilityRelevanceRationale:
         sc["sources"][0]["relevance_rationale"] = "Core topic match"
         (run_dir / "scorecards.json").write_text(json.dumps(sc, indent=2))
 
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         render_run(run_dir, output_dir)
 
         c001_dirs = [d for d in output_dir.iterdir() if d.is_dir() and d.name.startswith("C001")]
@@ -1437,8 +1436,8 @@ class TestReliabilityRelevanceRationale:
 class TestRenderRunRobisAuditFallback:
     """Test that per-item self-audit falls back to global robis_audit when item has no audit."""
 
-    def test_robis_audit_on_item_page(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_robis_audit_on_item_page(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         _create_plugin_format_run(run_dir)
 
@@ -1461,7 +1460,7 @@ class TestRenderRunRobisAuditFallback:
         }
         (run_dir / "self-audit.json").write_text(json.dumps(sa, indent=2))
 
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         render_run(run_dir, output_dir)
 
         # C001 should get the global robis_audit since it has no per-item audit
@@ -1476,8 +1475,8 @@ class TestRenderRunRobisAuditFallback:
 class TestRenderRunItemWithNoId:
     """Test that items with no ID are skipped gracefully."""
 
-    def test_item_without_id_skipped(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_item_without_id_skipped(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
 
         ri = {
@@ -1504,7 +1503,7 @@ class TestRenderRunItemWithNoId:
         ]:
             (run_dir / f).write_text("{}")
 
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         render_run(run_dir, output_dir)
 
         # Only C001 dir should exist, no-id item should be skipped
@@ -1516,8 +1515,8 @@ class TestRenderRunItemWithNoId:
 class TestItemIndexWithoutOptionalSections:
     """Test item index when optional sections are absent."""
 
-    def test_minimal_item_index(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_minimal_item_index(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
 
         # Minimal run with just a query, no hypotheses or synthesis
@@ -1541,7 +1540,7 @@ class TestItemIndexWithoutOptionalSections:
         (run_dir / "self-audit.json").write_text("{}")
         (run_dir / "reports.json").write_text("{}")
 
-        output_dir = tmp_path / "md"  # type: ignore[operator]
+        output_dir = tmp_path / "md"
         render_run(run_dir, output_dir)
 
         assert (output_dir / "index.md").exists()
@@ -1797,7 +1796,7 @@ def _create_rich_cli_run(run_dir: Path) -> None:
 class TestRenderRunRichCli:
     """Tests for render_run with rich optional fields in CLI format."""
 
-    def test_rich_cli_run(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_rich_cli_run(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run-rich"
         run_dir.mkdir()
         _create_rich_cli_run(run_dir)
@@ -1817,12 +1816,12 @@ class TestCollectHypothesisRatingsEdgeCases:
 
     def test_non_dict_report(self) -> None:
         """Covers 322->333: isinstance(report, dict) is False."""
-        result = _collect_hypothesis_ratings("not a dict", {})
+        result = _collect_hypothesis_ratings("not a dict", {})  # type: ignore[arg-type]
         assert result == {}
 
     def test_non_dict_synthesis(self) -> None:
         """Covers the False path for synthesis being non-dict."""
-        result = _collect_hypothesis_ratings({}, "not a dict")
+        result = _collect_hypothesis_ratings({}, "not a dict")  # type: ignore[arg-type]
         assert result == {}
 
     def test_non_dict_assessment_in_report(self) -> None:
@@ -1879,7 +1878,7 @@ class TestExtractSourcesForItemExtra:
 
     def test_empty_sources_list(self) -> None:
         """Covers the branch where sources_list exists but no matches."""
-        scorecards = {"sources": []}
+        scorecards: dict[str, Any] = {"sources": []}
         result = _extract_sources_for_item(scorecards, "C001")
         assert result == []
 
@@ -1893,7 +1892,7 @@ class TestExtractSourcesForItemExtra:
 class TestWriteHypothesesEmpty:
     """Cover the early-return path in _write_hypotheses."""
 
-    def test_empty_hypotheses(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_empty_hypotheses(self, tmp_path: Path) -> None:
         """Covers line 1021: `return` when hyps is empty."""
         from diogenes.renderer import _write_hypotheses
 
@@ -1908,7 +1907,7 @@ class TestWriteHypothesesEmpty:
 class TestWriteSearchesEmpty:
     """Cover the early-return path in _write_searches."""
 
-    def test_empty_searches(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_empty_searches(self, tmp_path: Path) -> None:
         """Covers line 1417: `return` when searches is empty."""
         from diogenes.renderer import _write_searches
 
@@ -1917,7 +1916,7 @@ class TestWriteSearchesEmpty:
         _write_searches(item_dir, "C001", {"searches": []}, {}, {})
         assert not (item_dir / "searches").exists()
 
-    def test_no_item_plan(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_no_item_plan(self, tmp_path: Path) -> None:
         """Covers `if not item_plan` branch."""
         from diogenes.renderer import _write_searches
 
@@ -2099,7 +2098,7 @@ def _create_cli_dict_gaps_run(run_dir: Path) -> None:
 class TestRenderRunMinimal:
     """Tests for render_run with minimal optional fields (False branches)."""
 
-    def test_minimal_run_renders(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_minimal_run_renders(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run-min"
         run_dir.mkdir()
         _create_minimal_run(run_dir)
@@ -2112,7 +2111,7 @@ class TestRenderRunMinimal:
 class TestRenderRunCliDictGaps:
     """Tests for render_run with CLI-format dict gaps."""
 
-    def test_cli_dict_gaps(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_cli_dict_gaps(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run-gaps"
         run_dir.mkdir()
         _create_cli_dict_gaps_run(run_dir)
@@ -2251,7 +2250,7 @@ def _create_run_with_assessment_variants(
 class TestAssessmentRenderingVariants:
     """Cover branches in _write_assessment for various data shapes."""
 
-    def test_no_report(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_no_report(self, tmp_path: Path) -> None:
         """Cover 1100->1112: report is falsy, skip verdict section."""
         run_dir = tmp_path / "run"
         run_dir.mkdir()
@@ -2262,7 +2261,7 @@ class TestAssessmentRenderingVariants:
         # Should still render assessment.md without report-based sections
         assert (c001_dirs[0] / "assessment.md").exists()
 
-    def test_verdict_chain_reasoning(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_verdict_chain_reasoning(self, tmp_path: Path) -> None:
         """Cover reasoning_chain branch (vs just `reasoning`)."""
         run_dir = tmp_path / "run"
         run_dir.mkdir()
@@ -2274,7 +2273,7 @@ class TestAssessmentRenderingVariants:
         assert "verdict string" in assessment
         assert "chain of reasoning" in assessment
 
-    def test_empty_assessment_dict(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_empty_assessment_dict(self, tmp_path: Path) -> None:
         """Cover 1151->1181: assessment dict exists but is empty."""
         run_dir = tmp_path / "run"
         run_dir.mkdir()
@@ -2286,7 +2285,7 @@ class TestAssessmentRenderingVariants:
         assessment = (c001_dirs[0] / "assessment.md").read_text()
         assert "Probability Assessment" not in assessment
 
-    def test_empty_gaps_dict(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_empty_gaps_dict(self, tmp_path: Path) -> None:
         """Cover 1190->1208: gaps is dict but empty (no expected/unanswered/impact)."""
         run_dir = tmp_path / "run"
         run_dir.mkdir()
@@ -2368,7 +2367,7 @@ def _create_run_with_search_variants(run_dir: Path) -> None:
 class TestSearchRenderingVariants:
     """Cover branches in _write_searches."""
 
-    def test_search_variants(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_search_variants(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_with_search_variants(run_dir)
@@ -2455,7 +2454,7 @@ def _create_run_with_sources_variants(run_dir: Path) -> None:
 class TestSourcesRenderingVariants:
     """Cover branches in _write_sources."""
 
-    def test_sources_variants(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_sources_variants(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_with_sources_variants(run_dir)
@@ -2537,7 +2536,7 @@ def _create_run_with_self_audit_variants(run_dir: Path) -> None:
 class TestSelfAuditVariants:
     """Cover branches in _write_self_audit and related writers."""
 
-    def test_self_audit_variants(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_self_audit_variants(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_with_self_audit_variants(run_dir)
@@ -2570,7 +2569,7 @@ def _create_run_no_synthesis_or_audit(run_dir: Path) -> None:
 class TestItemWithoutSynthesisOrAudit:
     """Cover branches where assessment.md/self-audit.md don't exist."""
 
-    def test_no_synthesis_or_audit(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_no_synthesis_or_audit(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_no_synthesis_or_audit(run_dir)
@@ -2601,7 +2600,7 @@ def _create_run_minimal_item(run_dir: Path) -> None:
 class TestItemWithoutAnyText:
     """Cover has_summary=False branch."""
 
-    def test_item_without_text(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_item_without_text(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_minimal_item(run_dir)
@@ -2613,11 +2612,11 @@ class TestItemWithoutAnyText:
 class TestRenderRunEmptyItems:
     """Cover branches when the run has no items at all."""
 
-    def test_render_run_no_items(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_render_run_no_items(self, tmp_path: Path) -> None:
         """Covers 563->572: toc_entries empty, no card sections."""
         run_dir = tmp_path / "run"
         run_dir.mkdir()
-        ri = {"claims": [], "queries": [], "axioms": []}
+        ri: dict[str, Any] = {"claims": [], "queries": [], "axioms": []}
         (run_dir / "research-input-clarified.json").write_text(json.dumps(ri))
         for fname in (
             "hypotheses.json",
@@ -2662,7 +2661,7 @@ def _create_run_with_item_no_id(run_dir: Path) -> None:
 class TestRenderRunItemWithoutIdInCards:
     """Cover 644->575: continue on item without id."""
 
-    def test_item_no_id_in_cards(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_item_no_id_in_cards(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_with_item_no_id(run_dir)
@@ -2724,7 +2723,7 @@ def _create_run_with_robis_no_overall(run_dir: Path) -> None:
 class TestRobisAuditBranches:
     """Cover robis_audit rendering branches."""
 
-    def test_robis_no_overall_and_bad_domain(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_robis_no_overall_and_bad_domain(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_with_robis_no_overall(run_dir)
@@ -2783,7 +2782,7 @@ def _create_run_report_no_bluf_no_verdict(run_dir: Path) -> None:
 class TestReportWithoutBlufOrVerdict:
     """Cover 811->813 and 818->820: report dict without bluf/verdict fields."""
 
-    def test_no_bluf_no_verdict(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_no_bluf_no_verdict(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_report_no_bluf_no_verdict(run_dir)
@@ -2848,7 +2847,7 @@ def _create_run_assessment_verdict_no_confidence(run_dir: Path) -> None:
 class TestAssessmentVerdictNoConfidence:
     """Cover 1174->1176: verdict present, confidence absent."""
 
-    def test_verdict_no_confidence(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_verdict_no_confidence(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_assessment_verdict_no_confidence(run_dir)
@@ -2913,7 +2912,7 @@ def _create_run_source_no_url_no_metadata(run_dir: Path) -> None:
 class TestSourceBareMinimum:
     """Cover 1577->1579 and 1586->1590: source with no metadata fields."""
 
-    def test_bare_source(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_bare_source(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_source_no_url_no_metadata(run_dir)
@@ -2979,7 +2978,7 @@ def _create_run_with_partial_gaps(run_dir: Path) -> None:
 class TestPartialGaps:
     """Cover 1192->1197, 1198->1203 False branches."""
 
-    def test_only_impact_in_gaps(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_only_impact_in_gaps(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_with_partial_gaps(run_dir)
@@ -3047,7 +3046,7 @@ def _create_run_with_plugin_source_verification(run_dir: Path) -> None:
 class TestPluginSourceVerification:
     """Cover 1296->1299, 1299->1302, 1302->1306 branches."""
 
-    def test_plugin_verification(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_plugin_verification(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_with_plugin_source_verification(run_dir)
@@ -3112,7 +3111,7 @@ def _create_run_with_empty_plugin_verification(run_dir: Path) -> None:
 class TestEmptyPluginVerificationAndGaps:
     """Cover 1204->1208, 1296->1299, 1299->1302, 1302->1306 False branches."""
 
-    def test_empty_plugin_verification_fields(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_empty_plugin_verification_fields(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_with_empty_plugin_verification(run_dir)
@@ -3180,7 +3179,7 @@ def _create_run_with_no_synthesis_for_item(run_dir: Path) -> None:
 class TestItemWithoutSynthesis:
     """Cover 831->833: assessment.md NOT existing in Results table."""
 
-    def test_no_synthesis_item(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_no_synthesis_item(self, tmp_path: Path) -> None:
         run_dir = tmp_path / "run"
         run_dir.mkdir()
         _create_run_with_no_synthesis_for_item(run_dir)
@@ -3207,7 +3206,7 @@ class TestRendererDefensiveGuards:
     # in _write_item_index and would crash on non-dict report. Those branches
     # are legitimately unreachable defensive guards.
 
-    def test_write_assessment_synthesis_non_dict(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_write_assessment_synthesis_non_dict(self, tmp_path: Path) -> None:
         """Cover 633->637, 635->637 inside _write_run_index.
 
         Similar defensive isinstance guards in run-index card rendering.
@@ -3234,7 +3233,7 @@ class TestRendererDefensiveGuards:
         result = _collect_hypothesis_ratings({}, {"assessment": "not a dict"})
         assert result == {}
 
-    def test_write_self_audit_process_non_dict_domain(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_write_self_audit_process_non_dict_domain(self, tmp_path: Path) -> None:
         """Cover the `not a dict` skip branch in the process_audit domain loop."""
         from diogenes.renderer import _write_self_audit
 
@@ -3251,7 +3250,7 @@ class TestRendererDefensiveGuards:
         content = (item_dir / "self-audit.md").read_text()
         assert "Synthesis Fairness" in content
 
-    def test_write_assessment_gaps_non_list_non_dict(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_write_assessment_gaps_non_list_non_dict(self, tmp_path: Path) -> None:
         """Cover 1190->1208: gaps is truthy but neither list nor dict.
 
         A string "gaps" value would trigger this defensive else-skip.
@@ -3266,7 +3265,7 @@ class TestRendererDefensiveGuards:
         # Evidence Gaps header may render but no list/dict content
         assert "Evidence Gaps" in content
 
-    def test_write_assessment_gaps_dict_no_impact(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_write_assessment_gaps_dict_no_impact(self, tmp_path: Path) -> None:
         """Cover 1204->1208: gaps dict with expected but no impact_on_confidence."""
         from diogenes.renderer import _write_assessment
 
@@ -3285,7 +3284,7 @@ class TestRendererDefensiveGuards:
 class TestMoreDefensiveBranches:
     """Additional targeted tests for remaining branches."""
 
-    def test_reading_list_unusual_priority(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_reading_list_unusual_priority(self, tmp_path: Path) -> None:
         """Cover 1353->1351: reading_list entry with priority outside the standard set."""
         from diogenes.renderer import _write_reading_list
 
@@ -3312,7 +3311,7 @@ class TestMoreDefensiveBranches:
         result = _extract_sources_for_item(scorecards, "C001")
         assert len(result) == 1
 
-    def test_assessment_confidence_without_verdict(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_assessment_confidence_without_verdict(self, tmp_path: Path) -> None:
         """Cover 1174->1176: assessment has confidence but no verdict.
 
         (1174 is `if assessment.get("verdict"):` — False path skips verdict, still

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -1,6 +1,7 @@
 """Tests for schema_validator module."""
 
 import json
+from pathlib import Path
 
 import pytest
 
@@ -72,15 +73,15 @@ class TestValidateResearchInput:
 class TestParseInputFile:
     """Tests for parse_input_file."""
 
-    def test_json_file(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "input.json"  # type: ignore[operator]
+    def test_json_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "input.json"
         path.write_text(json.dumps({"claims": [{"text": "Test"}]}))
         result = parse_input_file(path)
         assert isinstance(result, dict)
         assert result["claims"][0]["text"] == "Test"
 
-    def test_text_file(self, tmp_path: pytest.TempPathFactory) -> None:
-        path = tmp_path / "input.md"  # type: ignore[operator]
+    def test_text_file(self, tmp_path: Path) -> None:
+        path = tmp_path / "input.md"
         path.write_text("Is AI reliable for fact-checking?")
         result = parse_input_file(path)
         assert isinstance(result, str)
@@ -110,10 +111,10 @@ class TestValidationError:
 class TestLoadSchemaInvalidJson:
     """Test _load_schema with invalid JSON content."""
 
-    def test_invalid_json_schema_file(self, tmp_path: pytest.TempPathFactory, monkeypatch: pytest.MonkeyPatch) -> None:
+    def test_invalid_json_schema_file(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
         from diogenes import schema_validator
 
-        schema_dir = tmp_path / "schemas"  # type: ignore[operator]
+        schema_dir = tmp_path / "schemas"
         schema_dir.mkdir()
         bad_schema = schema_dir / "bad.schema.json"
         bad_schema.write_text("not valid json {{{")

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -2,6 +2,7 @@
 
 import json
 import subprocess
+from pathlib import Path
 
 import pytest
 
@@ -94,16 +95,17 @@ class TestStepStatus:
 class TestPipelineState:
     """Tests for PipelineState."""
 
-    def test_fresh_state(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_fresh_state(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         assert not state.all_complete()
-        assert state.next_step() is not None
-        assert state.next_step().name == "step_01_research_input_clarified"
+        first = state.next_step()
+        assert first is not None
+        assert first.name == "step_01_research_input_clarified"
 
-    def test_mark_complete(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_mark_complete(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         state.mark_complete("step_01_research_input_clarified", output_file="research-input-clarified.json")
@@ -111,8 +113,8 @@ class TestPipelineState:
         # State file should exist
         assert (run_dir / "pipeline-state.json").exists()
 
-    def test_mark_started(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_mark_started(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         state.mark_started("step_01_research_input_clarified")
@@ -120,8 +122,8 @@ class TestPipelineState:
         data = json.loads((run_dir / "pipeline-state.json").read_text())
         assert data["steps"][0]["status"] == "running"
 
-    def test_mark_failed(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_mark_failed(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         state.mark_started("step_01_research_input_clarified")
@@ -131,8 +133,8 @@ class TestPipelineState:
         assert data["steps"][0]["status"] == "failed"
         assert data["steps"][0]["diagnostics"] == "API error"
 
-    def test_persistence_and_reload(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_persistence_and_reload(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state1 = PipelineState(run_dir)
         state1.mark_complete("step_01_research_input_clarified")
@@ -140,8 +142,8 @@ class TestPipelineState:
         state2 = PipelineState(run_dir)
         assert state2.is_complete("step_01_research_input_clarified")
 
-    def test_next_step_checks_prerequisites(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_next_step_checks_prerequisites(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         # Complete step 1
@@ -154,8 +156,8 @@ class TestPipelineState:
         assert next_step is not None
         assert next_step.name == "step_02_hypotheses"
 
-    def test_all_complete(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_all_complete(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         for step in PIPELINE_STEPS:
@@ -163,8 +165,8 @@ class TestPipelineState:
         assert state.all_complete()
         assert state.next_step() is None
 
-    def test_summary(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_summary(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         state.mark_complete("step_01_research_input_clarified")
@@ -174,8 +176,8 @@ class TestPipelineState:
         assert s["failed"] == 0
         assert s["remaining"] == 10
 
-    def test_summary_with_failure(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_summary_with_failure(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         state.mark_failed("step_01_research_input_clarified", diagnostics="err")
@@ -183,8 +185,8 @@ class TestPipelineState:
         assert s["failed"] == 1
         assert s["remaining"] == 10
 
-    def test_elapsed_seconds_computed(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_elapsed_seconds_computed(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         state.mark_started("step_01_research_input_clarified")
@@ -193,7 +195,7 @@ class TestPipelineState:
         assert data["elapsed_seconds"] is not None
         assert data["elapsed_seconds"] >= 0
 
-    def test_pid_captured_on_save(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_pid_captured_on_save(self, tmp_path: Path) -> None:
         """pipeline-state.json includes the PID of the writing process.
 
         Used to correlate OS-level crash reports (e.g., macOS SIGABRT)
@@ -202,15 +204,15 @@ class TestPipelineState:
         """
         import os
 
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         state.mark_complete("step_01_research_input_clarified")
         data = json.loads((run_dir / "pipeline-state.json").read_text())
         assert data["pid"] == os.getpid()
 
-    def test_completed_at_set_when_all_done(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_completed_at_set_when_all_done(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         for step in PIPELINE_STEPS:
@@ -218,25 +220,25 @@ class TestPipelineState:
         data = json.loads((run_dir / "pipeline-state.json").read_text())
         assert data["completed_at"] is not None
 
-    def test_mark_complete_without_prior_start(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_mark_complete_without_prior_start(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         # Complete without calling mark_started first
         state.mark_complete("step_01_research_input_clarified")
         assert state.is_complete("step_01_research_input_clarified")
 
-    def test_mark_failed_without_prior_start(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_mark_failed_without_prior_start(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         state.mark_failed("step_01_research_input_clarified", diagnostics="immediate fail")
         data = json.loads((run_dir / "pipeline-state.json").read_text())
         assert data["steps"][0]["status"] == "failed"
 
-    def test_save_with_invalid_created_at(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_save_with_invalid_created_at(self, tmp_path: Path) -> None:
         """Covers the ValueError handler in _save when _created_at is unparseable."""
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         # Inject an invalid created_at to trigger the ValueError branch
@@ -246,9 +248,9 @@ class TestPipelineState:
         # elapsed_seconds should be None because parsing created_at failed
         assert data["elapsed_seconds"] is None
 
-    def test_mark_complete_with_invalid_started_at(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_mark_complete_with_invalid_started_at(self, tmp_path: Path) -> None:
         """Covers the ValueError handler in mark_complete when started_at is unparseable."""
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         # Inject a step with an invalid started_at
@@ -263,9 +265,9 @@ class TestPipelineState:
         assert step["status"] == "complete"
         assert step["elapsed_seconds"] is None
 
-    def test_mark_failed_with_invalid_started_at(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_mark_failed_with_invalid_started_at(self, tmp_path: Path) -> None:
         """Covers the ValueError handler in mark_failed when started_at is unparseable."""
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         # Inject a step with an invalid started_at
@@ -280,9 +282,9 @@ class TestPipelineState:
         assert step["status"] == "failed"
         assert step["elapsed_seconds"] is None
 
-    def test_save_with_no_created_at(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_save_with_no_created_at(self, tmp_path: Path) -> None:
         """Covers 257->263: _save when _created_at is None (falsy)."""
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         # Pre-populate a state file with no created_at key
         (run_dir / "pipeline-state.json").write_text(json.dumps({"steps": []}))
@@ -292,9 +294,9 @@ class TestPipelineState:
         # elapsed_seconds should be None because created_at is None
         assert data["elapsed_seconds"] is None
 
-    def test_mark_complete_with_none_started_at(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_mark_complete_with_none_started_at(self, tmp_path: Path) -> None:
         """Covers 310->316: mark_complete when existing.started_at is None (falsy)."""
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         # Inject a step with started_at=None
@@ -309,9 +311,9 @@ class TestPipelineState:
         assert step["status"] == "complete"
         assert step["elapsed_seconds"] is None
 
-    def test_mark_failed_with_none_started_at(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_mark_failed_with_none_started_at(self, tmp_path: Path) -> None:
         """Covers 334->340: mark_failed when existing.started_at is None (falsy)."""
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         state._completed["step_01_research_input_clarified"] = StepStatus(
@@ -382,8 +384,8 @@ class TestComputeVersion:
 class TestVersionInPipelineState:
     """Version metadata persisted in pipeline-state.json."""
 
-    def test_version_written_on_fresh_state(self, tmp_path: pytest.TempPathFactory) -> None:
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+    def test_version_written_on_fresh_state(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         state = PipelineState(run_dir)
         state.mark_complete("step_01_research_input_clarified")
@@ -391,7 +393,7 @@ class TestVersionInPipelineState:
         assert "version" in data
         assert "package_version" in data["version"]
 
-    def test_version_preserved_across_reload(self, tmp_path: pytest.TempPathFactory) -> None:
+    def test_version_preserved_across_reload(self, tmp_path: Path) -> None:
         """Resuming a run keeps the version from when the run was created.
 
         The version stamp identifies which code produced the outputs, not
@@ -399,7 +401,7 @@ class TestVersionInPipelineState:
         reload means resuming on a different commit doesn't overwrite the
         provenance trail.
         """
-        run_dir = tmp_path / "run-1"  # type: ignore[operator]
+        run_dir = tmp_path / "run-1"
         run_dir.mkdir()
         # Pre-populate with a specific version block that differs from
         # whatever _compute_version would produce here


### PR DESCRIPTION
## Summary

Closes #147

The type-check CI step was scoped narrowly (`uv run mypy src/`), leaving 101 mypy errors in `tests/` invisible to CI. This PR fixes all 101 and widens the CI step to `uv run mypy src tests` so regressions can't merge silently.

## Root cause of the bulk

53 of 101 errors were a single misannotation: `tmp_path: pytest.TempPathFactory` in test signatures. `tmp_path` is actually `pathlib.Path`; `TempPathFactory` is a different fixture with no `/` operator. The wrong annotation had ~33 `# type: ignore[operator]` comments papering over the resulting errors — once the annotation is corrected, the ignores become stale and also flag.

## Remaining fixes (incidental)

- Missing generic args: `dict` → `dict[str, Any]`, `tuple` → `tuple[...]`
- Missing var annotations on fixtures that build typed dicts
- `monkeypatch.setattr(run_mod.time, ...)` → `monkeypatch.setattr("time.sleep", ...)` — the former hits `attr-defined` because stdlib `time` isn't re-exported from `diogenes.commands.run`
- Typed the six `dispatch_side_effect` helpers used as mock `side_effect`s to mirror `_dispatch_step`'s signature

## Why ruff needed no change

`pyproject.toml` already sets `[tool.ruff] src = ["src", "tests"]`, so `ruff check` already covers both. Only mypy had the gap.

## Test plan

- [x] `uv run mypy src tests` — 0 errors across 36 files
- [x] 540 tests pass
- [x] 100% line + branch coverage maintained
- [x] `ruff check` + `ruff format --check` clean
- [ ] Confirm CI's new `mypy src tests` step passes after push

## Follow-ups (filed separately)

- Centralize the widened scope in `standard-actions/actions/python/type-check` so other repos inherit.
- Apply same fix to mq-rest-admin-python (37 uncaught errors in its `tests/`).