### PR TITLE
chore: remove standard-tooling as a Python dev dependency

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -128,8 +128,9 @@ standard-tooling repository under `docs/`.
 
 ### Standard Tooling
 
-`standard-tooling` is distributed as a host-level developer tool plus a
-project dev dep. See
+`standard-tooling` is distributed as a host-level developer tool and
+provided inside the dev container via the Docker image. It is not a Python
+dev dependency. See
 https://github.com/wphillipmoore/standard-tooling/blob/develop/docs/specs/host-level-tool.md
 for the canonical spec.
 
@@ -144,15 +145,12 @@ Per-clone setup:
 
 ```bash
 git config core.hooksPath .githooks   # Enable the pre-commit gate
-uv sync --group dev                   # Install runtime + dev deps,
-                                      # including standard-tooling
-                                      # pinned via [tool.uv.sources]
+uv sync --group dev                   # Install runtime + dev deps
 ```
 
-Inside the dev container, `uv run st-validate-local` resolves against
-`.venv/bin/st-*` (the pinned version), not the image's pre-bake. Host
-commands (`st-commit`, `st-submit-pr`, etc.) come from the `uv tool install`
-above.
+Inside the dev container, `st-validate-local` is provided by the Docker
+image. Host commands (`st-commit`, `st-submit-pr`, etc.) come from the
+`uv tool install` above.
 
 ### Two-Tier CI Model
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,11 +66,7 @@ dev = [
     "pip-audit",
     "pip-licenses",
     "mcp>=1.27.0",
-    "standard-tooling",
 ]
-
-[tool.uv.sources]
-standard-tooling = { git = "https://github.com/wphillipmoore/standard-tooling", tag = "v1.4" }
 
 [tool.setuptools]
 package-dir = {"" = "src"}

--- a/uv.lock
+++ b/uv.lock
@@ -360,7 +360,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "standard-tooling" },
     { name = "types-jsonschema" },
     { name = "types-requests" },
 ]
@@ -386,7 +385,6 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
-    { name = "standard-tooling", git = "https://github.com/wphillipmoore/standard-tooling?tag=v1.4" },
     { name = "types-jsonschema" },
     { name = "types-requests" },
 ]
@@ -1344,11 +1342,6 @@ sdist = { url = "https://files.pythonhosted.org/packages/26/8c/f9290339ef6d79bad
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/7f/3de5402f39890ac5660b86bcf5c03f9d855dad5c4ed764866d7b592b46fd/sse_starlette-3.3.4-py3-none-any.whl", hash = "sha256:84bb06e58939a8b38d8341f1bc9792f06c2b53f48c608dd207582b664fc8f3c1", size = 14330, upload-time = "2026-03-29T09:00:21.846Z" },
 ]
-
-[[package]]
-name = "standard-tooling"
-version = "1.4.13"
-source = { git = "https://github.com/wphillipmoore/standard-tooling?tag=v1.4#eba8f830a0a4ed664132ea6393ee68ed2012a659" }
 
 [[package]]
 name = "starlette"


### PR DESCRIPTION
# Pull Request

## Summary

- Remove standard-tooling as a Python dev dependency

## Issue Linkage

- Ref #193

## Testing



## Notes

- Remove `standard-tooling` from the `[dependency-groups] dev` list and
the `[tool.uv.sources]` section in `pyproject.toml`. The `st-*` CLI
tools are now provided by the Docker image and the host-level
`uv tool install`; they no longer need to be managed as a Python
dependency.

Update `CLAUDE.md` to reflect the new provenance: standard-tooling
comes from the Docker image inside the container, not from
`.venv/bin/st-*`.