### PR TITLE
fix: pipeline reports emit title for run-level index headings (#161)

### DIFF
--- a/src/diogenes/prompts/sub-agents/reports.md
+++ b/src/diogenes/prompts/sub-agents/reports.md
@@ -34,6 +34,23 @@ purposes only; do not attempt to re-interpret the sources yourself.
 Produce the final report. Every claim must be sourced. Every judgment
 must be distinguished from fact. Every reasoning chain must be explicit.
 
+### Topic title (mandatory)
+
+Emit a top-level `title` field: a short, human-readable topic label
+for this item. It is read by the renderer into run-level index cards
+and per-item page titles, so it must be informative enough that a
+table-of-contents entry like `Q001 — <title>` conveys what the query
+is about without opening the card.
+
+- Target length: 8–10 words.
+- Hard cap: 60 characters.
+- Style: noun phrase, title case or sentence case — no trailing period.
+- Content: derive from the clarified input text plus the final
+  assessment answer. Prefer concrete domain terms over generic filler
+  ("LLM watermarking techniques" over "A study of AI text").
+- Do not duplicate the verdict or confidence label here. The renderer
+  already appends those separately.
+
 ### Claim mode report structure
 
 1. Claim as received and clarified

--- a/src/diogenes/renderer.py
+++ b/src/diogenes/renderer.py
@@ -193,10 +193,25 @@ def _pipeline_notes_section(events: dict[str, Any]) -> list[str]:
 
 
 def _card_heading_for(item: dict[str, Any], report: dict[str, Any]) -> str:
-    """Build '{id} — {topic} — {qualifier}' heading string used across pages."""
+    """Build '{id} — {topic} — {qualifier}' heading string used across pages.
+
+    Reads `title`, `verdict`, and `confidence` at the report top level.
+    Falls back to `assessment_summary.{verdict,confidence}` for the
+    qualifier — the pipeline emits those nested, and the top-level
+    position is reserved for future simplification. Missing pieces
+    degrade gracefully: an id-only heading is still valid output so
+    older runs (produced before `title` became required) render without
+    crashing.
+    """
     iid = item.get("id", "?")
     topic = report.get("title", "").strip()
     qualifier = (report.get("verdict") or report.get("confidence") or "").strip()
+    if not qualifier:
+        assess = report.get("assessment_summary")
+        if isinstance(assess, dict):
+            nested = assess.get("verdict") or assess.get("confidence") or ""
+            if isinstance(nested, str):
+                qualifier = nested.strip()
     parts = [iid]
     if topic:
         parts.append(topic)

--- a/src/diogenes/schemas/reports.schema.json
+++ b/src/diogenes/schemas/reports.schema.json
@@ -7,6 +7,7 @@
   "required": [
     "id",
     "mode",
+    "title",
     "input_summary",
     "assessment_summary",
     "evidence_summary",
@@ -26,6 +27,12 @@
         "claim",
         "query"
       ]
+    },
+    "title": {
+      "type": "string",
+      "description": "Short human-readable topic label for this claim/query, used in run-level index cards and per-item page titles. Target 8-10 words, hard cap 60 characters. Generated from the clarified text plus the assessment answer so TOC entries are meaningful without opening each card.",
+      "minLength": 1,
+      "maxLength": 60
     },
     "input_summary": {
       "type": "object",

--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -760,6 +760,7 @@ class TestStep10Report:
     def test_generates_report(self) -> None:
         mock_client = MagicMock()
         mock_client.call_sub_agent.return_value = {
+            "title": "Sample topic label",
             "assessment_summary": {"verdict": "Supported", "answer": "Yes"},
         }
 
@@ -778,3 +779,94 @@ class TestStep10Report:
         )
         assert "C001" in result
         assert "Q001" in result
