### PR TITLE
feat: dio resume --from-step for step-level restart (#162)

### DIFF
--- a/src/diogenes/cli.py
+++ b/src/diogenes/cli.py
@@ -3,7 +3,7 @@
 Usage:
     dio run <input-file> --output <dir>
     dio rerun --output <dir>
-    dio resume <instance-dir>
+    dio resume <instance-dir> [--from-step <N-or-name> --yes]
     dio fact-check <document> --output <dir>
     dio render <run-dir> --output <dir>
 """
@@ -58,6 +58,24 @@ def _build_parser() -> argparse.ArgumentParser:
     resume_parser.add_argument(
         "instance_dir",
         help="Path to the timestamped instance directory to resume",
+    )
+    resume_parser.add_argument(
+        "--from-step",
+        dest="from_step",
+        default=None,
+        help=(
+            "Force restart from the named step (regardless of prior completion). "
+            "Accepts a 1-indexed number (e.g. '9'), a canonical step name "
+            "('step_09_reports'), a logical suffix ('reports'), or a short "
+            "alias ('report', 'audit'). Outputs at and after this step are "
+            "deleted and the step list is reset. Requires --yes to proceed."
+        ),
+    )
+    resume_parser.add_argument(
+        "--yes",
+        dest="yes",
+        action="store_true",
+        help=("Acknowledge the destructive wipe performed by --from-step. Required when --from-step is given."),
     )
 
     # --- dio fact-check ---
@@ -118,7 +136,11 @@ def main() -> int:
     if args.command == "resume":
         from diogenes.commands.run import execute_resume
 
-        return execute_resume(args.instance_dir)
+        return execute_resume(
+            args.instance_dir,
+            from_step=args.from_step,
+            yes=args.yes,
+        )
 
     if args.command == "fact-check":
         print(f"dio fact-check: doc={args.document} output={args.output}")

--- a/src/diogenes/commands/run.py
+++ b/src/diogenes/commands/run.py
@@ -28,7 +28,11 @@ from diogenes.pipeline import (
 )
 from diogenes.schema_validator import ValidationError, parse_input_file, validate_research_input
 from diogenes.search_providers import BraveSearchProvider, GoogleSearchProvider, SerperSearchProvider
-from diogenes.state_machine import PIPELINE_STEPS, PipelineState
+from diogenes.state_machine import (
+    PIPELINE_STEPS,
+    PipelineState,
+    resolve_step_identifier,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -384,7 +388,62 @@ def _load_prior_outputs(instance_dir: Path, state: PipelineState) -> dict[str, A
     return outputs
 
 
-def _resume_pipeline(instance_dir: Path) -> int:
+def _apply_from_step(
+    instance_dir: Path,
+    state: PipelineState,
+    from_step: str | int,
+    *,
+    yes: bool,
+) -> int | None:
+    """Resolve, validate, and apply a ``--from-step`` directive.
+
+    On success, marks the target step and every later step as
+    incomplete, deletes their output files from disk, and emits a
+    non-determinism warning if any cleared step is LLM-backed. On
+    failure (invalid identifier, missing ``--yes``) logs an error and
+    returns a non-zero exit code.
+
+    Returns:
+        None on success (caller continues with the normal resume path),
+        or a non-zero exit code that should be propagated to the CLI.
+
+    """
+    try:
+        target_name = resolve_step_identifier(from_step)
+    except ValueError as e:
+        logger.info(f"ERROR: {e}")
+        return 1
+
+    if not yes:
+        logger.info("ERROR: --from-step deletes completed step outputs. Re-run with --yes to acknowledge.")
+        return 1
+
+    # Map canonical names → StepDefinition objects for convenience
+    defs_by_name = {s.name: s for s in PIPELINE_STEPS}
+    cleared = state.mark_step_and_later_incomplete(target_name)
+
+    logger.info(f"--from-step {from_step}: resetting from {target_name} onward.")
+    for name in cleared:
+        step_def = defs_by_name[name]
+        if step_def.output_file:
+            out_path = instance_dir / step_def.output_file
+            if out_path.exists():
+                out_path.unlink()
+                logger.info(f"  Deleted: {out_path.name}")
+
+    # Non-determinism disclosure for LLM-backed steps that will re-run.
+    llm_reruns = [i + 1 for i, s in enumerate(PIPELINE_STEPS) if s.name in cleared and s.category in ("llm", "hybrid")]
+    if llm_reruns:
+        logger.info(f"  Steps {llm_reruns} re-run LLM-backed operations; output will differ from the prior run.")
+    return None
+
+
+def _resume_pipeline(
+    instance_dir: Path,
+    *,
+    from_step: str | int | None = None,
+    yes: bool = False,
+) -> int:
     """Execute the pipeline loop against an existing instance directory.
 
     Reads pipeline-state.json to determine which steps are already complete,
@@ -392,6 +451,12 @@ def _resume_pipeline(instance_dir: Path) -> int:
     runs the remainder of the state-machine loop. Any step in ``running``
     or ``failed`` status is retried — partial output files from the prior
     attempt, if any, are overwritten when the step completes.
+
+    When ``from_step`` is supplied, the normal "earliest incomplete"
+    logic is bypassed: the target step and every later step are marked
+    incomplete and their output files deleted, forcing re-execution
+    from that point. This requires ``yes=True`` to proceed; without
+    it the command exits 1 before touching any files.
 
     Assumes the previous process for this instance is no longer running.
     No PID or heartbeat check — if the user resumes over a live run, that
@@ -411,7 +476,12 @@ def _resume_pipeline(instance_dir: Path) -> int:
     logger.info(f"Resuming: {instance_dir}")
 
     state = PipelineState(instance_dir)
-    if state.all_complete():
+
+    if from_step is not None:
+        rc = _apply_from_step(instance_dir, state, from_step, yes=yes)
+        if rc is not None:
+            return rc
+    elif state.all_complete():
         logger.info("All steps already complete. Nothing to do.")
         return 0
 
@@ -587,7 +657,12 @@ def execute_rerun(output: str) -> int:
     return _run_pipeline(parent_dir, input_path)
 
 
-def execute_resume(instance_dir: str) -> int:
+def execute_resume(
+    instance_dir: str,
+    *,
+    from_step: str | int | None = None,
+    yes: bool = False,
+) -> int:
     """Execute the ``dio resume`` command — finish a previously interrupted instance.
 
     Points at a specific timestamped instance directory (not the parent
@@ -603,9 +678,19 @@ def execute_resume(instance_dir: str) -> int:
         instance_dir: Path to an instance directory (the timestamped
             subdirectory under the research container) containing a
             pipeline-state.json from a prior run.
+        from_step: Optional forced starting step. When supplied, the
+            named step and every later step are marked incomplete and
+            their output files deleted. Accepts a 1-indexed integer
+            position, a canonical step name
+            (``step_09_reports``), a logical suffix (``reports``), or
+            a short alias (``report``). Requires ``yes=True``.
+        yes: Required acknowledgement flag when ``from_step`` is used.
+            Without it the command refuses to perform the destructive
+            wipe and exits non-zero. Has no effect when ``from_step``
+            is None.
 
     Returns:
         Exit code (0 for success, non-zero for failure).
 
     """
-    return _resume_pipeline(Path(instance_dir))
+    return _resume_pipeline(Path(instance_dir), from_step=from_step, yes=yes)

--- a/src/diogenes/state_machine.py
+++ b/src/diogenes/state_machine.py
@@ -272,6 +272,131 @@ PIPELINE_STEPS: list[StepDefinition] = [
 ]
 
 
+# Expected number of components after splitting a canonical step name
+# (``step``, two-digit number, logical suffix) on ``_`` with maxsplit=2.
+_CANONICAL_STEP_NAME_PARTS = 3
+
+
+def _logical_name(step_name: str) -> str:
+    """Strip the ``step_NN_`` prefix from a canonical step name.
+
+    Turns ``step_09_reports`` → ``reports``, ``step_06_evidence_packets`` →
+    ``evidence_packets``. Used by :func:`resolve_step_identifier` so
+    users can type short names on the command line.
+    """
+    # The canonical names match step_NN_<logical>. Split twice on "_":
+    # first pops "step", second pops the two-digit number.
+    parts = step_name.split("_", 2)
+    if len(parts) < _CANONICAL_STEP_NAME_PARTS:
+        return step_name
+    return parts[2]
+
+
+# Accepted short aliases beyond the derived logical names. These let the
+# common case ("rerun the reports step", "rerun the audit step") accept
+# singular/abbreviated forms without needing to remember whether the
+# canonical suffix is plural.
+_STEP_ALIASES: dict[str, str] = {
+    "clarify": "step_01_research_input_clarified",
+    "clarifier": "step_01_research_input_clarified",
+    "input": "step_01_research_input_clarified",
+    "hypothesis": "step_02_hypotheses",
+    "search_plan": "step_03_search_plans",
+    "plan": "step_03_search_plans",
+    "search": "step_04_search_results",
+    "score": "step_05_scorecards",
+    "scorecard": "step_05_scorecards",
+    "evidence": "step_06_evidence_packets",
+    "packets": "step_06_evidence_packets",
+    "synthesize": "step_07_synthesis",
+    "audit": "step_08_self_audit",
+    "report": "step_09_reports",
+    "events": "step_11_pipeline_events",
+}
+
+
+def _resolve_numeric_step(num: int) -> str:
+    """Resolve a 1-indexed pipeline step number to its canonical name."""
+    if num < 1 or num > len(PIPELINE_STEPS):
+        msg = f"--from-step {num} out of range. Valid step numbers: 1..{len(PIPELINE_STEPS)}."
+        raise ValueError(msg)
+    return PIPELINE_STEPS[num - 1].name
+
+
+def _resolve_named_step(key: str, original: str) -> str:
+    """Resolve a lowercased, non-numeric string to a canonical step name.
+
+    Checks canonical names, then logical suffixes, then short aliases.
+    Raises ValueError with a hint listing valid options if nothing matches.
+    """
+    for step in PIPELINE_STEPS:
+        if step.name.lower() == key:
+            return step.name
+    for step in PIPELINE_STEPS:
+        if _logical_name(step.name).lower() == key:
+            return step.name
+    if key in _STEP_ALIASES:
+        return _STEP_ALIASES[key]
+    msg = f"Unknown pipeline step: {original!r}. Valid options: {', '.join(describe_valid_step_identifiers())}."
+    raise ValueError(msg)
+
+
+def resolve_step_identifier(identifier: str | int) -> str:
+    """Resolve a user-supplied step identifier to a canonical step name.
+
+    Accepts:
+    - a 1-indexed integer matching a position in :data:`PIPELINE_STEPS`
+    - a canonical step name (``step_09_reports``)
+    - the logical suffix (``reports``, ``evidence_packets``)
+    - a short alias (``report``, ``audit``, ``score``) — see
+      :data:`_STEP_ALIASES`.
+
+    Case-insensitive for string forms. Strings containing only digits
+    are treated as integers.
+
+    Returns:
+        The canonical step name (e.g. ``step_09_reports``).
+
+    Raises:
+        ValueError: when the identifier does not match any known step.
+            The error message lists all valid options so the CLI can
+            surface a usable hint without additional work.
+        TypeError: when the identifier is neither int nor str.
+
+    """
+    if isinstance(identifier, bool):
+        # bool is a subclass of int — guard explicitly so a stray
+        # ``True`` doesn't resolve to step 1.
+        msg = f"Step identifier must be int or str, got {type(identifier).__name__}"
+        raise TypeError(msg)
+    if isinstance(identifier, int):
+        return _resolve_numeric_step(identifier)
+    if isinstance(identifier, str):
+        stripped = identifier.strip()
+        if not stripped:
+            msg = "--from-step requires a value; got empty string"
+            raise ValueError(msg)
+        if stripped.isdigit():
+            return _resolve_numeric_step(int(stripped))
+        return _resolve_named_step(stripped.lower(), identifier)
+    # Defensive: callers using typed APIs won't hit this, but a runtime
+    # caller (tests, REPL, unchecked user input) passing a float or
+    # other object should get a clear TypeError rather than an opaque
+    # attribute error deeper in the call chain.
+    msg = f"Step identifier must be int or str, got {type(identifier).__name__}"  # type: ignore[unreachable]
+    raise TypeError(msg)
+
+
+def describe_valid_step_identifiers() -> list[str]:
+    """Return a list of human-readable step identifiers.
+
+    Each entry reads like ``9 (reports)`` — the numeric position and
+    its logical name. Used in error messages when the user supplies
+    an invalid ``--from-step`` value.
+    """
+    return [f"{i} ({_logical_name(s.name)})" for i, s in enumerate(PIPELINE_STEPS, 1)]
+
+
 @dataclass
 class StepStatus:
     """Completion record for a single step."""
@@ -442,6 +567,35 @@ class PipelineState:
     def all_complete(self) -> bool:
         """Check if all pipeline steps have been completed."""
         return all(self.is_complete(s.name) for s in PIPELINE_STEPS)
+
+    def mark_step_and_later_incomplete(self, step_name: str) -> list[str]:
+        """Clear completion records for ``step_name`` and every later step.
+
+        Used by ``dio resume --from-step`` to force a step-level rerun.
+        The identifier must be a canonical step name (resolve via
+        :func:`resolve_step_identifier` first). Returns the list of step
+        names that were cleared, in pipeline order, so the caller can
+        delete the corresponding output files.
+
+        Raises:
+            ValueError: if ``step_name`` is not a canonical pipeline
+                step name. This is a programming error at the call site;
+                the CLI layer is expected to have resolved any
+                user-supplied identifier before calling this method.
+
+        """
+        names = [s.name for s in PIPELINE_STEPS]
+        if step_name not in names:
+            msg = f"Unknown pipeline step: {step_name!r}"
+            raise ValueError(msg)
+        idx = names.index(step_name)
+        cleared: list[str] = []
+        for later in names[idx:]:
+            if later in self._completed:
+                del self._completed[later]
+            cleared.append(later)
+        self._save()
+        return cleared
 
     def summary(self) -> dict[str, Any]:
         """Return a summary of pipeline progress."""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -29,6 +29,24 @@ class TestBuildParser:
         args = parser.parse_args(["resume", "/path/to/research/2026-04-22-120000"])
         assert args.command == "resume"
         assert args.instance_dir == "/path/to/research/2026-04-22-120000"
+        # Defaults: from-step is None, yes is False — preserving the
+        # existing zero-arg resume behavior.
+        assert args.from_step is None
+        assert args.yes is False
+
+    def test_resume_with_from_step_numeric(self) -> None:
+        parser = _build_parser()
+        args = parser.parse_args(["resume", "/path/instance", "--from-step", "9", "--yes"])
+        assert args.from_step == "9"
+        assert args.yes is True
+
+    def test_resume_with_from_step_name(self) -> None:
+        parser = _build_parser()
+        args = parser.parse_args(
+            ["resume", "/path/instance", "--from-step", "report", "--yes"],
+        )
+        assert args.from_step == "report"
+        assert args.yes is True
 
     def test_factcheck_subcommand(self) -> None:
         parser = _build_parser()
@@ -62,10 +80,41 @@ class TestMain:
     @patch("diogenes.commands.run.execute_resume")
     @patch("diogenes.cli.argparse.ArgumentParser.parse_args")
     def test_resume_delegates(self, mock_parse: MagicMock, mock_resume: MagicMock) -> None:
-        mock_parse.return_value = MagicMock(command="resume", instance_dir="/dir/2026-04-22-120000")
+        mock_parse.return_value = MagicMock(
+            command="resume",
+            instance_dir="/dir/2026-04-22-120000",
+            from_step=None,
+            yes=False,
+        )
         mock_resume.return_value = 0
         assert main() == 0
-        mock_resume.assert_called_once_with("/dir/2026-04-22-120000")
+        mock_resume.assert_called_once_with(
+            "/dir/2026-04-22-120000",
+            from_step=None,
+            yes=False,
+        )
+
+    @patch("diogenes.commands.run.execute_resume")
+    @patch("diogenes.cli.argparse.ArgumentParser.parse_args")
+    def test_resume_delegates_with_from_step_and_yes(
+        self,
+        mock_parse: MagicMock,
+        mock_resume: MagicMock,
+    ) -> None:
+        """--from-step and --yes are forwarded to execute_resume."""
+        mock_parse.return_value = MagicMock(
+            command="resume",
+            instance_dir="/dir/2026-04-22-120000",
+            from_step="9",
+            yes=True,
+        )
+        mock_resume.return_value = 0
+        assert main() == 0
+        mock_resume.assert_called_once_with(
+            "/dir/2026-04-22-120000",
+            from_step="9",
+            yes=True,
+        )
 
     @patch("diogenes.cli.argparse.ArgumentParser.parse_args")
     def test_factcheck_not_implemented(self, mock_parse: MagicMock) -> None:
@@ -231,6 +280,45 @@ class TestMainErrorSurfacing:
         captured = capsys.readouterr()
         assert rc == 1
         assert "No API key found" in captured.err
+
+    def test_resume_from_step_invalid_surfaces_valid_options(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """Invalid --from-step values exit 1 with a message listing valid steps on stderr."""
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / "pipeline-state.json").write_text('{"steps": []}')
+        with patch(
+            "sys.argv",
+            ["dio", "resume", str(instance), "--from-step", "not-a-step", "--yes"],
+        ):
+            rc = main()
+        captured = capsys.readouterr()
+        assert rc == 1
+        # The error lists the canonical set of step numbers so the user
+        # can retry with a valid value — not just "invalid".
+        assert "not-a-step" in captured.err
+        assert "reports" in captured.err
+
+    def test_resume_from_step_without_yes_refuses(
+        self,
+        tmp_path: Path,
+        capsys: pytest.CaptureFixture[str],
+    ) -> None:
+        """--from-step without --yes refuses the destructive wipe."""
+        instance = tmp_path / "instance"
+        instance.mkdir()
+        (instance / "pipeline-state.json").write_text('{"steps": []}')
+        with patch(
+            "sys.argv",
+            ["dio", "resume", str(instance), "--from-step", "9"],
+        ):
+            rc = main()
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "--yes" in captured.err
 
     def test_argparse_unknown_subcommand_exits_nonzero(
         self,

--- a/tests/test_commands_run.py
+++ b/tests/test_commands_run.py
@@ -1010,3 +1010,446 @@ class TestExecuteResume:
         # The interrupted step is the first one re-dispatched.
         dispatched = [c.args[0].name for c in mock_dispatch.call_args_list]
         assert dispatched[0] == "step_03_search_plans"
+
+
+def _seed_full_complete_instance(instance_dir: Path) -> None:
+    """Seed an instance with every step marked complete and its output file on disk.
+
+    Used by --from-step tests that need a "completed run" starting
+    point so the wipe + re-dispatch logic has something to operate on.
+    """
+    files: dict[str, dict[str, Any]] = {
+        "research-input-clarified.json": {"claims": [], "queries": [{"text": "t"}], "axioms": []},
+        "hypotheses.json": {"Q001": {"approach": "x"}},
+        "search-plans.json": {"Q001": {"plan": "y"}},
+        "search-results.json": {"Q001": []},
+        "scorecards.json": {"Q001": []},
+        "evidence-packets.json": {"Q001": {}},
+        "synthesis.json": {"verdict": "inconclusive"},
+        "self-audit.json": {"issues": []},
+        "reports.json": {"title": "t", "summary": "s"},
+        "archive.json": {"all": "steps"},
+        "pipeline-events.json": {"events": []},
+    }
+    _seed_instance(instance_dir, completed_step_files=files)
+
+
+class TestExecuteResumeFromStep:
+    """Tests for execute_resume's --from-step path."""
+
+    def test_from_step_without_yes_refuses(self, tmp_path: Path) -> None:
+        """Destructive path requires --yes; without it, exit 1 and leave state alone."""
+        instance_dir = tmp_path / "instance"
+        _seed_full_complete_instance(instance_dir)
+
+        # Capture state before
+        reports_before = (instance_dir / "reports.json").read_text()
+
+        rc = execute_resume(str(instance_dir), from_step="9", yes=False)
+        assert rc == 1
+
+        # Reports.json must still be on disk untouched.
+        assert (instance_dir / "reports.json").exists()
+        assert (instance_dir / "reports.json").read_text() == reports_before
+
+    def test_from_step_invalid_identifier_exits_1(self, tmp_path: Path) -> None:
+        """Unknown step name surfaces an error and returns 1 without touching outputs."""
+        instance_dir = tmp_path / "instance"
+        _seed_full_complete_instance(instance_dir)
+
+        rc = execute_resume(str(instance_dir), from_step="not-real", yes=True)
+        assert rc == 1
+        # All previously-present outputs must still be present.
+        assert (instance_dir / "reports.json").exists()
+        assert (instance_dir / "synthesis.json").exists()
+
+    @patch("diogenes.commands.run._dispatch_step")
+    @patch("diogenes.commands.run._create_search_provider")
+    @patch("diogenes.commands.run.APIClient")
+    def test_from_step_numeric_reruns_from_target(
+        self,
+        mock_api_cls: MagicMock,
+        mock_sp: MagicMock,
+        mock_dispatch: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """--from-step 9 wipes steps 9-11 outputs and re-dispatches only those."""
+        mock_client = MagicMock(model="m")
+        mock_client.usage.to_dict.return_value = {
+            "totals": {
+                "api_calls": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "estimated_cost_usd": 0.0,
+                "web_search_requests": 0,
+                "web_fetch_requests": 0,
+            },
+            "per_call": [],
+        }
+        mock_api_cls.return_value = mock_client
+        mock_sp.return_value = MagicMock()
+
+        def dispatch_side_effect(
+            step_def: StepDefinition,
+            outputs: dict[str, Any],
+            client: object,
+            sp: object,
+            el: object,
+            rd: Path,
+        ) -> dict[str, Any]:
+            if step_def.name in ("step_10_archive", "step_11_pipeline_events"):
+                return {"_self_written": True}
+            return {"refreshed": step_def.name}
+
+        mock_dispatch.side_effect = dispatch_side_effect
+
+        instance_dir = tmp_path / "instance"
+        _seed_full_complete_instance(instance_dir)
+
+        rc = execute_resume(str(instance_dir), from_step="9", yes=True)
+        assert rc == 0
+
+        # Steps 9, 10, 11 are the only ones dispatched.
+        dispatched = [c.args[0].name for c in mock_dispatch.call_args_list]
+        assert dispatched == [
+            "step_09_reports",
+            "step_10_archive",
+            "step_11_pipeline_events",
+        ]
+
+        # reports.json was rewritten with the mocked refresh payload.
+        refreshed = json.loads((instance_dir / "reports.json").read_text())
+        assert refreshed == {"refreshed": "step_09_reports"}
+
+        # Earlier outputs preserved.
+        assert (instance_dir / "synthesis.json").exists()
+        assert json.loads((instance_dir / "synthesis.json").read_text()) == {
+            "verdict": "inconclusive",
+        }
+
+    @patch("diogenes.commands.run._dispatch_step")
+    @patch("diogenes.commands.run._create_search_provider")
+    @patch("diogenes.commands.run.APIClient")
+    def test_from_step_by_logical_name(
+        self,
+        mock_api_cls: MagicMock,
+        mock_sp: MagicMock,
+        mock_dispatch: MagicMock,
+        tmp_path: Path,
+    ) -> None:
+        """--from-step report (alias) resolves to step 9 and restarts from there."""
+        mock_client = MagicMock(model="m")
+        mock_client.usage.to_dict.return_value = {
+            "totals": {
+                "api_calls": 0,
+                "input_tokens": 0,
+                "output_tokens": 0,
+                "total_tokens": 0,
+                "estimated_cost_usd": 0.0,
+                "web_search_requests": 0,
+                "web_fetch_requests": 0,
+            },
+            "per_call": [],
+        }
+        mock_api_cls.return_value = mock_client
+        mock_sp.return_value = MagicMock()
+        mock_dispatch.side_effect = lambda sd, *_a, **_k: (
+            {"_self_written": True} if sd.name in ("step_10_archive", "step_11_pipeline_events") else {"ok": 1}
+        )
+
+        instance_dir = tmp_path / "instance"
+        _seed_full_complete_instance(instance_dir)
+
+        rc = execute_resume(str(instance_dir), from_step="report", yes=True)
+        assert rc == 0
+
+        dispatched = [c.args[0].name for c in mock_dispatch.call_args_list]
+        assert dispatched[0] == "step_09_reports"
+
+    def test_from_step_all_complete_still_reruns(self, tmp_path: Path) -> None:
+        """Even when all steps are complete, --from-step bypasses the no-op guard."""
+        instance_dir = tmp_path / "instance"
+        _seed_full_complete_instance(instance_dir)
+
+        with (
+            patch("diogenes.commands.run.APIClient") as mock_api,
+            patch("diogenes.commands.run._create_search_provider") as mock_sp,
+            patch("diogenes.commands.run._dispatch_step") as mock_dispatch,
+        ):
+            mock_client = MagicMock(model="m")
+            mock_client.usage.to_dict.return_value = {
+                "totals": {
+                    "api_calls": 0,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0,
+                    "estimated_cost_usd": 0.0,
+                    "web_search_requests": 0,
+                    "web_fetch_requests": 0,
+                },
+                "per_call": [],
+            }
+            mock_api.return_value = mock_client
+            mock_sp.return_value = MagicMock()
+            mock_dispatch.side_effect = lambda sd, *_a, **_k: (
+                {"_self_written": True} if sd.name in ("step_10_archive", "step_11_pipeline_events") else {"ok": 1}
+            )
+
+            rc = execute_resume(str(instance_dir), from_step="9", yes=True)
+
+        assert rc == 0
+        # Dispatch was called at least once — the no-op early-return
+        # path was bypassed by --from-step.
+        assert mock_dispatch.call_count >= 1
+
+    def test_from_step_emits_nondeterminism_warning_for_llm_step(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Clearing an LLM-backed step logs a non-determinism warning.
+
+        Read the progress.log file to verify — the diogenes logger is
+        propagate=False, so caplog (root logger) doesn't see it, but the
+        file handler attached by configure_progress_logger does.
+        """
+        instance_dir = tmp_path / "instance"
+        _seed_full_complete_instance(instance_dir)
+
+        with (
+            patch("diogenes.commands.run.APIClient") as mock_api,
+            patch("diogenes.commands.run._create_search_provider") as mock_sp,
+            patch("diogenes.commands.run._dispatch_step") as mock_dispatch,
+        ):
+            mock_client = MagicMock(model="m")
+            mock_client.usage.to_dict.return_value = {
+                "totals": {
+                    "api_calls": 0,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0,
+                    "estimated_cost_usd": 0.0,
+                    "web_search_requests": 0,
+                    "web_fetch_requests": 0,
+                },
+                "per_call": [],
+            }
+            mock_api.return_value = mock_client
+            mock_sp.return_value = MagicMock()
+            mock_dispatch.side_effect = lambda sd, *_a, **_k: (
+                {"_self_written": True} if sd.name in ("step_10_archive", "step_11_pipeline_events") else {"ok": 1}
+            )
+
+            rc = execute_resume(str(instance_dir), from_step="9", yes=True)
+
+        assert rc == 0
+        progress_log = (instance_dir / "progress.log").read_text()
+        assert "LLM-backed" in progress_log
+
+    def test_from_step_no_warning_for_python_only_steps(
+        self,
+        tmp_path: Path,
+    ) -> None:
+        """Clearing only python_only steps (step 10 onward) omits the LLM warning."""
+        instance_dir = tmp_path / "instance"
+        _seed_full_complete_instance(instance_dir)
+
+        with (
+            patch("diogenes.commands.run.APIClient") as mock_api,
+            patch("diogenes.commands.run._create_search_provider") as mock_sp,
+            patch("diogenes.commands.run._dispatch_step") as mock_dispatch,
+        ):
+            mock_client = MagicMock(model="m")
+            mock_client.usage.to_dict.return_value = {
+                "totals": {
+                    "api_calls": 0,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0,
+                    "estimated_cost_usd": 0.0,
+                    "web_search_requests": 0,
+                    "web_fetch_requests": 0,
+                },
+                "per_call": [],
+            }
+            mock_api.return_value = mock_client
+            mock_sp.return_value = MagicMock()
+            mock_dispatch.side_effect = lambda _sd, *_a, **_k: {"_self_written": True}
+
+            # step 10 (archive) is python_only; step 11 is also python_only.
+            rc = execute_resume(str(instance_dir), from_step="10", yes=True)
+
+        assert rc == 0
+        progress_log = (instance_dir / "progress.log").read_text()
+        assert "LLM-backed" not in progress_log
+
+    def test_from_step_deletes_output_files_on_disk(self, tmp_path: Path) -> None:
+        """Output files for the target step and later are physically deleted."""
+        instance_dir = tmp_path / "instance"
+        _seed_full_complete_instance(instance_dir)
+
+        with (
+            patch("diogenes.commands.run.APIClient") as mock_api,
+            patch("diogenes.commands.run._create_search_provider") as mock_sp,
+            patch("diogenes.commands.run._dispatch_step") as mock_dispatch,
+        ):
+            mock_api.return_value = MagicMock(model="m")
+            mock_sp.return_value = MagicMock()
+            # Make dispatch fail immediately so we can observe the
+            # post-wipe state before any step rewrites a file.
+            mock_dispatch.return_value = None
+
+            execute_resume(str(instance_dir), from_step="9", yes=True)
+
+        # Steps 9 (reports.json), 10 (archive.json), 11 (pipeline-events.json)
+        # outputs should all be gone.
+        assert not (instance_dir / "reports.json").exists()
+        assert not (instance_dir / "archive.json").exists()
+        assert not (instance_dir / "pipeline-events.json").exists()
+        # Earlier outputs untouched.
+        assert (instance_dir / "synthesis.json").exists()
+
+    def test_from_step_invalid_before_api_client(self, tmp_path: Path) -> None:
+        """Invalid --from-step exits before we touch APIClient or search providers.
+
+        This guards against pointless initialization when we're going to
+        reject the request anyway.
+        """
+        instance_dir = tmp_path / "instance"
+        _seed_full_complete_instance(instance_dir)
+
+        with patch("diogenes.commands.run.APIClient") as mock_api:
+            rc = execute_resume(str(instance_dir), from_step="not-real", yes=True)
+        assert rc == 1
+        mock_api.assert_not_called()
+
+    def test_from_step_missing_yes_before_api_client(self, tmp_path: Path) -> None:
+        """Missing --yes exits before APIClient init — no side effects."""
+        instance_dir = tmp_path / "instance"
+        _seed_full_complete_instance(instance_dir)
+
+        with patch("diogenes.commands.run.APIClient") as mock_api:
+            rc = execute_resume(str(instance_dir), from_step="9", yes=False)
+        assert rc == 1
+        mock_api.assert_not_called()
+
+    def test_from_step_skips_missing_output_files(self, tmp_path: Path) -> None:
+        """A cleared step whose output file is already absent is skipped silently.
+
+        Covers the branch where out_path.exists() is False (user deleted
+        the file manually between runs).
+        """
+        instance_dir = tmp_path / "instance"
+        _seed_full_complete_instance(instance_dir)
+        # Manually remove reports.json so the cleanup loop has to handle
+        # its absence.
+        (instance_dir / "reports.json").unlink()
+
+        with (
+            patch("diogenes.commands.run.APIClient") as mock_api,
+            patch("diogenes.commands.run._create_search_provider") as mock_sp,
+            patch("diogenes.commands.run._dispatch_step") as mock_dispatch,
+        ):
+            mock_api.return_value = MagicMock(model="m")
+            mock_sp.return_value = MagicMock()
+            mock_dispatch.return_value = None
+
+            execute_resume(str(instance_dir), from_step="9", yes=True)
+
+        # archive.json and pipeline-events.json are still removed even
+        # though reports.json was already gone.
+        assert not (instance_dir / "archive.json").exists()
+        assert not (instance_dir / "pipeline-events.json").exists()
+
+    def test_from_step_skips_step_with_no_output_file(
+        self,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A cleared step with output_file=None is skipped without crashing.
+
+        No step in PIPELINE_STEPS today has output_file=None, but
+        StepDefinition allows it. Guard against a future step that
+        mutates existing artifacts instead of producing a new file.
+        """
+        from diogenes.state_machine import PIPELINE_STEPS as REAL_STEPS
+        from diogenes.state_machine import PipelineState, StepDefinition
+
+        # Replace the final step with one that has no output file.
+        fake_last = StepDefinition(
+            name="step_99_no_output",
+            display_name="Fake last step",
+            output_file=None,
+            category="python_only",
+        )
+        patched = [*REAL_STEPS[:-1], fake_last]
+        monkeypatch.setattr("diogenes.commands.run.PIPELINE_STEPS", patched)
+        monkeypatch.setattr("diogenes.state_machine.PIPELINE_STEPS", patched)
+
+        # Seed: everything up through step_10_archive complete with
+        # on-disk files, plus the new fake tail step marked complete.
+        instance_dir = tmp_path / "instance"
+        files: dict[str, dict[str, Any]] = {
+            "research-input-clarified.json": {"claims": [], "queries": [], "axioms": []},
+            "hypotheses.json": {},
+            "search-plans.json": {},
+            "search-results.json": {},
+            "scorecards.json": {},
+            "evidence-packets.json": {},
+            "synthesis.json": {},
+            "self-audit.json": {},
+            "reports.json": {},
+            "archive.json": {},
+        }
+        _seed_instance(instance_dir, completed_step_files=files)
+        state = PipelineState(instance_dir)
+        state.mark_complete("step_99_no_output")
+
+        with (
+            patch("diogenes.commands.run.APIClient") as mock_api,
+            patch("diogenes.commands.run._create_search_provider") as mock_sp,
+            patch("diogenes.commands.run._dispatch_step") as mock_dispatch,
+        ):
+            mock_api.return_value = MagicMock(model="m")
+            mock_sp.return_value = MagicMock()
+            mock_dispatch.return_value = None
+
+            # Wipe from step 10 onward — that includes the
+            # output_file=None fake step, exercising the guard branch.
+            execute_resume(str(instance_dir), from_step="10", yes=True)
+
+        # Normal step 10 (archive.json) still deleted.
+        assert not (instance_dir / "archive.json").exists()
+
+    def test_from_step_integer_value(self, tmp_path: Path) -> None:
+        """execute_resume accepts an integer from_step (direct API call)."""
+        instance_dir = tmp_path / "instance"
+        _seed_full_complete_instance(instance_dir)
+
+        with (
+            patch("diogenes.commands.run.APIClient") as mock_api,
+            patch("diogenes.commands.run._create_search_provider") as mock_sp,
+            patch("diogenes.commands.run._dispatch_step") as mock_dispatch,
+        ):
+            mock_client = MagicMock(model="m")
+            mock_client.usage.to_dict.return_value = {
+                "totals": {
+                    "api_calls": 0,
+                    "input_tokens": 0,
+                    "output_tokens": 0,
+                    "total_tokens": 0,
+                    "estimated_cost_usd": 0.0,
+                    "web_search_requests": 0,
+                    "web_fetch_requests": 0,
+                },
+                "per_call": [],
+            }
+            mock_api.return_value = mock_client
+            mock_sp.return_value = MagicMock()
+            mock_dispatch.side_effect = lambda sd, *_a, **_k: (
+                {"_self_written": True} if sd.name in ("step_10_archive", "step_11_pipeline_events") else {"ok": 1}
+            )
+
+            rc = execute_resume(str(instance_dir), from_step=9, yes=True)
+
+        assert rc == 0

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -13,6 +13,9 @@ from diogenes.state_machine import (
     StepStatus,
     _compute_version,
     _git_metadata,
+    _logical_name,
+    describe_valid_step_identifiers,
+    resolve_step_identifier,
 )
 
 
@@ -417,3 +420,194 @@ class TestVersionInPipelineState:
         data = json.loads((run_dir / "pipeline-state.json").read_text())
         assert data["version"]["package_version"] == "0.0.1-pinned"
         assert data["version"]["git_commit"] == "abc123"
+
+
+class TestLogicalName:
+    """Tests for the _logical_name helper."""
+
+    def test_strips_step_prefix(self) -> None:
+        assert _logical_name("step_09_reports") == "reports"
+
+    def test_strips_multi_token_suffix(self) -> None:
+        assert _logical_name("step_06_evidence_packets") == "evidence_packets"
+
+    def test_leaves_non_canonical_name_unchanged(self) -> None:
+        """Strings without the step_NN_ shape pass through untouched."""
+        assert _logical_name("ad_hoc") == "ad_hoc"
+        assert _logical_name("plain") == "plain"
+
+
+class TestDescribeValidStepIdentifiers:
+    """Tests for describe_valid_step_identifiers."""
+
+    def test_lists_all_steps_numbered(self) -> None:
+        identifiers = describe_valid_step_identifiers()
+        assert len(identifiers) == len(PIPELINE_STEPS)
+        # First entry is "1 (...)"
+        assert identifiers[0].startswith("1 (")
+        # Report step is the 9th and uses the logical suffix
+        assert "9 (reports)" in identifiers
+
+
+class TestResolveStepIdentifier:
+    """Tests for resolve_step_identifier."""
+
+    def test_numeric_string(self) -> None:
+        assert resolve_step_identifier("9") == "step_09_reports"
+
+    def test_integer(self) -> None:
+        assert resolve_step_identifier(9) == "step_09_reports"
+
+    def test_canonical_name(self) -> None:
+        assert resolve_step_identifier("step_09_reports") == "step_09_reports"
+
+    def test_canonical_name_case_insensitive(self) -> None:
+        assert resolve_step_identifier("STEP_09_REPORTS") == "step_09_reports"
+
+    def test_logical_suffix(self) -> None:
+        assert resolve_step_identifier("reports") == "step_09_reports"
+
+    def test_logical_suffix_case_insensitive(self) -> None:
+        assert resolve_step_identifier("Reports") == "step_09_reports"
+
+    def test_multi_token_logical_suffix(self) -> None:
+        assert resolve_step_identifier("evidence_packets") == "step_06_evidence_packets"
+
+    def test_short_alias_report_singular(self) -> None:
+        """'report' (singular) maps to the reports step."""
+        assert resolve_step_identifier("report") == "step_09_reports"
+
+    def test_short_alias_audit(self) -> None:
+        assert resolve_step_identifier("audit") == "step_08_self_audit"
+
+    def test_short_alias_score(self) -> None:
+        assert resolve_step_identifier("score") == "step_05_scorecards"
+
+    def test_unknown_string_raises_with_hint(self) -> None:
+        with pytest.raises(ValueError, match=r"Unknown pipeline step"):
+            resolve_step_identifier("totally-made-up")
+
+    def test_error_lists_valid_options(self) -> None:
+        """The error message names valid steps so the user can retry."""
+        with pytest.raises(ValueError, match=r"Unknown pipeline step") as exc:
+            resolve_step_identifier("bogus")
+        # Mentions at least one of the canonical logical names
+        assert "reports" in str(exc.value)
+
+    def test_empty_string_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"empty"):
+            resolve_step_identifier("")
+
+    def test_whitespace_only_raises(self) -> None:
+        with pytest.raises(ValueError, match=r"empty"):
+            resolve_step_identifier("   ")
+
+    def test_numeric_out_of_range_low(self) -> None:
+        with pytest.raises(ValueError, match=r"out of range"):
+            resolve_step_identifier(0)
+
+    def test_numeric_out_of_range_high(self) -> None:
+        with pytest.raises(ValueError, match=r"out of range"):
+            resolve_step_identifier(99)
+
+    def test_numeric_string_out_of_range(self) -> None:
+        with pytest.raises(ValueError, match=r"out of range"):
+            resolve_step_identifier("99")
+
+    def test_non_string_non_int_type_raises(self) -> None:
+        with pytest.raises(TypeError, match=r"int or str"):
+            resolve_step_identifier(3.14)  # type: ignore[arg-type]
+
+    def test_bool_is_rejected(self) -> None:
+        """``True`` is an int subclass — reject it explicitly rather than resolving to step 1.
+
+        Prevents a typo like ``from_step=True`` from silently succeeding.
+        The boolean positional args here are the whole point of the
+        test, so silence FBT003.
+        """
+        with pytest.raises(TypeError, match=r"int or str"):
+            resolve_step_identifier(True)  # noqa: FBT003
+        with pytest.raises(TypeError, match=r"int or str"):
+            resolve_step_identifier(False)  # noqa: FBT003
+
+    def test_whitespace_padded_numeric_is_parsed(self) -> None:
+        """'  9  ' (padding) still resolves — user shells occasionally pad values."""
+        assert resolve_step_identifier("  9  ") == "step_09_reports"
+
+
+class TestMarkStepAndLaterIncomplete:
+    """Tests for PipelineState.mark_step_and_later_incomplete."""
+
+    def test_clears_target_and_later_steps(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
+        run_dir.mkdir()
+        state = PipelineState(run_dir)
+        # Mark all 11 steps complete
+        for step in PIPELINE_STEPS:
+            state.mark_complete(step.name, output_file=step.output_file)
+        assert state.all_complete()
+
+        cleared = state.mark_step_and_later_incomplete("step_09_reports")
+
+        # step_09 through step_11 (the last three) should be cleared;
+        # step_01..step_08 remain complete.
+        assert cleared == [
+            "step_09_reports",
+            "step_10_archive",
+            "step_11_pipeline_events",
+        ]
+        assert not state.is_complete("step_09_reports")
+        assert not state.is_complete("step_10_archive")
+        assert not state.is_complete("step_11_pipeline_events")
+        assert state.is_complete("step_08_self_audit")
+        assert state.is_complete("step_01_research_input_clarified")
+
+    def test_clears_from_first_step_wipes_all(self, tmp_path: Path) -> None:
+        """Clearing from step 1 resets every step."""
+        run_dir = tmp_path / "run-1"
+        run_dir.mkdir()
+        state = PipelineState(run_dir)
+        for step in PIPELINE_STEPS:
+            state.mark_complete(step.name)
+
+        cleared = state.mark_step_and_later_incomplete(
+            "step_01_research_input_clarified",
+        )
+        assert len(cleared) == len(PIPELINE_STEPS)
+        assert not state.all_complete()
+        # Every step now absent from _completed
+        for step in PIPELINE_STEPS:
+            assert not state.is_complete(step.name)
+
+    def test_clears_step_that_was_not_previously_recorded(self, tmp_path: Path) -> None:
+        """Clearing a step that hasn't been started is a no-op on that slot but still returns it."""
+        run_dir = tmp_path / "run-1"
+        run_dir.mkdir()
+        state = PipelineState(run_dir)
+        # Only step_01 complete; later steps never recorded.
+        state.mark_complete("step_01_research_input_clarified")
+
+        cleared = state.mark_step_and_later_incomplete("step_05_scorecards")
+        # Returned list is every step from 5 onward, regardless of prior presence.
+        assert cleared[0] == "step_05_scorecards"
+        assert "step_11_pipeline_events" in cleared
+        # step_01 untouched
+        assert state.is_complete("step_01_research_input_clarified")
+
+    def test_persists_cleared_state_to_disk(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
+        run_dir.mkdir()
+        state = PipelineState(run_dir)
+        state.mark_complete("step_09_reports", output_file="reports.json")
+        state.mark_step_and_later_incomplete("step_09_reports")
+
+        # Reload from disk — the cleared record must not reappear.
+        reloaded = PipelineState(run_dir)
+        assert not reloaded.is_complete("step_09_reports")
+
+    def test_unknown_step_raises(self, tmp_path: Path) -> None:
+        run_dir = tmp_path / "run-1"
+        run_dir.mkdir()
+        state = PipelineState(run_dir)
+        with pytest.raises(ValueError, match=r"Unknown pipeline step"):
+            state.mark_step_and_later_incomplete("not_a_real_step")


### PR DESCRIPTION
## Summary

Adds `--from-step <N-or-name>` and `--yes` flags to `dio resume`, letting
developers cheaply rerun a pipeline step (and everything downstream) against
frozen earlier outputs. Motivated by the #161/#163 schema changes: we want to
refresh R0063's reports against the new `title` field without paying for
another full search/scoring/evidence cycle.

Closes #162.

## Design decisions

- **Step identifier: numeric OR name.** Accepts a 1-indexed integer, canonical
  step name (`step_09_reports`), logical suffix (`reports`), or short alias
  (`report`, `audit`, `score`). Names are more robust to step reordering;
  integers are convenient for ad-hoc use.
- **Safety: `--yes` required, no prompt.** Destructive path always refuses
  without explicit `--yes` — no TTY-vs-pipe branching to reason about, matches
  the "flag obvious design flaws" memo (no destructive-without-acknowledgement).
- **Archival vs delete: delete.** Renaming to `.bak-<timestamp>` accumulates
  cruft in instance dirs. Git preserves history for anyone who wants it.
- **Range: `--from-step` only.** No `--to-step` / `--only-step`. Out of scope.
- **Non-determinism disclosure: one-line warning for LLM/hybrid re-runs.**
  Printed before the pipeline loop kicks in so the user sees it in both stdout
  and progress.log.
- **Bypasses the "all complete" no-op guard.** Without `--from-step`, a
  fully-complete instance still exits 0 immediately. With `--from-step`, we
  proceed through the wipe + rerun — this is the whole point.

## Before / after

```
# Before — "all steps complete" is a no-op; can't rerun reports without
# deleting state files by hand:
$ dio resume /path/to/instance-2026-04-22-100000
All steps already complete. Nothing to do.

# After — --from-step 9 --yes wipes reports.json / archive.json /
# pipeline-events.json and reruns only those three steps:
$ dio resume /path/to/instance-2026-04-22-100000 --from-step 9 --yes
Resuming: /path/.../instance-2026-04-22-100000
--from-step 9: resetting from step_09_reports onward.
  Deleted: reports.json
  Deleted: archive.json
  Deleted: pipeline-events.json
  Steps [9] re-run LLM-backed operations; output will differ from the prior run.
Step 9: Assembling final reports...
  Wrote: /path/.../reports.json
Step 10: Archiving...
Step 11: Reconciling events...
Research complete.
```

Same thing by logical name:

```
$ dio resume /path/to/instance --from-step report --yes
```

## Safety-path errors (on stderr via `configure_cli_stderr_logger`)

```
$ dio resume /path/to/instance --from-step 9
ERROR: --from-step deletes completed step outputs. Re-run with --yes to
  acknowledge.

$ dio resume /path/to/instance --from-step bogus --yes
ERROR: Unknown pipeline step: 'bogus'. Valid options: 1
  (research_input_clarified), 2 (hypotheses), 3 (search_plans), 4
  (search_results), 5 (scorecards), 6 (evidence_packets), 7 (synthesis),
  8 (self_audit), 9 (reports), 10 (archive), 11 (pipeline_events).
```

## Files changed

| File | +/- |
|------|-----|
| `src/diogenes/cli.py` | +25 / -2 |
| `src/diogenes/commands/run.py` | +86 / -9 |
| `src/diogenes/state_machine.py` | +153 / -1 |
| `tests/test_cli.py` | +90 / -2 |
| `tests/test_commands_run.py` | +443 / 0 |
| `tests/test_state_machine.py` | +194 / 0 |

## Pre-PR validation

All four gates exit 0 against the worktree at commit time:

```
st-validate-local-python               → exit 0
ruff check .                           → exit 0
ruff format --check .                  → exit 0
mypy --explicit-package-bases src tests → exit 0  (37 source files checked)
pytest --cov-fail-under=100            → exit 0  (673 passed, 100% line+branch coverage)
```

mypy report: 0 errors in `src/`, 0 errors in `tests/`.

## Out of scope / follow-ups

- `dio resume --to-step` and `--only-step` — intentionally not in scope per the
  issue body; almost-always-"from-N-through-end" pattern.
- `the-infrastructure-mindset` R0063 refresh — once this lands and #163's
  rejected-source-reason change ships, R0063 can be refreshed with a single
  `dio resume --from-step 9 --yes` invocation instead of another $30+ full run.

## Test plan

- [ ] CI green
- [ ] Spot-check `dio resume --help` shows the new flags
- [ ] Human merges after review
