### PR TITLE
feat: plugin usage.json schema compliance (minimum slice)

### DIFF
--- a/ai-research-methodology/skills/research/SKILL.md
+++ b/ai-research-methodology/skills/research/SKILL.md
@@ -417,8 +417,29 @@ each item, assemble the final report from all prior steps. Write
 **Step 5j: Archive** — Combine all JSON outputs into `archive.json`
 with a timestamp and pipeline version.
 
-**Step 5k: Usage** — Record token usage, API call counts, and estimated
-costs. Write `usage.json` to the run group directory.
+**Step 5k: Usage** — Write `usage.json` to the run group directory.
+The file MUST conform to `src/diogenes/schemas/usage.schema.json`. Use
+the canonical `totals` + `per_call` structure so plugin-path and
+CLI-path runs are directly comparable.
+
+Claude Code does not expose per-API-call token counts, cache metrics,
+or per-call costs to skills. Set the fields you cannot observe to 0
+rather than omitting or inventing values:
+
+- `totals.input_tokens`, `totals.output_tokens`, `totals.total_tokens`,
+  `totals.estimated_cost_usd` — set to 0.
+- `totals.api_calls` — set to 0 unless you have an accurate count from
+  Python-side MCP calls.
+- `totals.web_search_requests` / `totals.web_fetch_requests` — set to
+  the accurate count tracked via `dio_search` / `dio_fetch` calls.
+- `per_call` — use an empty array `[]` if you do not have per-agent
+  token breakdowns.
+
+Plugin-specific extras (scoring distribution, verdict summaries, per-run
+stats, anything that does not fit the canonical shape) go under the
+optional top-level `plugin_metadata` key, free-form. Do NOT add new
+top-level keys — `additionalProperties: false` at the root will reject
+them.
 
 **Output files per run directory** (all JSON, no markdown):
 

--- a/src/diogenes/schemas/usage.schema.json
+++ b/src/diogenes/schemas/usage.schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://raw.githubusercontent.com/wphillipmoore/ai-research-methodology/main/src/diogenes/schemas/usage.schema.json",
   "title": "Usage Report",
-  "description": "Token usage, cost estimates, and API call tracking for a research run.",
+  "description": "Token usage, cost estimates, and API call tracking for a research run. On the CLI path all fields are accurate. On the plugin path (inside Claude Code) token counts are not exposed to the skill and those fields are set to 0; plugin-specific statistics that don't fit the canonical shape go under `plugin_metadata`.",
   "type": "object",
   "required": ["totals", "per_call"],
   "properties": {
@@ -39,6 +39,11 @@
         },
         "additionalProperties": false
       }
+    },
+    "plugin_metadata": {
+      "type": "object",
+      "description": "Plugin-path-only extras that don't fit the canonical CLI shape. Examples: source scoring distribution, verdict summaries, per-run pipeline stats. The CLI path never sets this key. Free-form to avoid schema churn as the plugin surface evolves; the canonical `totals` and `per_call` structure remains authoritative for cross-path comparison.",
+      "additionalProperties": true
     }
   },
   "additionalProperties": false

--- a/tests/test_schema_validator.py
+++ b/tests/test_schema_validator.py
@@ -121,3 +121,109 @@ class TestLoadSchemaInvalidJson:
         monkeypatch.setattr(schema_validator, "_SCHEMAS_DIR", schema_dir)
         with pytest.raises(ValidationError, match="Invalid JSON"):
             validate({}, "bad.schema.json")
