### PR TITLE
fix: run ruff/mypy/pytest/audit on host so local matches CI (#160)

### DIFF
--- a/docs/validation.md
+++ b/docs/validation.md
@@ -9,11 +9,34 @@ st-validate-local
 This runs all Tier 1 validation checks: lint, format, type check, tests,
 and repo-specific custom validation. Requires standard-tooling on PATH.
 
+The dev scripts (`scripts/dev/lint.sh`, `typecheck.sh`, `test.sh`,
+`audit.sh`) run **on the host** via `uv run` by default, so failures
+surface without needing Docker. This is the intentional local-validation
+contract: anything CI rejects must be rejected locally.
+
+For CI parity (to reproduce a container-only failure), opt in with:
+
+```bash
+USE_DOCKER=1 scripts/dev/lint.sh
+```
+
+This requires `st-docker-test` on PATH and the Docker daemon running.
+
+## What each script runs (must match CI)
+
+- `lint.sh` runs `uv run ruff check` and `uv run ruff format --check .`
+  (matches CI unit-tests: Run ruff check + Run ruff format check).
+- `typecheck.sh` runs `uv run mypy src tests` (matches CI type-check).
+- `test.sh` runs `uv run pytest --cov=diogenes --cov-branch
+  --cov-fail-under=100` (matches CI unit-tests: Run tests with coverage).
+- `audit.sh` runs `uv lock --check`, `uv run pip-audit`, and
+  `uv run pip-licenses` (matches CI dependency-audit).
+
 ## Manual validation (without standard-tooling)
 
 ```bash
 uv run ruff check
 uv run ruff format --check .
-uv run mypy src/
-uv run pytest -v
+uv run mypy src tests
+uv run pytest --cov=diogenes --cov-branch --cov-fail-under=100
 ```

--- a/scripts/dev/audit.sh
+++ b/scripts/dev/audit.sh
@@ -1,12 +1,30 @@
 #!/usr/bin/env bash
+# audit.sh — run uv lock + pip-audit + pip-licenses, matching CI.
+#
+# Default: run on the host via `uv run` so failures surface immediately.
+# Opt-in Docker parity: USE_DOCKER=1 scripts/dev/audit.sh
 set -euo pipefail
 
-export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
-export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --check --frozen --group dev && uv lock --check && uv run pip-audit -r requirements.txt -r requirements-dev.txt && uv run pip-licenses --allow-only=\"\$(grep -v '^\#' .pip-licenses-allowlist | grep -v '^\$' | paste -sd ';' -)\"}"
+if [[ "${USE_DOCKER:-0}" == "1" ]]; then
+  export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
+  export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --check --frozen --group dev && uv lock --check && uv run pip-audit -r requirements.txt -r requirements-dev.txt && uv run pip-licenses --allow-only=\"\$(grep -v '^\#' .pip-licenses-allowlist | grep -v '^\$' | paste -sd ';' -)\"}"
 
-if ! command -v st-docker-test >/dev/null 2>&1; then
-  echo "ERROR: st-docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
-  exit 1
+  if ! command -v st-docker-test >/dev/null 2>&1; then
+    echo "ERROR: st-docker-test not found on PATH." >&2
+    echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
+    exit 1
+  fi
+  exec st-docker-test
 fi
-exec st-docker-test
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+echo "== uv lock --check =="
+uv lock --check
+
+echo "== pip-audit =="
+uv run pip-audit -r requirements.txt -r requirements-dev.txt
+
+echo "== pip-licenses =="
+allow="$(grep -v '^#' "$repo_root/.pip-licenses-allowlist" | grep -v '^$' | paste -sd ';' -)"
+uv run pip-licenses --allow-only="$allow"

--- a/scripts/dev/lint.sh
+++ b/scripts/dev/lint.sh
@@ -1,12 +1,27 @@
 #!/usr/bin/env bash
+# lint.sh — run ruff check + ruff format --check, matching CI's unit-tests job.
+#
+# Default: run on the host via `uv run` so failures surface immediately,
+# without requiring Docker or `st-docker-test` on PATH. This mirrors the
+# local-validation contract: anything CI rejects must be rejected locally.
+#
+# Opt-in Docker parity (for debugging CI-only failures):
+#   USE_DOCKER=1 scripts/dev/lint.sh
 set -euo pipefail
 
-export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
-export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run ruff check && uv run ruff format --check .}"
+if [[ "${USE_DOCKER:-0}" == "1" ]]; then
+  export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
+  export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run ruff check && uv run ruff format --check .}"
 
