### PR TITLE
chore(ci): upgrade standard-actions from @v1.3 to @v1.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   security-and-standards:
-    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.3
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.4
     permissions:
       contents: read
       security-events: write
@@ -150,7 +150,7 @@ jobs:
 
       - name: Version divergence gate (PRs targeting develop)
         if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.3
+        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.4
         with:
           head-version-command: python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])"
           main-version-command: git show origin/main:pyproject.toml | python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ permissions:
 
 jobs:
   publish:
-    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.3
+    uses: wphillipmoore/standard-actions/.github/workflows/publish-release.yml@v1.4
     permissions:
       attestations: write
       contents: write


### PR DESCRIPTION
## Summary

- Upgrade all standard-actions workflow references from `@v1.3` to `@v1.4`

## What changed in v1.4

- Trivy table-to-stdout output for CI visibility
- Trivy bump to 0.70.0
- CI action pin updates (create-github-app-token v3, attest-build-provenance v4)
- Workflow cleanups

Ref wphillipmoore/standard-actions#245
