### PR TITLE
fix: walk up parent dirs looking for .env (#155)

### DIFF
--- a/src/diogenes/config.py
+++ b/src/diogenes/config.py
@@ -55,6 +55,54 @@ class DioConfig:
     pipeline: PipelineConfig = field(default_factory=PipelineConfig)
 
 
+def _find_dotenv(cwd: Path, filename: str = ".env") -> Path | None:
+    """Search for a ``.env`` file starting at ``cwd`` and walking up parents.
+
+    The walk is bounded: it stops at the first directory that satisfies any
+    of these conditions, in order of precedence:
+
+    1. The directory contains ``filename`` — return that path.
+    2. The directory contains a ``.git`` entry (file or directory) —
+       treat it as the repo/workspace root and stop. If ``filename`` is
+       not present there, return ``None``. This prevents crossing repo
+       boundaries when dio is invoked from, say, a sibling repo under
+       ``~/dev/github/``.
+    3. The directory is the user's home directory — stop and return
+       ``None``. We never walk above ``$HOME``.
+    4. The directory is the filesystem root — stop and return ``None``.
+
+    The git-boundary stop is the primary bound: it matches the mental model
+    that a ``.env`` belongs to a specific checkout, and dio should not pick
+    up a parent directory's unrelated ``.env``.
+
+    Args:
+        cwd: Starting directory for the search.
+        filename: Name of the dotenv file to search for. Defaults to ``.env``.
+
+    Returns:
+        Absolute path to the nearest ``.env`` at or above ``cwd`` within the
+        bound, or ``None`` if none is found.
+
+    """
+    home = Path.home()
+    current = cwd.resolve()
+    while True:
+        candidate = current / filename
+        if candidate.exists():
+            return candidate
+        # Stop at git boundary (don't cross into a parent repo / user's ~).
+        if (current / ".git").exists():
+            return None
+        # Stop at the user's home directory.
+        if current == home:
+            return None
+        parent = current.parent
+        # Stop at the filesystem root.
+        if parent == current:
+            return None
+        current = parent
+
+
 def _parse_dotenv(path: Path) -> dict[str, str]:
     """Parse a .env file and return key-value pairs.
 
@@ -98,13 +146,22 @@ def load_config() -> DioConfig:
     Priority (highest to lowest):
 
     1. ``ANTHROPIC_API_KEY`` environment variable
-    2. ``ANTHROPIC_API_KEY`` from ``.env`` file in the current directory
+    2. ``ANTHROPIC_API_KEY`` from the nearest ``.env`` file, searched
+       from the current directory upward (see :func:`_find_dotenv` for
+       the bounds of this search — git boundary, ``$HOME``, or the
+       filesystem root).
     3. ``api.key`` in ``./.diorc`` (project-level config, current directory)
     4. ``api.key`` in ``~/.diorc`` (user-level config)
 
     The ``.env`` file follows standard Python convention (VS Code, Docker
     Compose, etc.): values are loaded as pseudo-environment variables and
     override config files, but real environment variables override ``.env``.
+
+    The upward-search behavior for ``.env`` (added for issue #155) lets
+    dio be invoked from any subdirectory of its dev tree — including
+    worktrees and nested subdirectories — without requiring ``cd`` to
+    the repo root. If ``[env] dotenv_path`` is set in ``.diorc`` to an
+    explicit path, that path is used as-is (no upward search).
 
     Returns:
         Resolved :class:`DioConfig` instance.
@@ -131,12 +188,20 @@ def load_config() -> DioConfig:
     model = str(api_sect.get("model", DEFAULT_MODEL))
     load_dotenv = bool(env_sect.get("load_dotenv", True))
 
-    # Load .env file (priority 2 — overrides .diorc but not env vars)
+    # Load .env file (priority 2 — overrides .diorc but not env vars).
+    # If [env] dotenv_path is explicitly configured, honor that path as-is
+    # (no upward search). Otherwise, search from cwd upward — see
+    # _find_dotenv for the bounds.
     dotenv_vars: dict[str, str] = {}
     if load_dotenv:
-        dotenv_name = str(env_sect.get("dotenv_path", ".env"))
-        dotenv_path = Path(dotenv_name)
-        if dotenv_path.exists():
+        explicit_path = env_sect.get("dotenv_path")
+        dotenv_path: Path | None
+        if explicit_path is not None:
+            candidate = Path(str(explicit_path))
+            dotenv_path = candidate if candidate.exists() else None
+        else:
+            dotenv_path = _find_dotenv(Path.cwd())
+        if dotenv_path is not None:
             dotenv_vars = _parse_dotenv(dotenv_path)
 
     # Priority 1: environment variable

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from diogenes.config import (
     DEFAULT_MODEL,
     ConfigError,
     DioConfig,
+    _find_dotenv,
     _load_toml,
     _parse_dotenv,
     _section,
@@ -68,6 +69,103 @@ class TestParseDotenv:
         path = tmp_path / ".env"
         path.write_text("KEY=x\n")
         assert _parse_dotenv(path) == {"KEY": "x"}
+
+
+class TestFindDotenv:
+    """Tests for _find_dotenv upward-search behavior (issue #155)."""
+
+    def test_found_in_cwd(self, tmp_path: Path) -> None:
+        """.env present in the starting directory is returned immediately."""
+        dotenv = tmp_path / ".env"
+        dotenv.write_text("KEY=value\n")
+        result = _find_dotenv(tmp_path)
+        assert result == dotenv.resolve()
+
+    def test_found_in_ancestor(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """.env in a parent directory is found via upward walk."""
+        # Keep the walk away from $HOME / real repo boundaries by pinning
+        # $HOME to somewhere unrelated.
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "nonexistent_home")
+        ancestor = tmp_path / "repo"
+        ancestor.mkdir()
+        dotenv = ancestor / ".env"
+        dotenv.write_text("KEY=value\n")
+        deep = ancestor / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        result = _find_dotenv(deep)
+        assert result == dotenv.resolve()
+
+    def test_stops_at_git_boundary(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """The walk stops at a .git directory and does not cross into parents."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "nonexistent_home")
+        # .env lives in tmp_path (the "parent repo"), but our starting
+        # directory is inside a nested repo with its own .git.
+        (tmp_path / ".env").write_text("SHOULD_NOT_BE_FOUND=1\n")
+        nested_repo = tmp_path / "nested"
+        nested_repo.mkdir()
+        (nested_repo / ".git").mkdir()
+        deep = nested_repo / "a" / "b"
+        deep.mkdir(parents=True)
+        result = _find_dotenv(deep)
+        assert result is None
+
+    def test_git_file_also_stops_walk(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """A .git FILE (worktree marker) also acts as a boundary."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "nonexistent_home")
+        (tmp_path / ".env").write_text("SHOULD_NOT_BE_FOUND=1\n")
+        worktree = tmp_path / "wt"
+        worktree.mkdir()
+        # git worktrees have a .git FILE, not a directory.
+        (worktree / ".git").write_text("gitdir: /elsewhere\n")
+        result = _find_dotenv(worktree)
+        assert result is None
+
+    def test_found_at_git_boundary_itself(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """If .env sits next to .git in the repo root, it is found there."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "nonexistent_home")
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        (repo / ".git").mkdir()
+        dotenv = repo / ".env"
+        dotenv.write_text("KEY=value\n")
+        deep = repo / "a" / "b"
+        deep.mkdir(parents=True)
+        result = _find_dotenv(deep)
+        assert result == dotenv.resolve()
+
+    def test_stops_at_home(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """The walk stops at $HOME and does not look above it."""
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        monkeypatch.setattr("pathlib.Path.home", lambda: fake_home)
+        # .env above $HOME should NOT be discovered.
+        (tmp_path / ".env").write_text("ABOVE_HOME=1\n")
+        deep = fake_home / "project" / "sub"
+        deep.mkdir(parents=True)
+        result = _find_dotenv(deep)
+        assert result is None
+
+    def test_not_found_at_all(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Returns None when no .env exists within the bounded walk."""
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "nonexistent_home")
+        deep = tmp_path / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        result = _find_dotenv(deep)
+        assert result is None
+
+    def test_filesystem_root_stops_walk(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """When the walk reaches the filesystem root, it stops and returns None.
+
+        We fake this by pointing $HOME somewhere that will never be hit
+        (under tmp_path that doesn't exist) so the only stopping condition
+        available up the tree from tmp_path is eventually the filesystem
+        root.
+        """
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "does-not-exist")
+        deep = tmp_path / "x"
+        deep.mkdir()
+        # No .env, no .git, no home match -> walk must terminate at /.
+        assert _find_dotenv(deep) is None
 
 
 class TestLoadToml:
@@ -219,6 +317,78 @@ class TestLoadConfig:
         diorc.write_text('[api]\nbase_url = "https://custom.api.com"\n')
         cfg = load_config()
         assert cfg.base_url == "https://custom.api.com"
+
+    def test_dotenv_found_in_ancestor(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """load_config() uses upward search to locate .env (issue #155)."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        for var in ("SERPER_API_KEY", "BRAVE_API_KEY", "GOOGLE_API_KEY", "GOOGLE_SEARCH_ENGINE_ID"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "nonexistent_home")
+        # .env sits two levels up from our cwd.
+        (tmp_path / ".env").write_text('ANTHROPIC_API_KEY="upward-key"\nSERPER_API_KEY="upward-serper"\n')
+        deep = tmp_path / "a" / "b"
+        deep.mkdir(parents=True)
+        monkeypatch.chdir(deep)
+        cfg = load_config()
+        assert cfg.api_key == "upward-key"
+        assert cfg.serper_api_key == "upward-serper"
+
+    def test_dotenv_blocked_by_git_boundary(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """A .git boundary below the .env prevents discovery (issue #155)."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        for var in ("SERPER_API_KEY", "BRAVE_API_KEY", "GOOGLE_API_KEY", "GOOGLE_SEARCH_ENGINE_ID"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "nonexistent_home")
+        # A .env in the outer dir that SHOULD NOT be picked up:
+        (tmp_path / ".env").write_text('ANTHROPIC_API_KEY="outer-key"\n')
+        # An inner "repo" with its own .git — dio should not cross this boundary.
+        inner = tmp_path / "inner-repo"
+        inner.mkdir()
+        (inner / ".git").mkdir()
+        monkeypatch.chdir(inner)
+        with pytest.raises(ConfigError, match="No API key"):
+            load_config()
+
+    def test_explicit_dotenv_path_skips_upward_search(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Explicit [env] dotenv_path in .diorc is honored as-is (no upward search)."""
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        for var in ("SERPER_API_KEY", "BRAVE_API_KEY", "GOOGLE_API_KEY", "GOOGLE_SEARCH_ENGINE_ID"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "nonexistent_home")
+        # Put a misleading .env in the ancestor that would normally be found.
+        (tmp_path / ".env").write_text('ANTHROPIC_API_KEY="ancestor-key"\n')
+        # Working dir has a .diorc that points at a specific file.
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        explicit = workdir / "custom.env"
+        explicit.write_text('ANTHROPIC_API_KEY="explicit-key"\n')
+        diorc = workdir / ".diorc"
+        diorc.write_text(f'[env]\ndotenv_path = "{explicit}"\n')
+        monkeypatch.chdir(workdir)
+        cfg = load_config()
+        assert cfg.api_key == "explicit-key"
+
+    def test_explicit_dotenv_path_missing_falls_through(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """If the explicit dotenv_path does not exist, it is silently skipped.
+
+        We do not fall back to upward search in this case — the user asked
+        for an explicit path; missing it should not silently surface an
+        unrelated .env.
+        """
+        monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+        for var in ("SERPER_API_KEY", "BRAVE_API_KEY", "GOOGLE_API_KEY", "GOOGLE_SEARCH_ENGINE_ID"):
+            monkeypatch.delenv(var, raising=False)
+        monkeypatch.setattr("pathlib.Path.home", lambda: tmp_path / "nonexistent_home")
+        # An ancestor .env that MUST NOT be picked up because the user
+        # pointed us at an explicit (missing) path.
+        (tmp_path / ".env").write_text('ANTHROPIC_API_KEY="should-not-be-found"\n')
+        workdir = tmp_path / "work"
+        workdir.mkdir()
+        diorc = workdir / ".diorc"
+        diorc.write_text('[env]\ndotenv_path = "/nonexistent/custom.env"\n')
+        monkeypatch.chdir(workdir)
+        with pytest.raises(ConfigError, match="No API key"):
+            load_config()
 
 
 class TestPipelineConfig:


### PR DESCRIPTION
## Summary

`diogenes.config.load_config()` previously read `.env` only from `Path.cwd()`, which made dio silently lose all search-backend credentials whenever it was invoked from anywhere other than the `ai-research-methodology` repo root — including from a worktree (`.worktrees/issue-N-slug/`) or from a sibling repo's checkout. This PR replaces the CWD-only read with a bounded upward walk: starting at `Path.cwd()`, walk parent directories until a `.env` is found or a stop-condition is hit. Real env vars still override `.env`, and `./.diorc` / `~/.diorc` priority is unchanged.

Closes #155

## Walk-up bound

The walk stops at the first of these (in priority order):

1. A directory containing `.env` — return it.
2. A directory containing a `.git` entry (file or directory) — treat as a repo/workspace boundary and stop.
3. `Path.home()` — never walk above `$HOME`.
4. The filesystem root — backstop for the unusual case where nothing else applies.

**Why git boundary as the primary stop:** a `.env` belongs to a specific checkout. If dio is invoked from inside a sibling repo that happens to live under a parent directory containing someone else's `.env`, we must not pick up the unrelated file. Treating `.git` as a boundary matches the mental model that a repo checkout is a self-contained workspace. A `.git` *file* (git worktree marker) is also honored — which is exactly the case this issue is trying to fix: worktrees under `.worktrees/issue-N-slug/` carry a `.git` file and the `.env` lives at the main worktree, so they resolve to the correct parent `.env` naturally.

**Why `$HOME` as secondary:** belt and suspenders — if the tree above `$HOME` had a stray `.env` (it shouldn't), we'd ignore it.

## Option 2 status (user-level `~/.diorc` for all search keys)

**Left as follow-up**, not tackled in this PR. Option 1 closes the worktree-workflow breakage with a 45-line change plus tests; extending `~/.diorc` to cover `SERPER_API_KEY`, `BRAVE_API_KEY`, `GOOGLE_API_KEY`, and `GOOGLE_SEARCH_ENGINE_ID` is a schema change worth doing separately so its semantics (priority vs `.env`, what's documented in `.diorc-example`, etc.) can be discussed on their own merits. I'll file a follow-up issue to track.

## Escape hatch preserved

`[env] dotenv_path = "..."` in `.diorc` is still honored as-is and disables the upward search. If the explicit path doesn't exist, we do NOT fall back to upward search — the user asked for a specific file, and silently finding an unrelated ancestor `.env` would be surprising.

## Before / after

```
# BEFORE this PR
$ cd /Users/pmoore/dev/github/the-infrastructure-mindset && dio search "x"
# -> ConfigError: No API key found. (since #154 landed; silent exit before that)

# AFTER this PR
$ cd /Users/pmoore/dev/github/the-infrastructure-mindset && dio search "x"
# -> still fails — the-infrastructure-mindset is a DIFFERENT repo with its own
#    .git; we correctly refuse to cross that boundary. (This is option 2's
#    territory, not option 1.)

# AFTER this PR — the case this fixes:
$ cd /Users/pmoore/dev/github/ai-research-methodology/.worktrees/issue-155-env-cwd-upward-search \
    && dio search "x"
# -> succeeds. Walks up from the worktree, past the .git FILE (worktree marker),
#    to the main worktree, finds .env there.

$ cd /Users/pmoore/dev/github/ai-research-methodology/some/nested/subdir \
    && dio search "x"
# -> succeeds. Walks up, hits .env in the repo root before reaching the .git
#    boundary.
```

## Pre-PR validation

All run with exit-code discipline (no pipes to `tail`).

```
ruff check .                         exit: 0
ruff format --check .                exit: 0
mypy --explicit-package-bases src tests   exit: 0
pytest --cov=src/diogenes --cov-branch --cov-fail-under=100    exit: 0
  -> 638 passed, 100.00% line + branch coverage
st-validate-local-python             exit: 0
```

## Files changed

- `src/diogenes/config.py` — added `_find_dotenv(cwd, filename=".env")`; wired it into `load_config()`; updated `load_config()` docstring to document the upward search and its bounds.
- `tests/test_config.py` — 8 new tests under `TestFindDotenv` (cwd hit, ancestor walk, `.git` dir boundary, `.git` file boundary, `.env` co-located with `.git`, `$HOME` stop, not-found, filesystem-root stop) and 4 new tests under `TestLoadConfig` (ancestor discovery, git-boundary block, explicit path overrides upward search, explicit path missing does not fall through).

## Test plan

- [x] Unit tests cover all four stop conditions and both the CWD-hit and ancestor-hit paths.
- [x] 100% line + branch coverage maintained.
- [x] `st-validate-local-python` passes.
- [ ] Manual smoke: invoke dio from a worktree directory and confirm keys resolve (deferred to post-merge; not expected to regress given the unit coverage).