-if ! command -v st-docker-test >/dev/null 2>&1; then
-  echo "ERROR: st-docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
-  exit 1
+  if ! command -v st-docker-test >/dev/null 2>&1; then
+    echo "ERROR: st-docker-test not found on PATH." >&2
+    echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
+    exit 1
+  fi
+  exec st-docker-test
 fi
-exec st-docker-test
+
+echo "== ruff check =="
+uv run ruff check
+echo "== ruff format --check =="
+uv run ruff format --check .

--- a/scripts/dev/test.sh
+++ b/scripts/dev/test.sh
@@ -1,12 +1,24 @@
 #!/usr/bin/env bash
+# test.sh — run pytest with branch coverage and 100% threshold, matching CI.
+#
+# CI runs `pytest --cov=diogenes --cov-report=term-missing --cov-branch
+# --cov-fail-under=100` (see .github/workflows/ci.yml unit-tests job).
+#
+# Default: run on the host via `uv run` so failures surface immediately.
+# Opt-in Docker parity: USE_DOCKER=1 scripts/dev/test.sh
 set -euo pipefail
 
-export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
-export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run pytest --cov=diogenes --cov-report=term-missing --cov-branch --cov-fail-under=100}"
+if [[ "${USE_DOCKER:-0}" == "1" ]]; then
+  export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
+  export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run pytest --cov=diogenes --cov-report=term-missing --cov-branch --cov-fail-under=100}"
 
-if ! command -v st-docker-test >/dev/null 2>&1; then
-  echo "ERROR: st-docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
-  exit 1
+  if ! command -v st-docker-test >/dev/null 2>&1; then
+    echo "ERROR: st-docker-test not found on PATH." >&2
+    echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
+    exit 1
+  fi
+  exec st-docker-test
 fi
-exec st-docker-test
+
+echo "== pytest --cov=diogenes --cov-branch --cov-fail-under=100 =="
+uv run pytest --cov=diogenes --cov-report=term-missing --cov-branch --cov-fail-under=100

--- a/scripts/dev/typecheck.sh
+++ b/scripts/dev/typecheck.sh
@@ -1,12 +1,25 @@
 #!/usr/bin/env bash
+# typecheck.sh — run mypy on src AND tests, matching CI's type-check job.
+#
+# CI runs `uv run mypy src tests` (see .github/workflows/ci.yml type-check job).
+# Historically this script ran `mypy src/` only, which let tests-only type
+# errors escape local validation. Now it mirrors CI.
+#
+# Default: run on the host via `uv run` so failures surface immediately.
+# Opt-in Docker parity: USE_DOCKER=1 scripts/dev/typecheck.sh
 set -euo pipefail
 
-export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
-export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run mypy src/}"
+if [[ "${USE_DOCKER:-0}" == "1" ]]; then
+  export DOCKER_DEV_IMAGE="${DOCKER_DEV_IMAGE:-dev-python:3.14}"
+  export DOCKER_TEST_CMD="${DOCKER_TEST_CMD:-uv sync --frozen --group dev && uv run mypy src tests}"
 
-if ! command -v st-docker-test >/dev/null 2>&1; then
-  echo "ERROR: st-docker-test not found on PATH." >&2
-  echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
-  exit 1
+  if ! command -v st-docker-test >/dev/null 2>&1; then
+    echo "ERROR: st-docker-test not found on PATH." >&2
+    echo "Set up standard-tooling: export PATH=../standard-tooling/.venv/bin:\$PATH" >&2
+    exit 1
+  fi
+  exec st-docker-test
 fi
