### PR TITLE
fix(ci): pass boolean to ci-security reusable workflow inputs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,8 +50,8 @@ jobs:
     uses: wphillipmoore/standard-actions/.github/workflows/ci-security.yml@v1.5
     with:
       language: python
-      run-standards: ${{ inputs.run-release || true }}
-      run-security: ${{ inputs.run-security || true }}
+      run-standards: ${{ inputs.run-release != 'false' }}
+      run-security: ${{ inputs.run-security != 'false' }}
     permissions:
       contents: read
       security-events: write


### PR DESCRIPTION
# Pull Request

## Summary

- Fix string-vs-boolean type mismatch that silently breaks security CI jobs

## Issue Linkage

- Ref wphillipmoore/standard-tooling#632

## Testing



## Notes

- Root-caused during fleet cleanup (standard-tooling#626). Security jobs were never spawning due to type mismatch.