+
+
+class TestUsageSchema:
+    """Tests for usage.schema.json — verifies CLI and plugin shapes both validate."""
+
+    def test_cli_shape_validates(self) -> None:
+        """The CLI produces a detailed per_call breakdown; this shape must validate."""
+        data = {
+            "totals": {
+                "input_tokens": 1000,
+                "output_tokens": 500,
+                "total_tokens": 1500,
+                "web_search_requests": 3,
+                "web_fetch_requests": 2,
+                "api_calls": 5,
+                "estimated_cost_usd": 0.012,
+            },
+            "per_call": [
+                {
+                    "agent": "hypothesis-gen",
+                    "model": "claude-sonnet-4-6",
+                    "input_tokens": 600,
+                    "output_tokens": 300,
+                    "cache_read_tokens": 200,
+                    "estimated_cost_usd": 0.007,
+                },
+            ],
+        }
+        assert validate(data, "usage.schema.json") == data
+
+    def test_plugin_shape_validates(self) -> None:
+        """Plugin path: token fields zeroed, plugin_metadata carries extras.
+
+        Claude Code does not expose token counts to skills, so the plugin
+        fills unknowns with 0 and carries plugin-specific stats under the
+        free-form `plugin_metadata` key.
+        """
+        data = {
+            "totals": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "web_search_requests": 7,
+                "web_fetch_requests": 4,
+                "api_calls": 0,
+                "estimated_cost_usd": 0.0,
+            },
+            "per_call": [],
+            "plugin_metadata": {
+                "scoring_distribution": {"high": 3, "medium": 2, "low": 1},
+                "verdict_summary": {"supported": 4, "contradicted": 1},
+            },
+        }
+        assert validate(data, "usage.schema.json") == data
+
+    def test_rejects_unknown_top_level_key(self) -> None:
+        """Plugin extras must go under plugin_metadata, not as new top-level keys."""
+        data = {
+            "totals": {
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "api_calls": 0,
+                "estimated_cost_usd": 0.0,
+            },
+            "per_call": [],
+            "custom_plugin_field": {"foo": "bar"},
+        }
+        with pytest.raises(ValidationError, match="usage.schema.json"):
+            validate(data, "usage.schema.json")
+
+    def test_rejects_missing_required_totals_field(self) -> None:
+        """Totals.input_tokens remains required even when set to 0."""
+        data = {
+            "totals": {
+                # missing input_tokens
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "api_calls": 0,
+                "estimated_cost_usd": 0.0,
+            },
+            "per_call": [],
+        }
+        with pytest.raises(ValidationError, match="usage.schema.json"):
+            validate(data, "usage.schema.json")
+
+    def test_cli_accumulator_output_conforms(self) -> None:
+        """Regression guard: UsageAccumulator.to_dict() output validates.
+
+        Catches drift between api_client.UsageAccumulator and
+        usage.schema.json — if either side changes, CI fails here.
+        """
+        from diogenes.api_client import CallUsage, UsageAccumulator
+
+        acc = UsageAccumulator()
+        acc.record(
+            CallUsage(
+                agent_name="hypothesis-gen",
+                model="claude-sonnet-4-6",
+                input_tokens=500,
+                output_tokens=100,
+                cache_read_tokens=200,
+                web_search_requests=2,
+            ),
+        )
+        validate(acc.to_dict(), "usage.schema.json")


### PR DESCRIPTION
## Summary

Ref #92

Minimum-scope slice — option D in the issue (accept the limitation, make the format conformant). The plugin path runs inside Claude Code, which does not expose token counts to skills; previously the plugin produced a free-form usage.json that did not match usage.schema.json, making cross-path comparison impossible.

Approaches A/B/C from the issue (hook into Claude Code telemetry, route all calls through MCP, wrap Anthropic calls in Python) are larger design changes deferred to later.

## Changes

**Schema (usage.schema.json):**
- Added optional top-level `plugin_metadata` (free-form object) for plugin-specific extras (scoring distribution, verdict summaries) that do not fit the canonical `totals + per_call` shape.
- Kept `additionalProperties: false` at the root so plugin extras go under `plugin_metadata` rather than sprouting new top-level keys.
- Expanded the top-level description to document the CLI/plugin split.

**SKILL.md Step 5k:**
- Explicitly points at `usage.schema.json` as the target format.
- Spells out that unobservable fields (tokens, costs) are set to 0, not omitted or invented.
- Directs plugin-specific stats to `plugin_metadata`.

## Tests added

- CLI-shaped usage.json validates.
- Plugin-shaped usage.json (zeros + plugin_metadata) validates.
- Unknown top-level keys rejected.
- Missing required totals fields rejected.
- **Regression guard:** `UsageAccumulator.to_dict()` output conforms — catches drift between `api_client.py` and the schema.

## Test plan

- [x] 545 tests pass (+5 new)
- [x] 100% line + branch coverage maintained
- [x] ruff check + format clean
- [x] mypy src tests — 0 errors (per newly-enforced CI scope from #148)
- [ ] Next plugin-path smoke run produces a schema-valid usage.json with tokens zeroed and stats under plugin_metadata