-exec st-docker-test
+
+echo "== mypy src tests =="
+uv run mypy src tests

--- a/tests/test_dev_scripts.py
+++ b/tests/test_dev_scripts.py
@@ -1,0 +1,238 @@
+"""Regression tests for ``scripts/dev/*.sh`` host-mode validation.
+
+These tests exist to prevent the "silent local validation" regression
+described in issue #160: the previous ``lint.sh`` / ``typecheck.sh`` /
+``test.sh`` required Docker + ``st-docker-test`` on PATH, and their
+output was invisible. A ruff-rejectable file could land and the local
+validator would report success. This suite asserts the opposite: when a
+known-bad file appears in the project, the relevant script must exit
+non-zero.
+
+The tests build an isolated tmp project that imports the real scripts,
+so they do not mutate the repo under test.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DEV = REPO_ROOT / "scripts" / "dev"
+
+
+def _uv_available() -> bool:
+    """Return True if uv is installed (the scripts shell out to it)."""
+    return shutil.which("uv") is not None
+
+
+pytestmark = pytest.mark.skipif(
+    not _uv_available(),
+    reason="scripts/dev/*.sh require `uv` on PATH",
+)
+
+
+def _write_minimal_project(root: Path, *, bad_source: str | None = None) -> None:
+    """Scaffold a tiny project that `uv run ruff/mypy/pytest` can operate on.
+
+    Writes a pyproject.toml mirroring the real repo's ruff/mypy config, a
+    ``src/toyproj/__init__.py`` (clean by default), and a ``tests/test_x.py``
+    placeholder. When ``bad_source`` is set, it is written to a module
+    the corresponding script will scan.
+    """
+    (root / "src" / "toyproj").mkdir(parents=True)
+    (root / "tests").mkdir()
+    (root / "src" / "toyproj" / "__init__.py").write_text('"""toyproj package."""\n')
+    (root / "tests" / "__init__.py").write_text("")
+    (root / "tests" / "test_x.py").write_text(
+        textwrap.dedent(
+            """\
+            def test_smoke() -> None:
+                assert 1 + 1 == 2
+            """
+        )
+    )
+    (root / "pyproject.toml").write_text(
+        textwrap.dedent(
+            """\
+            [build-system]
+            requires = ["setuptools>=68", "wheel"]
+            build-backend = "setuptools.build_meta"
+
+            [project]
+            name = "toyproj"
+            version = "0.0.1"
+            requires-python = ">=3.14,<4.0"
+
+            [tool.setuptools]
+            package-dir = {"" = "src"}
+
+            [tool.setuptools.packages.find]
+            where = ["src"]
+
+            [dependency-groups]
+            dev = ["ruff", "mypy", "pytest", "pytest-cov"]
+
+            [tool.ruff]
+            line-length = 120
+            target-version = "py314"
+            src = ["src", "tests"]
+
+            [tool.ruff.lint]
+            select = ["E", "F", "PT"]
+
+            [tool.mypy]
+            python_version = "3.14"
+            strict = true
+
+            [tool.pytest.ini_options]
+            testpaths = ["tests"]
+            """
+        )
+    )
+    if bad_source is not None:
+        (root / "src" / "toyproj" / "bad.py").write_text(bad_source)
+
+
+def _copy_script(script_name: str, dest: Path) -> Path:
+    """Copy a repo dev script into ``dest/scripts/dev/`` preserving mode."""
+    target_dir = dest / "scripts" / "dev"
+    target_dir.mkdir(parents=True, exist_ok=True)
+    target = target_dir / script_name
+    shutil.copy(SCRIPTS_DEV / script_name, target)
+    target.chmod(0o755)
+    return target
+
+
+def _run_script(script: Path, cwd: Path) -> subprocess.CompletedProcess[str]:
+    """Run a dev script and capture its output."""
+    env = os.environ.copy()
+    env.pop("USE_DOCKER", None)
+    return subprocess.run(  # noqa: S603  # trusted: script path is from this repo
+        [str(script)],
+        cwd=str(cwd),
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+class TestLintScriptRegressionGuard:
+    """Contract: scripts/dev/lint.sh must fail on ruff-rejectable code."""
+
+    def test_clean_project_exits_zero(self, tmp_path: Path) -> None:
+        _write_minimal_project(tmp_path)
+        script = _copy_script("lint.sh", tmp_path)
+        result = _run_script(script, tmp_path)
+        assert result.returncode == 0, f"clean project should pass lint; stderr={result.stderr!r}"
+        assert "ruff check" in result.stdout
+
+    def test_unused_import_fails(self, tmp_path: Path) -> None:
+        # F401: unused import — classic ruff rejection.
+        _write_minimal_project(
+            tmp_path,
+            bad_source='"""Bad module."""\nimport os  # F401 unused\n',
+        )
+        script = _copy_script("lint.sh", tmp_path)
+        result = _run_script(script, tmp_path)
+        assert result.returncode != 0, (
+            f"ruff-rejectable file must fail lint.sh; stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+    def test_bad_format_fails(self, tmp_path: Path) -> None:
+        # Unformatted source — ruff format --check must reject.
+        _write_minimal_project(
+            tmp_path,
+            bad_source='"""Bad module."""\nx=1+2\n',
+        )
+        script = _copy_script("lint.sh", tmp_path)
+        result = _run_script(script, tmp_path)
+        assert result.returncode != 0, (
+            f"badly-formatted file must fail lint.sh; stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+
+class TestTypecheckScriptRegressionGuard:
+    """Contract: scripts/dev/typecheck.sh must fail on mypy errors.
+
+    Critically, it must catch errors in ``tests/`` as well as ``src/``
+    — this was gap #4 in issue #160 (CI ran ``mypy src tests``; local
+    ran ``mypy src/``, missing test-only annotation errors).
+    """
+
+    def test_tests_type_error_fails(self, tmp_path: Path) -> None:
+        _write_minimal_project(tmp_path)
+        # Plant a mypy-rejectable return-type mismatch IN tests/ to prove
+        # the expanded scope (src tests) vs. the old (src/) is working.
+        (tmp_path / "tests" / "test_bad.py").write_text(
+            textwrap.dedent(
+                """\
+                def returns_int() -> int:
+                    return "not an int"  # type: str -> int mismatch
+                """
+            )
+        )
+        script = _copy_script("typecheck.sh", tmp_path)
+        result = _run_script(script, tmp_path)
+        assert result.returncode != 0, (
+            f"mypy error in tests/ must fail typecheck.sh (gap #4); stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+        assert "tests" in (result.stdout + result.stderr)
+
+
+class TestTestScriptRegressionGuard:
+    """Contract: scripts/dev/test.sh must enforce 100% coverage."""
+
+    def test_missing_coverage_fails(self, tmp_path: Path) -> None:
+        _write_minimal_project(tmp_path)
+        # Add an untested branch to force <100% coverage.
+        (tmp_path / "src" / "toyproj" / "uncovered.py").write_text(
+            textwrap.dedent(
+                """\
+                def never_called() -> int:
+                    return 42
+                """
+            )
+        )
+        # Rewrite test.sh invocation to target toyproj (repo default targets
+        # diogenes). Easiest: replace the cov package name in a copy.
+        target_dir = tmp_path / "scripts" / "dev"
+        target_dir.mkdir(parents=True, exist_ok=True)
+        src = (SCRIPTS_DEV / "test.sh").read_text()
+        patched = src.replace("--cov=diogenes", "--cov=toyproj")
+        script = target_dir / "test.sh"
+        script.write_text(patched)
+        script.chmod(0o755)
+        result = _run_script(script, tmp_path)
+        assert result.returncode != 0, (
+            "uncovered code must fail test.sh's --cov-fail-under=100; "
+            f"stdout={result.stdout!r} stderr={result.stderr!r}"
+        )
+
+
+class TestDockerOptIn:
+    """Docker opt-in must still enforce the PATH guard."""
+
+    def test_use_docker_without_st_docker_test_fails(self, tmp_path: Path) -> None:
+        _write_minimal_project(tmp_path)
+        script = _copy_script("lint.sh", tmp_path)
+        env = os.environ.copy()
+        env["USE_DOCKER"] = "1"
+        # Scrub PATH so st-docker-test cannot resolve.
+        env["PATH"] = "/usr/bin:/bin"
+        result = subprocess.run(  # noqa: S603  # trusted: script path is from this repo
+            [str(script)],
+            cwd=str(tmp_path),
+            env=env,
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        assert result.returncode != 0
+        assert "st-docker-test not found" in result.stderr


### PR DESCRIPTION
## Summary

Yesterday's PR #159 took 16 commits because `st-validate-local-python`
kept exiting 0 while CI rejected four distinct things local should
have caught. This PR fixes the four gaps and adds a regression test
to keep them closed.

Closes #160

## Before / after per gap

| # | CI runs | Local (before) | Local (after) |
|--|--|--|--|
| 1 | `uv run ruff check .` | nothing (Docker path never fired) | `uv run ruff check` in `scripts/dev/lint.sh` on the host |
| 2 | `uv run ruff format --check .` | nothing | `uv run ruff format --check .` in `scripts/dev/lint.sh` on the host |
| 3 | `pytest --cov-fail-under=100` | nothing | `pytest --cov=diogenes --cov-branch --cov-fail-under=100` in `scripts/dev/test.sh` on the host |
| 4 | `uv run mypy src tests` | `uv run mypy src/` only | `uv run mypy src tests` (matches CI) |

## Root cause

All four `scripts/dev/*.sh` delegated to `st-docker-test`, which
required Docker + `st-docker-test` on PATH. When the caller had
neither, the scripts exited 1 *silently-enough* that the four
"Running: scripts/dev/X.sh" lines from the orchestrator looked like
success. Nothing ran, and CI later rejected what local should have.

`scripts/dev/typecheck.sh` additionally hard-coded `mypy src/` while
CI already ran `mypy src tests` — a real repo-config divergence.

## Hypothesis result

The issue posits this is "repo config, not standard-tooling." That
**holds**. `standard_tooling/bin/validate_local_lang.py` already
surfaces sub-script non-zero exits (see its `failed = 1` branch on
line 60). The gap was entirely in this repo's `scripts/dev/*.sh`
being Docker-only and the typecheck scope being narrower than CI.

No standard-tooling change needed.

## Fix shape

- `lint.sh`, `typecheck.sh`, `test.sh`, `audit.sh` now default to
  host-mode via `uv run`, with visible output. The Docker path is
  still available via `USE_DOCKER=1 scripts/dev/<script>.sh` for CI-
  parity debugging (and that path is still guarded by the
  `st-docker-test` PATH check).
- `typecheck.sh` now runs `mypy src tests`, matching CI.
- `tests/test_dev_scripts.py` adds a regression guard: scaffolds an
  isolated tmp_path project, plants known-bad files (unused import,
  bad format, tests-only mypy error, uncovered branch), and asserts
  the scripts exit non-zero. Also proves the Docker opt-in still
  fails loudly when `st-docker-test` is missing from PATH.
- `docs/validation.md` documents the host-default + Docker opt-in
  and lists every CI step each script mirrors.

## Regression test proof

Sanity check run from this branch: planting `src/diogenes/_tmp_bad.py`
with an unused import, then running
`st-validate-local-python`, produces exit code 1 (was exit 0 before
this PR). See `tests/test_dev_scripts.py::TestLintScriptRegressionGuard`
for the automated version.

## Test plan

- [x] `uv run ruff check .` clean
- [x] `uv run ruff format --check .` clean
- [x] `uv run mypy src tests` clean (37 source files, 0 errors)
- [x] `uv run pytest --cov=diogenes --cov-branch --cov-fail-under=100`
  passes (580 tests, 100% coverage)
- [x] `st-validate-local-python` exits 0 on this branch
- [x] `st-validate-local-python` exits 1 when a ruff-rejectable file
  is planted
- [x] `markdownlint docs/validation.md` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