+
+    def test_uses_reports_schema(self) -> None:
+        """step10_report passes reports.schema.json to the sub-agent (issue #161)."""
+        mock_client = MagicMock()
+        mock_client.call_sub_agent.return_value = {
+            "title": "Topic",
+            "assessment_summary": {"verdict": "Supported"},
+        }
+        research_input = {"claims": [{"id": "C001", "clarified_text": "Test"}], "queries": []}
+
+        step10_report(
+            research_input,
+            {"C001": {}},
+            {"C001": {}},
+            {"C001": {"scorecards": []}},
+            {"C001": {}},
+            {"C001": {}},
+            mock_client,
+        )
+
+        _args, kwargs = mock_client.call_sub_agent.call_args
+        assert kwargs["output_schema"] == "reports.schema.json", (
+            "step10_report must declare the reports schema so constrained decoding "
+            "enforces the new required `title` field from issue #161"
+        )
+
+    def test_preserves_title_field_from_agent_response(self) -> None:
+        """The `title` field round-trips from the sub-agent response into results (issue #161).
+
+        The renderer's run-level index cards read `report.title` to build
+        their heading. If step10_report ever drops or rewrites the field,
+        the index collapses to bare ids — the exact regression #161 fixes.
+        """
+        mock_client = MagicMock()
+        mock_client.call_sub_agent.return_value = {
+            "title": "LLM watermarking techniques survey",
+            "assessment_summary": {"verdict": "Supported", "confidence": "High (80-95%)"},
+        }
+
+        research_input = {"claims": [{"id": "C001", "clarified_text": "Test claim"}], "queries": []}
+        result = step10_report(
+            research_input,
+            {"C001": {}},
+            {"C001": {}},
+            {"C001": {"scorecards": []}},
+            {"C001": {}},
+            {"C001": {}},
+            mock_client,
+        )
+
+        assert result["C001"]["title"] == "LLM watermarking techniques survey", (
+            "step10_report must surface the agent's `title` field verbatim so the "
+            "renderer can build run-level index card headings"
+        )
+
+
+class TestReportsSchema:
+    """Schema-level tests for reports.schema.json (issue #161)."""
+
+    def test_schema_requires_top_level_title(self) -> None:
+        """`title` is a required top-level field on every report.
+
+        The renderer's `_card_heading_for` reads it to build headings like
+        `### Q001 — <topic> — <qualifier>`. Missing `title` collapsed R0063's
+        run-level index to bare `### Q001` cards (issue #161). Making the
+        field required here means constrained-decoding catches the regression
+        at the API boundary, not at render time.
+        """
+        import json as _json
+        from pathlib import Path as _Path
+
+        schema_path = _Path(__file__).parent.parent / "src" / "diogenes" / "schemas" / "reports.schema.json"
+        schema = _json.loads(schema_path.read_text())
+        assert "title" in schema["required"], (
+            "reports.schema.json must list `title` as required so constrained "
+            "decoding rejects outputs that would collapse the run-level index"
+        )
+        assert schema["properties"]["title"]["type"] == "string"
+        # Hard cap matches the issue spec (~60 chars, ~8-10 words)
+        assert schema["properties"]["title"].get("maxLength") == 60
+
+    def test_reports_prompt_describes_title_field(self) -> None:
+        """reports.md tells the LLM to produce the `title` field (issue #161)."""
+        from pathlib import Path as _Path
+
+        prompt_path = _Path(__file__).parent.parent / "src" / "diogenes" / "prompts" / "sub-agents" / "reports.md"
+        prompt_text = prompt_path.read_text()
+        assert "title" in prompt_text.lower(), "reports.md must instruct the LLM to emit `title`"
+        assert "60 character" in prompt_text or "60 char" in prompt_text, (
+            "reports.md must state the 60-character hard cap so the LLM produces headings that fit on one TOC line"
+        )

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -569,6 +569,65 @@ class TestCardHeadingFor:
         item = {"id": "C003"}
         assert _card_heading_for(item, {}) == "C003"
 
