### PR TITLE
ci: adopt standard-actions v1.5 reusable workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,73 +30,17 @@ jobs:
       language: python
       versions: '["3.14"]'
 
-  lint:
-    name: "quality / lint / 3.14"
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/wphillipmoore/dev-python:3.14
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install dependencies
-        run: uv sync --frozen --group dev
-
-      - name: Lint
-        run: uv run ruff check
-
-      - name: Format check
-        run: uv run ruff format --check .
-
-  typecheck:
-    name: "quality / typecheck / 3.14"
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/wphillipmoore/dev-python:3.14
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Install dependencies
-        run: uv sync --frozen --group dev
-
-      - name: Type check
-        run: uv run mypy src tests
-
   test:
-    name: "test / unit / 3.14"
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/wphillipmoore/dev-python:3.14
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Mark workspace safe for git
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Install dependencies
-        run: uv sync --frozen --group dev
-
-      - name: Tests
-        run: |
-          uv run pytest \
-            --cov=diogenes \
-            --cov-report=term-missing \
-            --cov-branch \
-            --cov-fail-under=100
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-test.yml@v1.5
+    with:
+      language: python
+      versions: '["3.14"]'
 
   audit:
-    name: "audit / dependencies / 3.14"
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/wphillipmoore/dev-python:3.14
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v6
-
-      - name: Check lockfile integrity
-        run: uv lock --check
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-audit.yml@v1.5
+    with:
+      language: python
+      versions: '["3.14"]'
 
   # ---------------------------------------------------------------------------
   # Security and standards
@@ -117,29 +61,7 @@ jobs:
   # ---------------------------------------------------------------------------
 
   release:
