### PR TITLE
docs: fleet docs sweep + dev dep bump

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,9 @@ This repository follows documented standards. Consult these on demand
 when the work requires it — do not attempt to preload and memorize them.
 
 - **Repository-specific**: `docs/repository-standards.md`
-- **Canonical**: `../standards-and-conventions` (local, preferred) or
-  https://github.com/wphillipmoore/standards-and-conventions (remote)
+- **Standards reference**: https://github.com/wphillipmoore/standards-and-conventions
+  — historical reference; active standards documentation lives in the
+  standard-tooling repository under `docs/`.
 
 ## User Overrides (Optional)
 
@@ -17,11 +18,8 @@ briefly and continue.
 
 ## Shared Skills
 
-If `../standards-and-conventions` is available locally:
-- Load skills from: `../standards-and-conventions/skills/**/SKILL.md`
-- Treat every skill found under that directory as available and active.
-
-If not available, skip shared skills and continue.
+None. Skills are delivered via the standard-tooling-plugin; see
+`.claude/settings.json`.
 
 ## Local Overrides
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,9 @@ requires it.
 - **Repository-specific standards**: `docs/repository-standards.md` —
   pre-flight checklist, branching, merge strategy, commit format, AI
   co-authors, linting policy
-- **Canonical standards**: `../standards-and-conventions` (local) or
-  https://github.com/wphillipmoore/standards-and-conventions (remote)
+- **Standards reference**: https://github.com/wphillipmoore/standards-and-conventions
+  — historical reference; active standards documentation lives in the
+  standard-tooling repository under `docs/`.
 
 Read these documents when:
 - Setting up the development environment
@@ -36,7 +37,7 @@ that is **exclusive to this repository's product**.
 - Workarounds for standard-tooling, standard-actions, or GitHub Actions
   (those go in the tooling repo's docs or issues)
 - Behavioral corrections that should apply across all repos (those go
-  in standards-and-conventions or shared CLAUDE.md patterns)
+  in standard-tooling docs or shared CLAUDE.md patterns)
 - Fixes for cross-repo tools (git hooks, CI workflows, Docker images)
 
 **The test:** Would this memory entry be wrong or misleading if applied
@@ -127,9 +128,9 @@ The repository contains:
 
 **Status**: Pre-Alpha (plugin is functional; Python coordinator is in design)
 
-**Canonical Standards**: This repository follows standards at
-https://github.com/wphillipmoore/standards-and-conventions
-(local path: `../standards-and-conventions` if available)
+**Standards reference**: https://github.com/wphillipmoore/standards-and-conventions
+— historical reference; active standards documentation lives in the
+standard-tooling repository under `docs/`.
 
 ## Development Commands
 
@@ -144,7 +145,7 @@ One-time host install (puts `st-docker-run`, `st-commit`, `st-submit-pr`,
 `st-prepare-release`, `st-finalize-repo` on PATH):
 
 ```bash
-uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.3'
+uv tool install 'standard-tooling @ git+https://github.com/wphillipmoore/standard-tooling@v1.4'
 ```
 
 Per-clone setup:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,7 +70,7 @@ dev = [
 ]
 
 [tool.uv.sources]
-standard-tooling = { git = "https://github.com/wphillipmoore/standard-tooling", tag = "v1.3" }
+standard-tooling = { git = "https://github.com/wphillipmoore/standard-tooling", tag = "v1.4" }
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/uv.lock
+++ b/uv.lock
@@ -386,7 +386,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "standard-tooling", git = "https://github.com/wphillipmoore/standard-tooling?tag=v1.3" },
+    { name = "standard-tooling", git = "https://github.com/wphillipmoore/standard-tooling?tag=v1.4" },
     { name = "types-jsonschema" },
     { name = "types-requests" },
 ]
@@ -1347,8 +1347,8 @@ wheels = [
 
 [[package]]
 name = "standard-tooling"
-version = "1.3.4"
-source = { git = "https://github.com/wphillipmoore/standard-tooling?tag=v1.3#66dfe8c3bd17fc23c2700a81f8952129f8f31924" }
+version = "1.4.0"
+source = { git = "https://github.com/wphillipmoore/standard-tooling?tag=v1.4#2fefb73112989011ec0cf4f34123baba04ca0877" }
 
 [[package]]
 name = "starlette"


### PR DESCRIPTION
# Pull Request

## Summary

- Sub-issue of standard-tooling#288. Downgrades standards-and-conventions references to historical/informational, bumps standard-tooling dev dep from v1.3 to v1.4, and removes stale shared-skills section pointing at s&c.

## Issue Linkage

- Fixes #178

## Testing



## Notes

- -