### PR TITLE
fix(release): use explicit secret passing for cross-org reusable workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,4 +19,6 @@ jobs:
     with:
       language: python
       container-tag: "3.14"
-    secrets: inherit
+    secrets:
+      APP_CLIENT_ID: ${{ secrets.APP_CLIENT_ID }}
+      APP_PRIVATE_KEY: ${{ secrets.APP_PRIVATE_KEY }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "diogenes"
-version = "1.2.0"
+version = "1.2.1"
 description = "Diogenes — deterministic AI research coordinator for evidence-based investigation"
 readme = "README.md"
 license = "GPL-3.0-only"

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.14, <4.0"
 
 [[package]]
@@ -338,7 +338,7 @@ wheels = [
 
 [[package]]
 name = "diogenes"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
# Pull Request

## Summary

- Replace secrets: inherit with explicit secret passing in cd.yml. secrets: inherit only works within the same GitHub org, so cross-org calls to vergil-actions reusable workflows require explicit declarations.

## Issue Linkage

- Ref #221

## Notes

- -