-    name: "release / version-bump"
-    if: ${{ inputs.run-release != false }}
-    runs-on: ubuntu-latest
-    container:
-      image: ghcr.io/wphillipmoore/dev-python:3.14
-    steps:
-      - name: Skip on non-PR events
-        if: github.event_name != 'pull_request'
-        run: echo "Not a pull request; skipping release gates."
-
-      - name: Checkout code
-        if: github.event_name == 'pull_request'
-        uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Mark workspace safe for git
-        if: github.event_name == 'pull_request'
-        run: git config --global --add safe.directory "$GITHUB_WORKSPACE"
-
-      - name: Version divergence gate (PRs targeting develop)
-        if: github.event_name == 'pull_request' && github.base_ref == 'develop'
-        uses: wphillipmoore/standard-actions/actions/release-gates/version-divergence@v1.5
-        with:
-          head-version-command: python3 -c "import tomllib; from pathlib import Path; print(tomllib.loads(Path('pyproject.toml').read_text())['project']['version'])"
-          main-version-command: git show origin/main:pyproject.toml | python3 -c "import sys, tomllib; print(tomllib.loads(sys.stdin.read())['project']['version'])"
+    uses: wphillipmoore/standard-actions/.github/workflows/ci-release.yml@v1.5
+    with:
+      language: python
+      run-release: ${{ inputs.run-release != false }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ dio-mcp = "diogenes.mcp_server:main"
 [dependency-groups]
 dev = [
     "ruff",
+    "ty",
     "mypy",
     "types-jsonschema",
     "types-requests",

--- a/src/diogenes/search.py
+++ b/src/diogenes/search.py
@@ -118,7 +118,7 @@ def _extract_pdf(url: str, body: bytes) -> str:
     try:
         reader = pypdf.PdfReader(io.BytesIO(body))
         pages = [page.extract_text() or "" for page in reader.pages]
-    except (pypdf.errors.PdfReadError, ValueError, OSError) as exc:
+    except (pypdf.errors.PdfReadError, ValueError, OSError) as exc:  # ty: ignore[possibly-missing-submodule]
         msg = f"pypdf failed to parse PDF from {url}: {exc}"
         raise FetchError(msg) from exc
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -163,7 +163,7 @@ class TestIterItems:
 class TestReconcileRun:
     """Tests for reconcile_run."""
 
-    def _create_run_dir(self, tmp_path: Path) -> pytest.TempPathFactory:
+    def _create_run_dir(self, tmp_path: Path) -> Path:
         """Create a minimal run directory with expected files."""
         run_dir = tmp_path / "run-1"
         run_dir.mkdir()
@@ -213,12 +213,12 @@ class TestReconcileRun:
         ):
             (run_dir / fname).write_text("{}")
 
-        return run_dir  # type: ignore[return-value]
+        return run_dir
 
     def test_basic_reconciliation(self, tmp_path: Path) -> None:
         run_dir = self._create_run_dir(tmp_path)
         logger = EventLogger(run_id="test")
-        coverage = reconcile_run(run_dir, logger)  # type: ignore[arg-type]
+        coverage = reconcile_run(run_dir, logger)
         assert coverage["sources_selected"] == 3
         assert coverage["sources_scored"] == 2
         assert coverage["packets_claimed"] == 10
@@ -281,7 +281,7 @@ class TestReconcileRun:
         logger = EventLogger(run_id="test")
         # Pre-log a fetch failure
         logger.log(step="step5", kind="fetch_failed", detail="timeout", layer="mcp", url="https://c.com")
-        coverage = reconcile_run(run_dir, logger)  # type: ignore[arg-type]
+        coverage = reconcile_run(run_dir, logger)
         # 2 scored + 1 fetch failure = 3 attempted, matching 3 selected
         assert coverage["sources_attempted"] == 3
         assert coverage["sources_capped"] == 0
@@ -291,7 +291,7 @@ class TestReconcileRun:
         logger = EventLogger(run_id="test")
         # No fetch failures logged, so attempted = scored = 2, but selected = 3
         # That means 1 was capped
-        coverage = reconcile_run(run_dir, logger)  # type: ignore[arg-type]
+        coverage = reconcile_run(run_dir, logger)
         assert coverage["sources_capped"] == 1
         capped_events = [e for e in logger.events if e["kind"] == "source_capped"]
         assert len(capped_events) == 1

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1875,12 +1875,12 @@ class TestCollectHypothesisRatingsEdgeCases:
 
     def test_non_dict_report(self) -> None:
         """Covers 322->333: isinstance(report, dict) is False."""
-        result = _collect_hypothesis_ratings("not a dict", {})  # type: ignore[arg-type]
+        result = _collect_hypothesis_ratings("not a dict", {})  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         assert result == {}
 
     def test_non_dict_synthesis(self) -> None:
         """Covers the False path for synthesis being non-dict."""
-        result = _collect_hypothesis_ratings({}, "not a dict")  # type: ignore[arg-type]
+        result = _collect_hypothesis_ratings({}, "not a dict")  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         assert result == {}
 
     def test_non_dict_assessment_in_report(self) -> None:
@@ -3281,7 +3281,7 @@ class TestRendererDefensiveGuards:
         """Cover outer isinstance(synthesis, dict) False via direct call."""
         from diogenes.renderer import _collect_hypothesis_ratings
 
-        result = _collect_hypothesis_ratings({}, None)  # type: ignore[arg-type]
+        result = _collect_hypothesis_ratings({}, None)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
         assert result == {}
 
     def test_collect_ratings_synthesis_assessment_non_dict(self) -> None:
@@ -4256,7 +4256,7 @@ class TestSchemaHelpersDefensiveBranches:
         report = {"assessment_summary": {"confidence": "Medium"}}
         # Pass a non-dict synthesis — the helper's type is dict[str, Any] but
         # the `isinstance` guard defends against real-world malformed JSON.
-        assert _resolve_confidence_label(report, None) == "Medium"  # type: ignore[arg-type]
+        assert _resolve_confidence_label(report, None) == "Medium"  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     def test_resolve_confidence_label_assessment_not_dict_uses_report(self) -> None:
         """Dict synthesis with non-dict assessment falls through to report."""

--- a/tests/test_state_machine.py
+++ b/tests/test_state_machine.py
@@ -516,7 +516,7 @@ class TestResolveStepIdentifier:
 
     def test_non_string_non_int_type_raises(self) -> None:
         with pytest.raises(TypeError, match=r"int or str"):
-            resolve_step_identifier(3.14)  # type: ignore[arg-type]
+            resolve_step_identifier(3.14)  # type: ignore[arg-type]  # ty: ignore[invalid-argument-type]
 
     def test_bool_is_rejected(self) -> None:
         """``True`` is an int subclass — reject it explicitly rather than resolving to step 1.

--- a/uv.lock
+++ b/uv.lock
@@ -360,6 +360,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "ty" },
     { name = "types-jsonschema" },
     { name = "types-requests" },
 ]
@@ -385,6 +386,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "ruff" },
+    { name = "ty" },
     { name = "types-jsonschema" },
     { name = "types-requests" },
 ]
@@ -1416,6 +1418,30 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/06/25/e3ebeefdebfdfae8c4a4396f5a6ea51fc6fa0831d63ce338e5090a8003dc/trafilatura-2.0.0.tar.gz", hash = "sha256:ceb7094a6ecc97e72fea73c7dba36714c5c5b577b6470e4520dca893706d6247", size = 253404, upload-time = "2024-12-03T15:23:24.16Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/b6/097367f180b6383a3581ca1b86fcae284e52075fa941d1232df35293363c/trafilatura-2.0.0-py3-none-any.whl", hash = "sha256:77eb5d1e993747f6f20938e1de2d840020719735690c840b9a1024803a4cd51d", size = 132557, upload-time = "2024-12-03T15:23:21.41Z" },
+]
+
+[[package]]
+name = "ty"
+version = "0.0.34"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/69/e24eefe2c35c0fdbdec9b60e162727af669bb76d64d993d982eb67b24c38/ty-0.0.34.tar.gz", hash = "sha256:a6efe66b0f13c03a65e6c72ec9abfe2792e2fd063c74fa67e2c4930e29d661be", size = 5585933, upload-time = "2026-05-01T23:06:46.388Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/83/7b/8b85003d6639ef17a97dcbb31f4511cfe78f1c81a964470db100c8c883e7/ty-0.0.34-py3-none-linux_armv6l.whl", hash = "sha256:9ecc3d14f07a95a6ceb88e07f8e62358dbd37325d3d5bd56da7217ff1fef7fb8", size = 11067094, upload-time = "2026-05-01T23:06:21.133Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/25/b0098f65b020b015c40567c763fc66fffbec88b2ba6f584bca1e92f05ebb/ty-0.0.34-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:0dccffd8a9d02321cd2dee3249df205e26d62694e741f4eeca36b157fd8b419f", size = 10840909, upload-time = "2026-05-01T23:06:18.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/55/5e4adcf7d2a1006b844903b27cb81244a9b748d850433a46a6c21776c401/ty-0.0.34-py3-none-macosx_11_0_arm64.whl", hash = "sha256:b0ea47a2998e167ab3b21d2f4b5309a9cf33c297809f6d7e3e753252223174d0", size = 10279378, upload-time = "2026-05-01T23:06:37.962Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/91/f537dca0db8fe2558e8ab04d8941d687b384fcc1df5eb9023b2db75ac26c/ty-0.0.34-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8b37da00b41a118a459ae56d8947e70651073fb33ebfbceb820e4a10b22d5023", size = 10817423, upload-time = "2026-05-01T23:06:26.247Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/c4/55a3ad1da2815af1009bdc1b8c90dc11a364cd314e4b48c5128ba9d38859/ty-0.0.34-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:81cbbb93c2342fe3de43e625d3a9eb149633e9f485e816ebf6395d08685355d8", size = 10851826, upload-time = "2026-05-01T23:06:24.198Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/9c7606af22d73fb43ea4369472d9c66ece11231be73b0efe8e3c61655559/ty-0.0.34-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4c5b4dea1594a021289e172582df9cde7089dce14b276fc650e7b212b1772e12", size = 11356318, upload-time = "2026-05-01T23:06:51.139Z" },
+    { url = "https://files.pythonhosted.org/packages/20/54/bb423f663721ab4138b216425c6b55eaefd3a068243b24d6d8fe988f4e13/ty-0.0.34-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:030fb00aa2d2a5b5ae9d9183d574e0c82dae80566700a7490c43669d8ece40cd", size = 11902968, upload-time = "2026-05-01T23:06:35.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/22/01122b21ab6b534a2f618c6bbe5f1f7f49fd56f4b2ec8887cd6d40d08fb3/ty-0.0.34-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5ae9555e24e36c63a8218e037a5a63f15579eb6aa94f41017e57cd41d335cfb5", size = 11548860, upload-time = "2026-05-01T23:06:42.155Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/50/86008b1392ec64bed1957bbcc7aaa43b466b50dfc91bb131841c21d7c5c3/ty-0.0.34-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:99eb23df9ed129fc26d1ab00d6f0b8dfe5253b09c2ac6abdb11523fa70d67f10", size = 11457097, upload-time = "2026-05-01T23:06:53.477Z" },
+    { url = "https://files.pythonhosted.org/packages/92/3e/4558b2296963ba99c58d8409c57d7db4f3061b656c3613cb21c02c1ef4c2/ty-0.0.34-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:85de45382016eceae69e104815eb2cfa200787df104002e262a86cbd43ed2c02", size = 10798192, upload-time = "2026-05-01T23:06:40.004Z" },
+    { url = "https://files.pythonhosted.org/packages/76/bf/650d24402be2ef678528d60caac1d9477a40fc37e3792ecef07834fd7a4a/ty-0.0.34-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:14cb575fb8fa5131f5129d100cfe23c1575d23faf5dfc5158432749a3e38c9b5", size = 10890390, upload-time = "2026-05-01T23:06:33.076Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/ef/ccd2ca13906079f7935fd7e067661b24233017f57d987d51d6a121d85bb5/ty-0.0.34-py3-none-musllinux_1_2_i686.whl", hash = "sha256:c6fc0b69d8450e6910ba9db34572b959b81329a97ae273c391f70e9fb6c1aade", size = 11031564, upload-time = "2026-05-01T23:06:55.812Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/2d/d27b72005b6f43599e3bcabab0d7135ac0c230b7a307bb99f9eea02c1cda/ty-0.0.34-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:30dfcec2f0fde3993f4f912ed0e057dcbebc8615299f610a4c2ddb7b5a3e1e06", size = 11553430, upload-time = "2026-05-01T23:06:31.096Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/12/20812e1ad930b8d4af70eebf19ad23cff6e31efcfa613ef884531fcdbaa1/ty-0.0.34-py3-none-win32.whl", hash = "sha256:97b77ddf007271b812a313a8f0a14929bc5590958433e1fb83ef585676f53342", size = 10436048, upload-time = "2026-05-01T23:06:49.108Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/6a/afa095c5987868fbda27c0f731146ac8e3d07b357adfa83daccaee5b1a16/ty-0.0.34-py3-none-win_amd64.whl", hash = "sha256:1f543968accb952705134028d1fda8656882787dbbc667ad4d6c3ba23791d604", size = 11462526, upload-time = "2026-05-01T23:06:28.514Z" },
+    { url = "https://files.pythonhosted.org/packages/63/8f/bf041a06260d77662c0605e56dacfe90b786bf824cbe1aed238d15fe5e84/ty-0.0.34-py3-none-win_arm64.whl", hash = "sha256:ea09108cbcb16b6b06d7596312b433bf49681e78d30e4dc7fb3c1b248a95e09a", size = 10846945, upload-time = "2026-05-01T23:06:44.428Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
# Pull Request

## Summary

- Replace all bespoke CI jobs with standard-actions v1.5 reusable workflows

## Issue Linkage

- Ref #196

## Testing



## Notes

- ## Changes

- **Remove bespoke lint job** — replaced by `ci-quality.yml` lint job via `st-validate --check lint`
- **Remove bespoke typecheck job** — replaced by `ci-quality.yml` typecheck job via `st-validate --check typecheck`
- **Remove bespoke test job** — replaced by `ci-test.yml` via `st-validate --check test`
- **Remove bespoke audit job** — replaced by `ci-audit.yml` via `st-validate --check audit`
- **Remove bespoke release job** — replaced by `ci-release.yml` using `st-version show` instead of inline Python version extraction

Net: 90 lines removed, 12 added. All CI jobs now delegate to standard-actions v1.5 reusable workflows with zero bespoke overrides.