+    def test_qualifier_falls_back_to_assessment_summary_confidence(self) -> None:
+        """Issue #161: pipeline emits confidence nested under `assessment_summary`.
+
+        When the top-level `confidence`/`verdict` fields are absent, the heading
+        must still pick up the nested qualifier so the TOC stays readable.
+        """
+        item = {"id": "Q001"}
+        report = {
+            "title": "LLM watermarking techniques",
+            "assessment_summary": {"confidence": "Medium (55-80%)"},
+        }
+        assert _card_heading_for(item, report) == "Q001 — LLM watermarking techniques — Medium (55-80%)"
+
+    def test_qualifier_falls_back_to_assessment_summary_verdict(self) -> None:
+        """Claim-mode reports: nested `assessment_summary.verdict` feeds the qualifier."""
+        item = {"id": "C001"}
+        report = {
+            "title": "Homophily in AI safety ethics",
+            "assessment_summary": {"verdict": "Likely (55-80%)"},
+        }
+        assert _card_heading_for(item, report) == "C001 — Homophily in AI safety ethics — Likely (55-80%)"
+
+    def test_title_missing_renders_id_only_for_backwards_compatibility(self) -> None:
+        """Older runs lacking `title` must still render without crashing (issue #161).
+
+        Older run JSONs (R0063 and earlier) do not carry `title`. The
+        renderer must degrade to id-only rather than raise — there is no
+        way to re-run those old LLM calls cheaply until #162 ships.
+        """
+        item = {"id": "Q001"}
+        report = {"assessment_summary": {"confidence": "High"}}
+        # No title → id plus nested qualifier only, no crash
+        assert _card_heading_for(item, report) == "Q001 — High"
+
+    def test_top_level_overrides_nested_qualifier(self) -> None:
+        """Top-level `verdict`/`confidence` win when present (forward compatibility)."""
+        item = {"id": "C001"}
+        report = {
+            "title": "Topic",
+            "verdict": "Strongly supported",
+            "assessment_summary": {"verdict": "ignored"},
+        }
+        assert _card_heading_for(item, report) == "C001 — Topic — Strongly supported"
+
+    def test_nested_qualifier_non_string_is_ignored(self) -> None:
+        """Defensive: a non-string nested verdict/confidence does not crash or leak.
+
+        Guards against malformed older run JSONs where the nested
+        `assessment_summary.verdict` might be something structured (a
+        dict/list) instead of a plain string.
+        """
+        item = {"id": "Q001"}
+        report = {
+            "title": "Topic",
+            # Non-string nested values — the helper must fall through to id+topic only.
+            "assessment_summary": {"verdict": {"unexpected": "shape"}},
+        }
+        assert _card_heading_for(item, report) == "Q001 — Topic"
+
 
 class TestAddToc:
     """Tests for _add_toc."""
@@ -3469,6 +3528,135 @@ class TestRunIndexCliFormatRegression:
         assert "Items investigated | 3" in index, (
             "Collection Statistics row missing or undercounting — expected 'Items investigated | 3'"
         )
+
+
+class TestRunIndexTitleHeadingRegression:
+    """Regression tests for issue #161.
+
+    Pre-fix behavior (R0063): the per-query cards in the run-level
+    `index.md` collapsed to bare `### Q001`, `### Q002`, … because the
+    pipeline's report-generation step did not emit a `title` field.
+    With 8+ queries the TOC became an opaque list of ids.
+
+    These tests assert that once `title` is populated at the report
+    level and the qualifier falls back to `assessment_summary` when
+    needed, the rendered run-level `index.md` carries the full
+    `### Q001 — <title> — <qualifier>` three-part heading format.
+    """
+
+    def test_run_index_card_heading_is_three_part_for_query(self, tmp_path: Path) -> None:
+        """Query card heading includes id, title, and nested confidence qualifier."""
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        clarified = {
+            "claims": [],
+            "queries": [
+                {
+                    "id": "Q001",
+                    "original_text": "Query text",
+                    "clarified_text": "Clarified query",
+                },
+            ],
+            "axioms": [],
+        }
+        (run_dir / "research-input-clarified.json").write_text(json.dumps(clarified))
+        reports = {
+            "Q001": {
+                "id": "Q001",
+                "mode": "query",
+                "title": "LLM watermarking techniques survey",
+                "assessment_summary": {
+                    "answer": "Several techniques documented.",
+                    "confidence": "Medium (55-80%)",
+                },
+            },
+        }
+        (run_dir / "reports.json").write_text(json.dumps(reports))
+
+        render_run(run_dir, run_dir)
+
+        index = (run_dir / "index.md").read_text()
+        assert "### Q001 — LLM watermarking techniques survey — Medium (55-80%)" in index, (
+            "run-level index card heading missing three-part format from issue #161 fix"
+        )
+
+    def test_run_index_card_heading_is_three_part_for_claim(self, tmp_path: Path) -> None:
+        """Claim card heading uses nested `assessment_summary.verdict` as qualifier."""
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        clarified = {
+            "claims": [
+                {
+                    "id": "C001",
+                    "original_text": "Claim text",
+                    "clarified_text": "Clarified claim",
+                },
+            ],
+            "queries": [],
+            "axioms": [],
+        }
+        (run_dir / "research-input-clarified.json").write_text(json.dumps(clarified))
+        reports = {
+            "C001": {
+                "id": "C001",
+                "mode": "claim",
+                "title": "AI safety ethics homophily",
+                "assessment_summary": {
+                    "verdict": "Likely (55-80%)",
+                    "confidence": "Medium",
+                },
+            },
+        }
+        (run_dir / "reports.json").write_text(json.dumps(reports))
+
+        render_run(run_dir, run_dir)
+
+        index = (run_dir / "index.md").read_text()
+        # The R0058-era target format from the issue
+        assert "### C001 — AI safety ethics homophily — Likely (55-80%)" in index, (
+            "run-level index claim heading missing three-part format from issue #161 fix"
+        )
+
+    def test_run_index_toc_entry_includes_title(self, tmp_path: Path) -> None:
+        """TOC sub-entries carry the topic title, not just bare ids.
+
+        This is the observable bug from R0063: an 8-query TOC rendered as
+        an opaque list of `Q001 … Q008` with no context. Post-fix, every
+        TOC entry carries its topic.
+        """
+        run_dir = tmp_path / "run"
+        run_dir.mkdir()
+        clarified = {
+            "claims": [],
+            "queries": [
+                {"id": "Q001", "clarified_text": "q1"},
+                {"id": "Q002", "clarified_text": "q2"},
+            ],
+            "axioms": [],
+        }
+        (run_dir / "research-input-clarified.json").write_text(json.dumps(clarified))
+        reports = {
+            "Q001": {
+                "id": "Q001",
+                "mode": "query",
+                "title": "Topic one",
+                "assessment_summary": {"confidence": "High"},
+            },
+            "Q002": {
+                "id": "Q002",
+                "mode": "query",
+                "title": "Topic two",
+                "assessment_summary": {"confidence": "Low"},
+            },
+        }
+        (run_dir / "reports.json").write_text(json.dumps(reports))
+
+        render_run(run_dir, run_dir)
+
+        index = (run_dir / "index.md").read_text()
+        # TOC lines are `    - [<heading>](#card-<id>)`; assert topic appears in the link text
+        assert "Topic one" in index, "TOC missing title `Topic one` for Q001"
+        assert "Topic two" in index, "TOC missing title `Topic two` for Q002"
 
 
 def _create_cli_format_realistic_run(run_dir: Path) -> None:


### PR DESCRIPTION
## Summary

Adds the missing top-level `title` field to the report-generation step so the renderer's run-level `index.md` can build full `### Q001 — <topic> — <qualifier>` headings. R0063 previously collapsed to bare `### Q001`, `### Q002`, ... making an 8-query TOC unnavigable.

- **Pipeline (primary fix)**: `reports.schema.json` requires a new top-level `title` field (60-char hard cap); `reports.md` prompt instructs the LLM to emit it.
- **Renderer (minor)**: `_card_heading_for` now falls back to `assessment_summary.{verdict,confidence}` when the top-level fields are absent. Pipeline leaves those nested; pulling them up would have required plumbing two additional required fields.
- **Backwards compatibility**: older runs without `title` still render (id-only heading, no crash). R0063 cannot be backfilled cheaply until #162 lands.

## Investigation

- `_card_heading_for` at `renderer.py:195` has read `report.title` since commit `098648a` (April 2026, "fix: use topic title in card headings").
- `title` was never added to `reports.schema.json` at the top level or to `reports.md`. Confirmed via `git log --all -S '"title"' -- src/diogenes/schemas/reports.schema.json` — the only `title` references in schema history are on `evidence_summary.key_sources[].title`.
- So this is "feature never implemented on the pipeline side", not a regression — but user-observable behavior matches a regression because the renderer shipped expecting the field.

## Before / after

Before:

```
### Q001
```

After:

```
### Q001 — LLM watermarking techniques survey — Medium (55-80%)
```

## Tests

All content-asserting, not coverage walks:

- Schema-level: `title` is required, capped at 60 chars; `reports.md` describes the field and the cap.
- Pipeline (`step10_report`): declares the reports schema and round-trips the agent's `title` verbatim into results.
- Renderer unit (`_card_heading_for`): falls back to nested verdict/confidence; top-level still wins when present; missing title degrades to id-only; non-string nested qualifier ignored.
- Renderer end-to-end (`render_run`): produces the three-part heading for both claim and query cards; TOC entries carry the topic titles (the R0063 observable symptom).

## Test plan

- [x] `ruff check .` passes
- [x] `ruff format --check .` passes
- [x] `mypy --explicit-package-bases src tests` passes
- [x] `pytest --cov=src/diogenes --cov-fail-under=100` passes (586 tests, 100.00% line+branch)
- [ ] Human reviews and merges

Closes #161

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
